### PR TITLE
New Engine (Buttinger et al.) and fix adaptive simulation

### DIFF
--- a/Examples/Monai/Monai.jl
+++ b/Examples/Monai/Monai.jl
@@ -360,15 +360,15 @@ Read the simulated gauge output.
 
 # ╔═╡ c0f8d550-de13-11eb-0fe8-69be1dcd7792
 begin
-	BGG1=readdlm("Monai_BG_Gauge_"*string(1)*".txt", '\t',  skipstart=1);
-	BGG2=readdlm("Monai_BG_Gauge_"*string(2)*".txt", '\t',  skipstart=1);
-	BGG3=readdlm("Monai_BG_Gauge_"*string(3)*".txt", '\t',  skipstart=1);
+	BGG1=readdlm("Monai_BG_Gauge_"*string(1)*".txt", '\t',  skipstart=2);
+	BGG2=readdlm("Monai_BG_Gauge_"*string(2)*".txt", '\t',  skipstart=2);
+	BGG3=readdlm("Monai_BG_Gauge_"*string(3)*".txt", '\t',  skipstart=2);
 end
 
 # ╔═╡ fd1c0930-de13-11eb-2eaf-4f04b2bf6604
 begin
 	plot(GaugeData[:,1],GaugeData[:,2],pen=(1.0,:black), region=(0,25,-1,5), xlabel="time [s]", ylabel="water level [cm]",title="Gauge 1")
-	plot!(BGG1[:,1],BGG1[:,2].*100.0,pen=(1.0,:red),show=true)
+	plot!(BGG1[:,1],BGG1[:,2] .* 100.0,pen=(1.0,:red),show=true)
 	
 end
 

--- a/src/Adaptation.cu
+++ b/src/Adaptation.cu
@@ -96,23 +96,9 @@ template <class T> void InitialAdaptation(Param& XParam, Forcing<float> &XForcin
 		log("Adapting mesh");
 		Adaptation(XParam, XForcing, XModel);
 
-		calcactiveCellCPU(XParam, XModel.blocks, XModel.zb);
 
-		//recalculate river positions (They may belong to a different block)
-		InitRivers(XParam, XForcing, XModel);
+		InitialConditions(XParam, XForcing, XModel);
 
-		//rerun boundary block (there may be new bnd block and old ones that do not belong anymore)
-		//Initbnds(XParam, XForcing, XModel);
-		Calcbndblks(XParam, XForcing, XModel.blocks);
-		Findbndblks(XParam, XModel, XForcing);
-
-		initoutput(XParam, XModel);
-
-		//Recalculate the masks
-		FindMaskblk(XParam, XModel.blocks);
-
-		// Re run initial contions to avoid dry/wet issues
-		initevolv(XParam, XModel.blocks, XForcing, XModel.evolv, XModel.zb);
 
 		
 	}

--- a/src/Adaptation.cu
+++ b/src/Adaptation.cu
@@ -96,6 +96,8 @@ template <class T> void InitialAdaptation(Param& XParam, Forcing<float> &XForcin
 		log("Adapting mesh");
 		Adaptation(XParam, XForcing, XModel);
 
+		calcactiveCellCPU(XParam, XModel.blocks, XModel.zb);
+
 		//recalculate river positions (They may belong to a different block)
 		InitRivers(XParam, XForcing, XModel);
 

--- a/src/Advection.cu
+++ b/src/Advection.cu
@@ -182,13 +182,17 @@ template <class T> __global__ void AdvkernelGPU(Param XParam, BlockP<T> XBlock, 
 	T eps = T(XParam.eps);
 	T hold = XEv.h[i];
 	T ho, uo, vo;
-	ho = hold + dt * XAdv.dh[i];
+	T dhi = XAdv.dh[i];
+
+	T edt = dt;// dhi > T(0.0) ? dt : min(dt, hold / (-1.0 * dhi));
+
+	ho = hold + edt * dhi;
 
 
 	if (ho > eps) {
 		//
-		uo = (hold * XEv.u[i] + dt * XAdv.dhu[i]) / ho;
-		vo = (hold * XEv.v[i] + dt * XAdv.dhv[i]) / ho;
+		uo = (hold * XEv.u[i] + edt * XAdv.dhu[i]) / ho;
+		vo = (hold * XEv.v[i] + edt * XAdv.dhv[i]) / ho;
 		
 	}
 	else

--- a/src/Advection.h
+++ b/src/Advection.h
@@ -19,6 +19,8 @@ template <class T> __host__ void cleanupCPU(Param XParam, BlockP<T> XBlock, Evol
 template <class T> __host__ T CalctimestepCPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime);
 template <class T> __host__ T CalctimestepGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime);
 
+template <class T> __host__ T timestepreductionCPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime);
+
 template <class T> __global__ void reducemin3(T* g_idata, T* g_odata, unsigned int n);
 
 // End of global definition

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -68,7 +68,8 @@ struct BlockP
 	int* RightBot, *RightTop;
 
 	int* level;
-	int* active;
+	int* active; // active blocks
+	int* activeCell; //To apply forcings (rain) only on these
 
 	maskinfo mask;
 	

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -18,6 +18,9 @@ struct GradientsP
 	T* dhdy;
 	T* dudy;
 	T* dvdy;
+
+	T* dzbdx;
+	T* dzbdy;
 };
 
 

--- a/src/BG_Flood.cu
+++ b/src/BG_Flood.cu
@@ -25,30 +25,31 @@
 #include "BG_Flood.h"
 
 
-
-
 /*! \fn int main(int argc, char **argv)
 * Main function 
 * This function is the entry point to the software
+* The main function setups all the init of the model and then calls the mainloop to actually run the model
+*
+*	There are 3 main class storing information about the model: XParam (class Param), XModel (class Model) and XForcing (class Forcing)
+*	Leading X stands for eXecution and is to avoid confusion between the class variable and the class declaration
+*	When running with the GPU there is also XModel_g
+*	which is the same as XModel but with GPU specific pointers
+*
+*
+* This function does:
+* * Reads the inputs to the model
+* * Allocate memory on GPU and CPU
+* * Prepare and initialise memory and arrays on CPU and GPU
+* * Setup initial condition
+* * Adapt grid if require
+* * Prepare output file
+* * Run main loop
+* * Clean up and close
 */
 int main(int argc, char **argv)
 {
 
-	//The main function setups all the init of the model and then calls the mainloop to actually run the model
-
-	// There are 3 main class storing information about the model: XParam (class Param), XModel (class Model) and XForcing (class Forcing)
-	// Leading X stands for eXecution and is to avoid confusion between the class variable and the class declaration
-	// When running with the GPU there is also XModel_g
-	// which is the same as XModel but with GPU specific pointers
-
-	//First part reads the inputs to the model
-	//then allocate memory on GPU and CPU
-	//Then prepare and initialise memory and arrays on CPU and GPU
-	// Setup initial condition
-	// Adapt grid if require
-	// Prepare output file
-	// Run main loop
-	// Clean up and close
+	
 
 	//===========================================
 	//  Define the main parameter controling the model (XModels class at produced later) 

--- a/src/BG_Flood.cu
+++ b/src/BG_Flood.cu
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 	InitMesh(XParam, XForcing, XModel);
 
 	//============================================
-	// Prepare initial conditions
+	// Prepare initial conditions on CPU
 	InitialConditions(XParam, XForcing, XModel);
 
 	//============================================
@@ -101,6 +101,8 @@ int main(int argc, char **argv)
 	//============================================
 	// Setup GPU (bypassed within the function if no suitable GPU is available)
 	SetupGPU(XParam, XModel,XForcing, XModel_g);
+
+
 
 	//
 	log("\nModel setup complete");

--- a/src/ConserveElevation.cu
+++ b/src/ConserveElevation.cu
@@ -1127,7 +1127,7 @@ template <class T> void conserveElevationTop(Param XParam, int ib, int ibTL, int
 {
 	int ihalo, jhalo, ibn, ip, jp;
 
-	int write;
+	
 
 	if (XBlock.level[ib] < XBlock.level[ibTL])
 	{

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -178,7 +178,7 @@ template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	//fillHalo(XParam, XModel.blocks, XModel.flux);
+	fillHalo(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Reduce minimum timestep

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -120,8 +120,8 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	//============================================
 	// Add bottom friction
-	//bottomfrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv_o);
-	XiafrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv, XModel.evolv_o);
+	bottomfrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv_o);
+	//XiafrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv, XModel.evolv_o);
 
 	//============================================
 	//Copy updated evolving variable back
@@ -183,7 +183,8 @@ template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 	//============================================
 	// Reduce minimum timestep
 	// Make only a half max step
-	XLoop.dt = double(CalctimestepCPU(XParam, XLoop, XModel.blocks, XModel.time)) * T(0.5);
+	//XLoop.dt = double(CalctimestepCPU(XParam, XLoop, XModel.blocks, XModel.time)) * T(0.5);
+	XLoop.dt = double(timestepreductionCPU(XParam, XLoop, XModel.blocks, XModel.time)) * T(0.5);
 	XLoop.dtmax = XLoop.dt;
 	XModel.time.dt = T(XLoop.dt);
 
@@ -207,13 +208,14 @@ template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 	}
 
 	//============================================
-	//Update evolving variable by 1/2 time step
+	//Update evolving variable by 1 time step
 	AdvkernelCPU(XParam, XModel.blocks, XModel.time.dt , XModel.zb, XModel.evolv, XModel.adv, XModel.evolv_o);
 
 
 	//============================================
 	// Add bottom friction
 	bottomfrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv_o);
+	//XiafrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv, XModel.evolv_o);
 
 	//============================================
 	//Copy updated evolving variable back

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -22,11 +22,13 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	updateKurgXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//AddSlopeSourceXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 
 	// Y- direction
-	updateKurgYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//AddSlopeSourceYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 
 	//============================================
@@ -78,11 +80,13 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	updateKurgXCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerXCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgXCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//AddSlopeSourceXCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
 	
 	// Y- direction
-	updateKurgYCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerYCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgYCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//AddSlopeSourceYCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
 
 	//============================================
@@ -162,11 +166,13 @@ template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	updateKurgXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//AddSlopeSourceXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 
 	// Y- direction
-	updateKurgYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//AddSlopeSourceYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 
 	//============================================

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -31,7 +31,7 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	fillHalo(XParam, XModel.blocks, XModel.flux);
+	//fillHalo(XParam, XModel.blocks, XModel.flux);
 	
 	//============================================
 	// Reduce minimum timestep
@@ -87,7 +87,7 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	fillHalo(XParam, XModel.blocks, XModel.flux);
+	//fillHalo(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -33,7 +33,7 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	//fillHalo(XParam, XModel.blocks, XModel.flux);
+	fillHalo(XParam, XModel.blocks, XModel.flux);
 	
 	//============================================
 	// Reduce minimum timestep
@@ -91,7 +91,7 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	//fillHalo(XParam, XModel.blocks, XModel.flux);
+	fillHalo(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -132,3 +132,83 @@ template void FlowCPU<float>(Param XParam, Loop<float>& XLoop, Forcing<float> XF
 template void FlowCPU<double>(Param XParam, Loop<double>& XLoop, Forcing<float> XForcing, Model<double> XModel);
 
 
+
+
+/*! \fn  void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel)
+* Debugging flow step
+* This function was crated to debug the main engine of the model
+*/
+template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel)
+{
+	//============================================
+	// Predictor step in reimann solver
+	//============================================
+
+	//============================================
+	//  Fill the halo for gradient reconstruction
+	fillHalo(XParam, XModel.blocks, XModel.evolv, XModel.zb);
+
+	//============================================
+	// Reset DTmax
+	InitArrayBUQ(XParam, XModel.blocks, XLoop.hugeposval, XModel.time.dtmax);
+
+	//============================================
+	// Calculate gradient for evolving parameters
+	gradientCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.zb);
+
+	//============================================
+	// Flux and Source term reconstruction
+	// X- direction
+	updateKurgXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//AddSlopeSourceXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+
+	// Y- direction
+	updateKurgYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//AddSlopeSourceYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+
+	//============================================
+	// Fill Halo for flux from fine to coarse
+	//fillHalo(XParam, XModel.blocks, XModel.flux);
+
+	//============================================
+	// Reduce minimum timestep
+	// Make only a half max step
+	XLoop.dt = double(CalctimestepCPU(XParam, XLoop, XModel.blocks, XModel.time)) * T(0.5);
+	XLoop.dtmax = XLoop.dt;
+	XModel.time.dt = T(XLoop.dt);
+
+	//============================================
+	// Update advection terms (dh dhu dhv) 
+	updateEVCPU(XParam, XModel.blocks, XModel.evolv, XModel.flux, XModel.adv);
+
+	//============================================
+	// Add forcing (Rain, Wind)
+	if (!XForcing.Rain.inputfile.empty())
+	{
+		AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
+	}
+	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
+	{
+		AddwindforcingCPU(XParam, XModel.blocks, XForcing.UWind, XForcing.VWind, XModel.adv);
+	}
+	if (XForcing.rivers.size() > 0)
+	{
+		AddRiverForcing(XParam, XLoop, XForcing.rivers, XModel);
+	}
+
+	//============================================
+	//Update evolving variable by 1/2 time step
+	AdvkernelCPU(XParam, XModel.blocks, XModel.time.dt , XModel.zb, XModel.evolv, XModel.adv, XModel.evolv_o);
+
+
+	//============================================
+	// Add bottom friction
+	bottomfrictionCPU(XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv_o);
+
+	//============================================
+	//Copy updated evolving variable back
+	cleanupCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.evolv);
+}
+template void HalfStepCPU<float>(Param XParam, Loop<float>& XLoop, Forcing<float> XForcing, Model<float> XModel);
+template void HalfStepCPU<double>(Param XParam, Loop<double>& XLoop, Forcing<float> XForcing, Model<double> XModel);
+

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -45,10 +45,10 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	//============================================
 	// Add forcing (Rain, Wind)
-	if (!XForcing.Rain.inputfile.empty())
-	{
-		AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
-	}
+	//if (!XForcing.Rain.inputfile.empty())
+	//{
+	//	AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
+	//}
 	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
 	{
 		AddwindforcingCPU(XParam, XModel.blocks, XForcing.UWind, XForcing.VWind, XModel.adv);
@@ -95,10 +95,10 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	
 	//============================================
 	// Add forcing (Rain, Wind)
-	if (!XForcing.Rain.inputfile.empty())
-	{
-		AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
-	}
+	//if (!XForcing.Rain.inputfile.empty())
+	//{
+	//	AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
+	//}
 	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
 	{
 		AddwindforcingCPU(XParam, XModel.blocks, XForcing.UWind, XForcing.VWind, XModel.adv);
@@ -122,7 +122,10 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	//Copy updated evolving variable back
 	cleanupCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.evolv);
 
-	
+	if (!XForcing.Rain.inputfile.empty())
+	{
+		AddrainforcingImplicitCPU(XParam, XLoop, XModel.blocks, XForcing.Rain, XModel.evolv);
+	}
 
 
 
@@ -183,10 +186,10 @@ template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 
 	//============================================
 	// Add forcing (Rain, Wind)
-	if (!XForcing.Rain.inputfile.empty())
-	{
-		AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
-	}
+	//if (!XForcing.Rain.inputfile.empty())
+	//{
+	//	AddrainforcingCPU(XParam, XModel.blocks, XForcing.Rain, XModel.adv);
+	//}
 	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
 	{
 		AddwindforcingCPU(XParam, XModel.blocks, XForcing.UWind, XForcing.VWind, XModel.adv);
@@ -208,6 +211,11 @@ template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 	//============================================
 	//Copy updated evolving variable back
 	cleanupCPU(XParam, XModel.blocks, XModel.evolv_o, XModel.evolv);
+
+	if (!XForcing.Rain.inputfile.empty())
+	{
+		AddrainforcingImplicitCPU(XParam, XLoop, XModel.blocks, XForcing.Rain, XModel.evolv);
+	}
 }
 template void HalfStepCPU<float>(Param XParam, Loop<float>& XLoop, Forcing<float> XForcing, Model<float> XModel);
 template void HalfStepCPU<double>(Param XParam, Loop<double>& XLoop, Forcing<float> XForcing, Model<double> XModel);

--- a/src/FlowCPU.h
+++ b/src/FlowCPU.h
@@ -14,6 +14,7 @@
 #include "Advection.h"
 #include "Friction.h"
 #include "Updateforcing.h"
+#include "Reimann.h"
 
 // End of global definition
 template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel);

--- a/src/FlowCPU.h
+++ b/src/FlowCPU.h
@@ -17,5 +17,7 @@
 
 // End of global definition
 template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel);
+template <class T> void HalfStepCPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel);
+
 
 #endif

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -45,13 +45,15 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
-	//AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+	UpdateButtingerXGPU << < gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 
 	// Y- direction
-	updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
-	//AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
-	//updateKurgY << < XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >> > (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);
+	UpdateButtingerYGPU << < gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+	// //updateKurgY << < XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >> > (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);
 	
 	CUDA_CHECK(cudaDeviceSynchronize());
 
@@ -109,12 +111,14 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
-	//AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
+	UpdateButtingerXGPU << < gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
 
 	// Y- direction
-	updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
-	//AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
+	UpdateButtingerYGPU << < gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	//============================================

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -111,12 +111,12 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	UpdateButtingerXGPU << < gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerXGPU << < gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
 
 	// Y- direction
-	UpdateButtingerYGPU << < gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerYGPU << < gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.zb);
 	CUDA_CHECK(cudaDeviceSynchronize());

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -57,7 +57,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+	//fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Reduce minimum timestep
@@ -119,7 +119,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+	//fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -59,7 +59,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+	//fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Reduce minimum timestep
@@ -123,7 +123,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+	//fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 
@@ -155,8 +155,8 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	
 	//============================================
 	// Add bottom friction
-	//bottomfrictionGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv_o);
-	XiafrictionGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv, XModel.evolv_o);
+	bottomfrictionGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv_o);
+	//XiafrictionGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.time.dt, XModel.cf, XModel.evolv, XModel.evolv_o);
 
 	CUDA_CHECK(cudaDeviceSynchronize());
 	

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -74,10 +74,10 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	
 	//============================================
 	// Add forcing (Rain, Wind)
-	if (!XForcing.Rain.inputfile.empty())
-	{
-		AddrainforcingGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XForcing.Rain, XModel.adv);
-	}
+	//if (!XForcing.Rain.inputfile.empty())
+	//{
+	//	AddrainforcingGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XForcing.Rain, XModel.adv);
+	//}
 	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
 	{
 		AddwindforcingGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XForcing.UWind, XForcing.VWind, XModel.adv);
@@ -129,10 +129,10 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Add forcing (Rain, Wind)
-	if (!XForcing.Rain.inputfile.empty())
-	{
-		AddrainforcingGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XForcing.Rain, XModel.adv);
-	}
+	//if (!XForcing.Rain.inputfile.empty())
+	//{
+	//	AddrainforcingGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XForcing.Rain, XModel.adv);
+	//}
 	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
 	{
 		AddwindforcingGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XForcing.UWind, XForcing.VWind, XModel.adv);
@@ -158,6 +158,11 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	//Copy updated evolving variable back
 	cleanupGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.evolv);
 	CUDA_CHECK(cudaDeviceSynchronize());
+
+	if (!XForcing.Rain.inputfile.empty())
+	{
+		AddrainforcingImplicitGPU << < gridDim, blockDim, 0 >> > (XParam,XLoop, XModel.blocks, XForcing.Rain, XModel.evolv);
+	}
 	
 	
 	for (int i = 0; i < XLoop.num_streams; i++)

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -59,7 +59,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	//fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Reduce minimum timestep
@@ -123,7 +123,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 	//============================================
 	// Fill Halo for flux from fine to coarse
-	//fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -45,12 +45,12 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	//============================================
 	// Flux and Source term reconstruction
 	// X- direction
-	UpdateButtingerXGPU << < gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 
 	// Y- direction
-	UpdateButtingerYGPU << < gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	UpdateButtingerYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 	// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 	// //updateKurgY << < XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >> > (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);

--- a/src/FlowGPU.h
+++ b/src/FlowGPU.h
@@ -12,6 +12,7 @@
 #include "Advection.h"
 #include "Friction.h"
 #include "Updateforcing.h"
+#include "Reimann.h"
 
 template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel);
 

--- a/src/Friction.cu
+++ b/src/Friction.cu
@@ -283,3 +283,26 @@ template <class T> __host__ __device__ T manningfriction(T g, T hi, T n)
 	T cfi= g * n * n / cbrt(hi);
 	return cfi;
 }
+
+/*! \fn bool ThresholdVelocity(T Threshold, T& u, T& v)
+* 
+* \brief Function Used to prevent crazy velocity
+* 
+* The function scale velocities so it doesn't exceeds a given threshold. 
+* Default threshold is/should be 16.0m/s
+*/
+template <class T> __host__ __device__ bool ThresholdVelocity(T Threshold, T& u, T& v)
+{
+	T normvel = sqrt(u * u + v * v);
+
+	bool alert = normvel > Threshold
+
+	if (alert)
+	{
+		u /= normvel / Threshold;
+		v /= normvel / Threshold;
+	}
+	return alert;
+}
+
+

--- a/src/Friction.cu
+++ b/src/Friction.cu
@@ -311,14 +311,12 @@ template <class T> __global__ void TheresholdVelGPU(Param XParam, BlockP<T> XBlo
 
 	T ui, vi;
 
-	bustedThreshold = ThresholdVelocity(XParam.VelThreshold, ui, T vi);
-
 	
-
 	XEvolv.u[i] = ui;
 
 	XEvolv.v[i] = vi;
 
+	bustedThreshold = ThresholdVelocity(XParam.VelThreshold, ui, vi);
 
 	
 	ui = XEvolv.u[i];
@@ -360,11 +358,12 @@ template <class T> __host__ void TheresholdVelCPU(Param XParam, BlockP<T> XBlock
 
 				vi = XEvolv.v[i];
 
-				bustedThreshold = ThresholdVelocity(XParam.VelThreshold, ui, T vi);
+				bustedThreshold = ThresholdVelocity(XParam.VelThreshold, ui, vi);
 
-				if bustedThreshold
+				if (bustedThreshold)
+				{
 					log("Memory Threshold exceeded!");
-
+				}
 				XEvolv.u[i] = ui;
 
 				XEvolv.v[i] = vi;
@@ -385,7 +384,7 @@ template <class T> __host__ __device__ bool ThresholdVelocity(T Threshold, T& u,
 {
 	T normvel = sqrt(u * u + v * v);
 
-	bool alert = normvel > Threshold
+	bool alert = normvel > Threshold;
 
 	if (alert)
 	{

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -317,36 +317,40 @@ template <class T> void gradientCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 	gradientHalo(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
 	gradientHalo(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
 	
+	if (XParam.conserveElevation)
+	{
+		conserveElevationGradHalo(XParam, XBlock, XEv.h, XEv.zs, zb, XGrad.dhdx, XGrad.dzsdx, XGrad.dhdy, XGrad.dzsdy);
+
+	}
+	
+	
+	refine_linear(XParam,XBlock, XEv.h, XGrad.dhdx, XGrad.dhdy);
+	refine_linear(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
+	refine_linear(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
+
+	RecalculateZs(XParam, XBlock, XEv, zb);
+				
+
+	gradientHalo(XParam, XBlock, XEv.h, XGrad.dhdx, XGrad.dhdy);
+	gradientHalo(XParam, XBlock, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
+	gradientHalo(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
+	gradientHalo(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
 
 	if (XParam.conserveElevation)
 	{
 		conserveElevationGradHalo(XParam, XBlock, XEv.h, XEv.zs, zb, XGrad.dhdx, XGrad.dzsdx, XGrad.dhdy, XGrad.dzsdy);
 
 	}
-	else
-	{
-		refine_linear(XParam,XBlock, XEv.h, XGrad.dhdx, XGrad.dhdy);
-		refine_linear(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
-		refine_linear(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
+	WetsloperesetCPU(XParam, XBlock, XEv, XGrad, zb);
 
-		RecalculateZs(XParam, XBlock, XEv, zb);
-				
-
-		gradientHalo(XParam, XBlock, XEv.h, XGrad.dhdx, XGrad.dhdy);
-		gradientHalo(XParam, XBlock, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
-		gradientHalo(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
-		gradientHalo(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
-
-		WetsloperesetCPU(XParam, XBlock, XEv, XGrad, zb);
-
-		WetsloperesetHaloLeftCPU(XParam, XBlock, XEv, XGrad, zb);
-		WetsloperesetHaloRightCPU(XParam, XBlock, XEv, XGrad, zb);
-		WetsloperesetHaloBotCPU(XParam, XBlock, XEv, XGrad, zb);
-		WetsloperesetHaloTopCPU(XParam, XBlock, XEv, XGrad, zb);
+	WetsloperesetHaloLeftCPU(XParam, XBlock, XEv, XGrad, zb);
+	WetsloperesetHaloRightCPU(XParam, XBlock, XEv, XGrad, zb);
+	WetsloperesetHaloBotCPU(XParam, XBlock, XEv, XGrad, zb);
+	WetsloperesetHaloTopCPU(XParam, XBlock, XEv, XGrad, zb);
 		
 
 
-	}
+	
 
 
 	//conserveElevationGradHalo(XParam, XBlock, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -101,9 +101,9 @@ template <class T> __global__ void gradient(int halowidth, int* active, int* lev
 
 
 	a_l = a[memloc(halowidth, blkmemwidth, ix - 1, iy, ib)];
-	a_t = a[memloc(halowidth, blkmemwidth, ix , iy+1, ib)];
+	a_t = a[memloc(halowidth, blkmemwidth, ix , iy + 1, ib)];
 	a_r = a[memloc(halowidth, blkmemwidth, ix + 1, iy, ib)];
-	a_b = a[memloc(halowidth, blkmemwidth, ix, iy-1, ib)];
+	a_b = a[memloc(halowidth, blkmemwidth, ix, iy - 1, ib)];
 	//__shared__ T a_s[18][18];
 
 
@@ -431,14 +431,15 @@ template <class T> void gradientHaloLeft(Param XParam, BlockP<T>XBlock, int ib, 
 	else if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
 	{
 		jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
-		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.75) : T(0.25);
+		//T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.75) : T(0.25);// This is the wrong way around
+		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75); // This is right (e.g. at iy==0 use 0.75 at iy==1 use 0.25)
 
 		ii = memloc(XParam, (XParam.blkwidth - 1), jj, XBlock.LeftBot[ib]);
 		ir = memloc(XParam, (XParam.blkwidth - 2), jj, XBlock.LeftBot[ib]);
 		it = memloc(XParam, (XParam.blkwidth - 1), jj - 1, XBlock.LeftBot[ib]);
 		itr = memloc(XParam, (XParam.blkwidth - 2), jj - 1, XBlock.LeftBot[ib]);
 
-		aleft = BilinearInterpolation(a[itr], a[it], a[ir], a[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
+		aleft = BilinearInterpolation(a[itr], a[ir], a[it], a[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
 	}
 	
 
@@ -563,14 +564,14 @@ template <class T> void gradientHaloRight(Param XParam, BlockP<T>XBlock, int ib,
 	else if (XBlock.level[XBlock.RightBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
 	{
 		jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
-		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.75) : T(0.25);
+		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75);
 
 		ii = memloc(XParam, 0, jj, XBlock.RightBot[ib]);
 		ir = memloc(XParam, 1, jj, XBlock.RightBot[ib]);
 		it = memloc(XParam, 0, jj - 1, XBlock.RightBot[ib]);
 		itr = memloc(XParam, 1, jj - 1, XBlock.RightBot[ib]);
 
-		aright = BilinearInterpolation(a[itr], a[it], a[ir], a[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
+		aright = BilinearInterpolation(a[it], a[ii], a[itr], a[ir], T(0.0), T(1.0), T(0.0), T(1.0), T(0.25), jr);
 	}
 
 
@@ -698,7 +699,7 @@ template <class T> void gradientHaloBot(Param XParam, BlockP<T>XBlock, int ib, i
 	else if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
 	{
 		jj = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
-		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.75) : T(0.25);
+		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
 
 		ii = memloc(XParam, jj, (XParam.blkwidth - 1), XBlock.BotLeft[ib]);
 		ir = memloc(XParam, jj, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
@@ -832,14 +833,14 @@ template <class T> void gradientHaloTop(Param XParam, BlockP<T>XBlock, int ib, i
 	else if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
 	{
 		jj = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
-		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.75) : T(0.25);
+		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
 
 		ii = memloc(XParam, jj, 0, XBlock.TopLeft[ib]);
 		ir = memloc(XParam, jj, 1, XBlock.TopLeft[ib]);
 		it = memloc(XParam, jj - 1, 0, XBlock.TopLeft[ib]);
 		itr = memloc(XParam, jj - 1, 1, XBlock.TopLeft[ib]);
 
-		atop = BilinearInterpolation(a[itr], a[it], a[ir], a[ii], T(0.0), T(1.0), T(0.0), T(1.0), jr, T(0.75));
+		atop = BilinearInterpolation(a[it], a[itr], a[ii], a[ir], T(0.0), T(1.0), T(0.0), T(1.0), jr, T(0.25));
 	}
 
 
@@ -971,14 +972,14 @@ template <class T> __global__ void gradientHaloLeftGPU(Param XParam, BlockP<T>XB
 	else if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
 	{
 		jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
-		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.75) : T(0.25);
+		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75);
 
 		ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 1), jj, XBlock.LeftBot[ib]);
 		ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), jj, XBlock.LeftBot[ib]);
 		it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 1), jj - 1, XBlock.LeftBot[ib]);
 		itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), jj - 1, XBlock.LeftBot[ib]);
 
-		aleft = BilinearInterpolation(a[itr], a[it], a[ir], a[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
+		aleft = BilinearInterpolation(a[itr], a[ir], a[it], a[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
 	}
 
 
@@ -1115,7 +1116,7 @@ template <class T> __global__ void gradientHaloBotGPU(Param XParam, BlockP<T>XBl
 	else if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
 	{
 		jj = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
-		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.75) : T(0.25);
+		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
 
 		ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 1), XBlock.BotLeft[ib]);
 		ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -315,6 +315,16 @@ template <class T> void gradientCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 		gradientHalo(XParam, XBlock, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
 		gradientHalo(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
 		gradientHalo(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
+
+		WetsloperesetCPU(XParam, XBlock, XEv, XGrad, zb);
+
+		WetsloperesetHaloLeftCPU(XParam, XBlock, XEv, XGrad, zb);
+		WetsloperesetHaloRightCPU(XParam, XBlock, XEv, XGrad, zb);
+		WetsloperesetHaloBotCPU(XParam, XBlock, XEv, XGrad, zb);
+		WetsloperesetHaloTopCPU(XParam, XBlock, XEv, XGrad, zb);
+		
+
+
 	}
 
 
@@ -469,6 +479,1251 @@ template <class T> __global__ void WetsloperesetYGPU(Param XParam, BlockP<T>XBlo
 }
 
 
+template <class T> __global__ void WetsloperesetHaloLeftGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int ix = -1;
+	int iy = threadIdx.y;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int lev = XBlock.level[ib];
+
+
+	T delta = calcres(XParam.dx, lev);
+
+	T zsi, zsright, zsleft;
+
+	int i, iright, ileft;
+	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+	iright = memloc(XParam.halowidth, blkmemwidth, ix + 1, iy, ib);
+
+	zsi = XEv.zs[i];
+	zsright = XEv.zs[iright];
+
+	int read, jj, ii, ir, it, itr;
+
+	if (XBlock.LeftBot[ib] == ib)//The lower half is a boundary 
+	{
+		if (iy < (XParam.blkwidth / 2))
+		{
+
+			read = memloc(XParam.halowidth, blkmemwidth, 0, iy, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+			zsleft = XEv.zs[read];
+		}
+
+		if (XBlock.LeftTop[ib] == ib) // boundary on the top half too
+		{
+			if (iy >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, 0, iy, ib);
+
+				zsleft = XEv.zs[read];
+			}
+		}
+		else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+		{
+
+			if (iy >= (XParam.blkwidth / 2))
+			{
+
+				jj = (iy - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj, XBlock.LeftTop[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj, XBlock.LeftTop[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj + 1, XBlock.LeftTop[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj + 1, XBlock.LeftTop[ib]);
+
+				zsleft = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+			}
+		}
+	}
+	else if (XBlock.level[ib] == XBlock.level[XBlock.LeftBot[ib]]) // LeftTop block does not exist
+	{
+
+		read = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), iy, XBlock.LeftBot[ib]);
+		zsleft = XEv.zs[read];
+
+	}
+	else if (XBlock.level[XBlock.LeftBot[ib]] > XBlock.level[ib])
+	{
+
+		if (iy < (XParam.blkwidth / 2))
+		{
+
+			jj = iy * 2;
+			int bb = XBlock.LeftBot[ib];
+
+			ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj, bb);
+			ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj, bb);
+			it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj + 1, bb);
+			itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj + 1, bb);
+
+			zsleft = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+		}
+		//now find out aboy lefttop block
+		if (XBlock.LeftTop[ib] == ib)
+		{
+			if (iy >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, 0, iy, ib);
+
+				zsleft = XEv.zs[read];
+			}
+		}
+		else
+		{
+			if (iy >= (XParam.blkwidth / 2))
+			{
+				//
+				jj = (iy - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj, XBlock.LeftTop[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj, XBlock.LeftTop[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj + 1, XBlock.LeftTop[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj + 1, XBlock.LeftTop[ib]);
+
+				zsleft = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zsa[it] + XEv.zs[itr]);
+			}
+		}
+
+	}
+	else if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+	{
+		jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
+		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75);
+
+		ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 1), jj, XBlock.LeftBot[ib]);
+		ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), jj, XBlock.LeftBot[ib]);
+		it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 1), jj - 1, XBlock.LeftBot[ib]);
+		itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), jj - 1, XBlock.LeftBot[ib]);
+
+		zsleft = BilinearInterpolation(XEv.zs[itr], XEv.zs[ir], XEv.zs[it], XEv.zs[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
+	}
+	
+
+	T dzsdxi = XGrad.dzsdx[i];
+
+
+	if (utils::sq(dzsdxi) > utils::sq(XGrad.dzbdx[i]))
+	{
+		T leftzs, rightzs;
+		leftzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+		rightzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+
+		if (leftzs > XEv.zs[ileft] || rightzs > zsright)
+		{
+			XGrad.dzsdx[i] = XGrad.dhdx[i] + XGrad.dzbdx[i];
+		}
+
+	}
+
+
+}
+
+template <class T> void WetsloperesetHaloLeftCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+
+
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int ix = -1;
+
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+
+		unsigned int ib = XBlock.active[ibl];
+
+		int lev = XBlock.level[ib];
+
+
+		T delta = calcres(XParam.dx, lev);
+
+		T zsi, zsright, zsleft;
+
+		for (int iy = 0; iy <= XParam.blkwidth; iy++)
+		{
+
+			int i, iright, ileft;
+			i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+			iright = memloc(XParam.halowidth, blkmemwidth, ix + 1, iy, ib);
+
+			zsi = XEv.zs[i];
+			zsright = XEv.zs[iright];
+
+			int read, jj, ii, ir, it, itr;
+
+			if (XBlock.LeftBot[ib] == ib)//The lower half is a boundary 
+			{
+				if (iy < (XParam.blkwidth / 2))
+				{
+
+					read = memloc(XParam.halowidth, blkmemwidth, 0, iy, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+					zsleft = XEv.zs[read];
+				}
+
+				if (XBlock.LeftTop[ib] == ib) // boundary on the top half too
+				{
+					if (iy >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, 0, iy, ib);
+
+						zsleft = XEv.zs[read];
+					}
+				}
+				else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+				{
+
+					if (iy >= (XParam.blkwidth / 2))
+					{
+
+						jj = (iy - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj, XBlock.LeftTop[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj, XBlock.LeftTop[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj + 1, XBlock.LeftTop[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj + 1, XBlock.LeftTop[ib]);
+
+						zsleft = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+					}
+				}
+			}
+			else if (XBlock.level[ib] == XBlock.level[XBlock.LeftBot[ib]]) // LeftTop block does not exist
+			{
+
+				read = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), iy, XBlock.LeftBot[ib]);
+				zsleft = XEv.zs[read];
+
+			}
+			else if (XBlock.level[XBlock.LeftBot[ib]] > XBlock.level[ib])
+			{
+
+				if (iy < (XParam.blkwidth / 2))
+				{
+
+					jj = iy * 2;
+					int bb = XBlock.LeftBot[ib];
+
+					ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj, bb);
+					ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj, bb);
+					it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj + 1, bb);
+					itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj + 1, bb);
+
+					zsleft = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+				}
+				//now find out aboy lefttop block
+				if (XBlock.LeftTop[ib] == ib)
+				{
+					if (iy >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, 0, iy, ib);
+
+						zsleft = XEv.zs[read];
+					}
+				}
+				else
+				{
+					if (iy >= (XParam.blkwidth / 2))
+					{
+						//
+						jj = (iy - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj, XBlock.LeftTop[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj, XBlock.LeftTop[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 3), jj + 1, XBlock.LeftTop[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 4), jj + 1, XBlock.LeftTop[ib]);
+
+						zsleft = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+					}
+				}
+
+			}
+			else if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+			{
+				jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
+				T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75);
+
+				ii = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 1), jj, XBlock.LeftBot[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), jj, XBlock.LeftBot[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 1), jj - 1, XBlock.LeftBot[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, (XParam.blkwidth - 2), jj - 1, XBlock.LeftBot[ib]);
+
+				zsleft = BilinearInterpolation(XEv.zs[itr], XEv.zs[ir], XEv.zs[it], XEv.zs[ii], T(0.0), T(1.0), T(0.0), T(1.0), T(0.75), jr);
+			}
+
+
+			T dzsdxi = XGrad.dzsdx[i];
+
+
+			if (utils::sq(dzsdxi) > utils::sq(XGrad.dzbdx[i]))
+			{
+				T leftzs, rightzs;
+				leftzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+				rightzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+
+				if (leftzs > XEv.zs[ileft] || rightzs > zsright)
+				{
+					XGrad.dzsdx[i] = XGrad.dhdx[i] + XGrad.dzbdx[i];
+				}
+
+			}
+		}
+
+	}
+}
+
+
+template <class T> __global__ void WetsloperesetHaloRightGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int ix = XParam.blkwidth;
+	int iy = threadIdx.y;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+	int i, j, jj, ii, ir, it, itr;
+	int xminus, read;
+
+	int lev = XBlock.level[ib];
+
+	T delta = calcres(XParam.dx, lev);
+
+
+	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+
+	int iright, ileft;
+	
+	ileft = memloc(XParam.halowidth, blkmemwidth, ix - 1, iy, ib);
+
+	T zsi, zsleft, zsright;
+
+	zsi = XEv.zs[i];
+	zsleft = XEv.zs[ileft];
+	
+	T dzsdxi = XGrad.dzsdx[i];
+
+
+	if (XBlock.RightBot[ib] == ib)//The lower half is a boundary 
+	{
+		if (iy < (XParam.blkwidth / 2))
+		{
+
+			read = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, iy, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+			zsright = XEv.zs[read];;
+		}
+
+		if (XBlock.RightTop[ib] == ib) // boundary on the top half too
+		{
+			if (iy >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, iy, ib);
+
+				zsright = XEv.zs[read];
+			}
+		}
+		else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+		{
+
+			if (iy >= (XParam.blkwidth / 2))
+			{
+
+				jj = (iy - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, 3, jj, XBlock.RightTop[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, 2, jj, XBlock.RightTop[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, 3, jj + 1, XBlock.RightTop[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, 2, jj + 1, XBlock.RightTop[ib]);
+
+				zsright = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+			}
+		}
+	}
+	else if (XBlock.level[ib] == XBlock.level[XBlock.RightBot[ib]]) // LeftTop block does not exist
+	{
+
+		read = memloc(XParam.halowidth, blkmemwidth, 1, iy, XBlock.RightBot[ib]);
+		zsright = XEv.zs[read];
+
+	}
+	else if (XBlock.level[XBlock.RightBot[ib]] > XBlock.level[ib])
+	{
+
+		if (iy < (XParam.blkwidth / 2))
+		{
+
+			jj = iy * 2;
+			int bb = XBlock.RightBot[ib];
+
+			ii = memloc(XParam.halowidth, blkmemwidth, 3, jj, bb);
+			ir = memloc(XParam.halowidth, blkmemwidth, 2, jj, bb);
+			it = memloc(XParam.halowidth, blkmemwidth, 3, jj + 1, bb);
+			itr = memloc(XParam.halowidth, blkmemwidth, 2, jj + 1, bb);
+
+			zsright = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+		}
+		//now find out aboy lefttop block
+		if (XBlock.RightTop[ib] == ib)
+		{
+			if (iy >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, iy, ib);
+
+				zsright = XEv.zs[read];
+			}
+		}
+		else
+		{
+			if (iy >= (XParam.blkwidth / 2))
+			{
+				//
+				jj = (iy - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, 3, jj, XBlock.RightTop[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, 2, jj, XBlock.RightTop[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, 3, jj + 1, XBlock.RightTop[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, 2, jj + 1, XBlock.RightTop[ib]);
+
+				zsright = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+			}
+		}
+
+	}
+	else if (XBlock.level[XBlock.RightBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+	{
+		jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
+		T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75);
+
+		ii = memloc(XParam.halowidth, blkmemwidth, 0, jj, XBlock.RightBot[ib]);
+		ir = memloc(XParam.halowidth, blkmemwidth, 1, jj, XBlock.RightBot[ib]);
+		it = memloc(XParam.halowidth, blkmemwidth, 0, jj - 1, XBlock.RightBot[ib]);
+		itr = memloc(XParam.halowidth, blkmemwidth, 1, jj - 1, XBlock.RightBot[ib]);
+
+		zsright = BilinearInterpolation(XEv.zs[it], XEv.zs[ii], XEv.zs[itr], XEv.zs[ir], T(0.0), T(1.0), T(0.0), T(1.0), T(0.25), jr);
+	}
+
+
+
+
+
+
+
+	if (utils::sq(dzsdxi) > utils::sq(XGrad.dzbdx[i]))
+	{
+		T leftzs, rightzs;
+		leftzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+		rightzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+
+		if (leftzs > zsleft || rightzs > zsright)
+		{
+			XGrad.dzsdx[i] = XGrad.dhdx[i] + XGrad.dzbdx[i];
+		}
+
+	}
+
+
+}
+
+template <class T> void WetsloperesetHaloRightCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int ix = XParam.blkwidth;
+	
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+
+
+		for (int iy = 0; iy < XParam.blkwidth; iy++)
+		{
+
+
+			
+			unsigned int ib = XBlock.active[ibl];
+			int i, j, jj, ii, ir, it, itr;
+			int xminus, read;
+
+			int lev = XBlock.level[ib];
+
+			T delta = calcres(XParam.dx, lev);
+
+
+			i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+
+			int iright, ileft;
+
+			ileft = memloc(XParam.halowidth, blkmemwidth, ix - 1, iy, ib);
+
+			T zsi, zsleft, zsright;
+
+			zsi = XEv.zs[i];
+			zsleft = XEv.zs[ileft];
+
+			T dzsdxi = XGrad.dzsdx[i];
+
+
+			if (XBlock.RightBot[ib] == ib)//The lower half is a boundary 
+			{
+				if (iy < (XParam.blkwidth / 2))
+				{
+
+					read = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, iy, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+					zsright = XEv.zs[read];;
+				}
+
+				if (XBlock.RightTop[ib] == ib) // boundary on the top half too
+				{
+					if (iy >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, iy, ib);
+
+						zsright = XEv.zs[read];
+					}
+				}
+				else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+				{
+
+					if (iy >= (XParam.blkwidth / 2))
+					{
+
+						jj = (iy - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, 3, jj, XBlock.RightTop[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, 2, jj, XBlock.RightTop[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, 3, jj + 1, XBlock.RightTop[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, 2, jj + 1, XBlock.RightTop[ib]);
+
+						zsright = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+					}
+				}
+			}
+			else if (XBlock.level[ib] == XBlock.level[XBlock.RightBot[ib]]) // LeftTop block does not exist
+			{
+
+				read = memloc(XParam.halowidth, blkmemwidth, 1, iy, XBlock.RightBot[ib]);
+				zsright = XEv.zs[read];
+
+			}
+			else if (XBlock.level[XBlock.RightBot[ib]] > XBlock.level[ib])
+			{
+
+				if (iy < (XParam.blkwidth / 2))
+				{
+
+					jj = iy * 2;
+					int bb = XBlock.RightBot[ib];
+
+					ii = memloc(XParam.halowidth, blkmemwidth, 3, jj, bb);
+					ir = memloc(XParam.halowidth, blkmemwidth, 2, jj, bb);
+					it = memloc(XParam.halowidth, blkmemwidth, 3, jj + 1, bb);
+					itr = memloc(XParam.halowidth, blkmemwidth, 2, jj + 1, bb);
+
+					zsright = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+				}
+				//now find out aboy lefttop block
+				if (XBlock.RightTop[ib] == ib)
+				{
+					if (iy >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, iy, ib);
+
+						zsright = XEv.zs[read];
+					}
+				}
+				else
+				{
+					if (iy >= (XParam.blkwidth / 2))
+					{
+						//
+						jj = (iy - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, 3, jj, XBlock.RightTop[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, 2, jj, XBlock.RightTop[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, 3, jj + 1, XBlock.RightTop[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, 2, jj + 1, XBlock.RightTop[ib]);
+
+						zsright = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+					}
+				}
+
+			}
+			else if (XBlock.level[XBlock.RightBot[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+			{
+				jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? ceil(iy * (T)0.5) : ceil(iy * (T)0.5) + XParam.blkwidth / 2;
+				T jr = ceil(iy * (T)0.5) * 2 > iy ? T(0.25) : T(0.75);
+
+				ii = memloc(XParam.halowidth, blkmemwidth, 0, jj, XBlock.RightBot[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, 1, jj, XBlock.RightBot[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, 0, jj - 1, XBlock.RightBot[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, 1, jj - 1, XBlock.RightBot[ib]);
+
+				zsright = BilinearInterpolation(XEv.zs[it], XEv.zs[ii], XEv.zs[itr], XEv.zs[ir], T(0.0), T(1.0), T(0.0), T(1.0), T(0.25), jr);
+			}
+
+
+
+
+
+
+
+			if (utils::sq(dzsdxi) > utils::sq(XGrad.dzbdx[i]))
+			{
+				T leftzs, rightzs;
+				leftzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+				rightzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdxi - XGrad.dhdx[i]);
+
+				if (leftzs > zsleft || rightzs > zsright)
+				{
+					XGrad.dzsdx[i] = XGrad.dhdx[i] + XGrad.dzbdx[i];
+				}
+
+			}
+		}
+
+	}
+}
+
+
+template <class T> __global__ void WetsloperesetHaloBotGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int iy = -1;
+	int ix = threadIdx.x;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int i, j, jj, ii, ir, it, itr;
+
+	int lev = XBlock.level[ib];
+
+	T delta = calcres(XParam.dx, lev);
+
+
+	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+
+	int itop,read;
+	itop = memloc(XParam.halowidth, blkmemwidth, ix, iy + 1, ib);
+	
+	T zsi, zstop, zsbot;
+
+	T dzsdyi = XGrad.dzsdy[i];
+
+	zsi = XEv.zs[i];
+	zstop = XEv.zs[itop];
+
+
+	if (XBlock.BotLeft[ib] == ib)//The lower half is a boundary 
+	{
+		if (ix < (XParam.blkwidth / 2))
+		{
+
+			read = memloc(XParam.halowidth, blkmemwidth, ix, 0, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+			zsbot = XEv.zs[read];
+
+		}
+
+		if (XBlock.BotRight[ib] == ib) // boundary on the top half too
+		{
+			if (ix >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, ix, 0, ib);
+
+				zsbot = XEv.zs[read];
+			}
+		}
+		else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+		{
+
+			if (ix >= (XParam.blkwidth / 2))
+			{
+
+				jj = (ix - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+
+				zsbot = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+			}
+		}
+	}
+	else if (XBlock.level[ib] == XBlock.level[XBlock.BotLeft[ib]]) // LeftTop block does not exist
+	{
+
+		read = memloc(XParam.halowidth, blkmemwidth, ix, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
+		zsbot = XEv.zs[read];
+
+
+
+	}
+	else if (XBlock.level[XBlock.BotLeft[ib]] > XBlock.level[ib])
+	{
+
+		if (ix < (XParam.blkwidth / 2))
+		{
+
+			jj = ix * 2;
+			int bb = XBlock.BotLeft[ib];
+
+			ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 3), bb);
+			ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 4), bb);
+			it = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 3), bb);
+			itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 4), bb);
+
+			zsbot = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+		}
+		//now find out aboy lefttop block
+		if (XBlock.BotRight[ib] == ib)
+		{
+			if (ix >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, ix, 0, ib);
+
+				zsbot = XEv.zs[read];
+			}
+		}
+		else
+		{
+			if (ix >= (XParam.blkwidth / 2))
+			{
+				//
+				jj = (ix - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+
+				zsbot = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+			}
+		}
+
+	}
+	else if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+	{
+		jj = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
+		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
+
+		ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 1), XBlock.BotLeft[ib]);
+		ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
+		it = memloc(XParam.halowidth, blkmemwidth, jj - 1, (XParam.blkwidth - 1), XBlock.BotLeft[ib]);
+		itr = memloc(XParam.halowidth, blkmemwidth, jj - 1, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
+
+		zsbot = BilinearInterpolation(XEv.zs[itr], XEv.zs[it], XEv.zs[ir], XEv.zs[ii], T(0.0), T(1.0), T(0.0), T(1.0), jr, T(0.75));
+	}
+
+
+	if (utils::sq(dzsdyi) > utils::sq(XGrad.dzbdy[i]))
+	{
+		T botzs, topzs;
+		botzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+		topzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+
+		if (botzs > zsbot || topzs > zstop)
+		{
+			XGrad.dzsdy[i] = XGrad.dhdy[i] + XGrad.dzbdy[i];
+		}
+
+	}
+
+
+}
+
+template <class T> void WetsloperesetHaloBotCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int iy = -1;
+	
+
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+
+		
+		unsigned int ib = XBlock.active[ibl];
+
+		 
+
+		int i, j, jj, ii, ir, it, itr;
+
+		int lev = XBlock.level[ib];
+
+		T delta = calcres(XParam.dx, lev);
+
+		for (int ix = 0; ix < XParam.blkwidth; ix++)
+		{
+
+
+			i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+
+			int itop, read;
+			itop = memloc(XParam.halowidth, blkmemwidth, ix, iy + 1, ib);
+
+			T zsi, zstop, zsbot;
+
+			T dzsdyi = XGrad.dzsdy[i];
+
+			zsi = XEv.zs[i];
+			zstop = XEv.zs[itop];
+
+
+			if (XBlock.BotLeft[ib] == ib)//The lower half is a boundary 
+			{
+				if (ix < (XParam.blkwidth / 2))
+				{
+
+					read = memloc(XParam.halowidth, blkmemwidth, ix, 0, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+					zsbot = XEv.zs[read];
+
+				}
+
+				if (XBlock.BotRight[ib] == ib) // boundary on the top half too
+				{
+					if (ix >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, ix, 0, ib);
+
+						zsbot = XEv.zs[read];
+					}
+				}
+				else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+				{
+
+					if (ix >= (XParam.blkwidth / 2))
+					{
+
+						jj = (ix - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+
+						zsbot = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+					}
+				}
+			}
+			else if (XBlock.level[ib] == XBlock.level[XBlock.BotLeft[ib]]) // LeftTop block does not exist
+			{
+
+				read = memloc(XParam.halowidth, blkmemwidth, ix, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
+				zsbot = XEv.zs[read];
+
+
+
+			}
+			else if (XBlock.level[XBlock.BotLeft[ib]] > XBlock.level[ib])
+			{
+
+				if (ix < (XParam.blkwidth / 2))
+				{
+
+					jj = ix * 2;
+					int bb = XBlock.BotLeft[ib];
+
+					ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 3), bb);
+					ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 4), bb);
+					it = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 3), bb);
+					itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 4), bb);
+
+					zsbot = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+				}
+				//now find out aboy lefttop block
+				if (XBlock.BotRight[ib] == ib)
+				{
+					if (ix >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, ix, 0, ib);
+
+						zsbot = XEv.zs[read];
+					}
+				}
+				else
+				{
+					if (ix >= (XParam.blkwidth / 2))
+					{
+						//
+						jj = (ix - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 3), XBlock.BotRight[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, (XParam.blkwidth - 4), XBlock.BotRight[ib]);
+
+						zsbot = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+					}
+				}
+
+			}
+			else if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+			{
+				jj = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
+				T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
+
+				ii = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 1), XBlock.BotLeft[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, jj, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, jj - 1, (XParam.blkwidth - 1), XBlock.BotLeft[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, jj - 1, (XParam.blkwidth - 2), XBlock.BotLeft[ib]);
+
+				zsbot = BilinearInterpolation(XEv.zs[itr], XEv.zs[it], XEv.zs[ir], XEv.zs[ii], T(0.0), T(1.0), T(0.0), T(1.0), jr, T(0.75));
+			}
+
+
+			if (utils::sq(dzsdyi) > utils::sq(XGrad.dzbdy[i]))
+			{
+				T botzs, topzs;
+				botzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+				topzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+
+				if (botzs > zsbot || topzs > zstop)
+				{
+					XGrad.dzsdy[i] = XGrad.dhdy[i] + XGrad.dzbdy[i];
+				}
+
+			}
+		}
+
+	}
+
+}
+
+template <class T> __global__ void WetsloperesetHaloTopGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int iy = XParam.blkwidth;
+	int ix = threadIdx.x;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int i, j, jj, ii, ir, it, itr;
+
+	int lev = XBlock.level[ib];
+
+	T delta = calcres(XParam.dx, lev);
+
+
+	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+
+	int itop, ibot, read;
+	
+	ibot = memloc(XParam.halowidth, blkmemwidth, ix, iy - 1, ib);
+
+	T zsi, zstop, zsbot;
+
+	zsi = XEv.zs[i];
+	zsbot = XEv.zs[ibot];
+
+	T dzsdyi = XGrad.dzsdy[i];
+
+
+	if (XBlock.TopLeft[ib] == ib)//The lower half is a boundary 
+	{
+		if (ix < (XParam.blkwidth / 2))
+		{
+
+			read = memloc(XParam.halowidth, blkmemwidth, ix, XParam.blkwidth - 1, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+			zstop = XEv.zs[read];
+
+		}
+
+		if (XBlock.TopRight[ib] == ib) // boundary on the top half too
+		{
+			if (ix >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, ix, XParam.blkwidth - 1, ib);
+
+				zstop = XEv.zs[read];
+			}
+		}
+		else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+		{
+
+			if (ix >= (XParam.blkwidth / 2))
+			{
+
+				jj = (ix - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, jj, 3, XBlock.TopRight[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, jj, 2, XBlock.TopRight[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, jj + 1, 3, XBlock.TopRight[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, 2, XBlock.TopRight[ib]);
+
+				zstop = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+			}
+		}
+	}
+	else if (XBlock.level[ib] == XBlock.level[XBlock.TopLeft[ib]]) // LeftTop block does not exist
+	{
+
+		read = memloc(XParam.halowidth, blkmemwidth, ix, 1, XBlock.TopLeft[ib]);
+		zstop = XEv.zs[read];
+
+
+
+	}
+	else if (XBlock.level[XBlock.TopLeft[ib]] > XBlock.level[ib])
+	{
+
+		if (ix < (XParam.blkwidth / 2))
+		{
+
+			jj = ix * 2;
+			int bb = XBlock.TopLeft[ib];;
+
+			ii = memloc(XParam.halowidth, blkmemwidth, jj, 3, bb);
+			ir = memloc(XParam.halowidth, blkmemwidth, jj, 2, bb);
+			it = memloc(XParam.halowidth, blkmemwidth, jj + 1, 3, bb);
+			itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, 2, bb);
+
+			zstop = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+		}
+		//now find out aboy lefttop block
+		if (XBlock.TopRight[ib] == ib)
+		{
+			if (ix >= (XParam.blkwidth / 2))
+			{
+				//
+
+				read = memloc(XParam.halowidth, blkmemwidth, ix, XParam.blkwidth - 1, ib);
+
+				zstop = XEv.zs[read];
+			}
+		}
+		else
+		{
+			if (ix >= (XParam.blkwidth / 2))
+			{
+				//
+				jj = (ix - XParam.blkwidth / 2) * 2;
+				ii = memloc(XParam.halowidth, blkmemwidth, jj, 3, XBlock.TopRight[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, jj, 2, XBlock.TopRight[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, jj + 1, 3, XBlock.TopRight[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, 2, XBlock.TopRight[ib]);
+
+				zstop = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+			}
+		}
+
+	}
+	else if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+	{
+		jj = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
+		T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
+
+		ii = memloc(XParam.halowidth, blkmemwidth, jj, 0, XBlock.TopLeft[ib]);
+		ir = memloc(XParam.halowidth, blkmemwidth, jj, 1, XBlock.TopLeft[ib]);
+		it = memloc(XParam.halowidth, blkmemwidth, jj - 1, 0, XBlock.TopLeft[ib]);
+		itr = memloc(XParam.halowidth, blkmemwidth, jj - 1, 1, XBlock.TopLeft[ib]);
+
+		zstop = BilinearInterpolation(XEv.zs[it], XEv.zs[itr], XEv.zs[ii], XEv.zs[ir], T(0.0), T(1.0), T(0.0), T(1.0), jr, T(0.25));
+	}
+
+
+	if (utils::sq(dzsdyi) > utils::sq(XGrad.dzbdy[i]))
+	{
+		T botzs, topzs;
+		botzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+		topzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+
+		if (botzs > zsbot || topzs > zstop)
+		{
+			XGrad.dzsdy[i] = XGrad.dhdy[i] + XGrad.dzbdy[i];
+		}
+
+	}
+
+
+}
+
+
+
+template <class T>  void WetsloperesetHaloTopCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, T* zb)
+{
+	unsigned int blkmemwidth = XParam.blkwidth + XParam.halowidth * 2;
+	unsigned int blksize = XParam.blkmemwidth * XParam.blkmemwidth;
+	int iy = XParam.blkwidth;
+	
+
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+		unsigned int ib = XBlock.active[ibl];
+
+		int i, j, jj, ii, ir, it, itr;
+
+		int lev = XBlock.level[ib];
+
+		T delta = calcres(XParam.dx, lev);
+
+		for (int ix = 0; ix < XParam.blkwidth; ix++)
+		{
+
+			i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
+
+			int itop, ibot, read;
+
+			ibot = memloc(XParam.halowidth, blkmemwidth, ix, iy - 1, ib);
+
+			T zsi, zstop, zsbot;
+
+			zsi = XEv.zs[i];
+			zsbot = XEv.zs[ibot];
+
+			T dzsdyi = XGrad.dzsdy[i];
+
+
+			if (XBlock.TopLeft[ib] == ib)//The lower half is a boundary 
+			{
+				if (ix < (XParam.blkwidth / 2))
+				{
+
+					read = memloc(XParam.halowidth, blkmemwidth, ix, XParam.blkwidth - 1, ib);// or memloc(XParam, -1, j, ib) but they should be the same
+
+					zstop = XEv.zs[read];
+
+				}
+
+				if (XBlock.TopRight[ib] == ib) // boundary on the top half too
+				{
+					if (ix >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, ix, XParam.blkwidth - 1, ib);
+
+						zstop = XEv.zs[read];
+					}
+				}
+				else // boundary is only on the bottom half and implicitely level of lefttopib is levelib+1
+				{
+
+					if (ix >= (XParam.blkwidth / 2))
+					{
+
+						jj = (ix - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, jj, 3, XBlock.TopRight[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, jj, 2, XBlock.TopRight[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, jj + 1, 3, XBlock.TopRight[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, 2, XBlock.TopRight[ib]);
+
+						zstop = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+
+					}
+				}
+			}
+			else if (XBlock.level[ib] == XBlock.level[XBlock.TopLeft[ib]]) // LeftTop block does not exist
+			{
+
+				read = memloc(XParam.halowidth, blkmemwidth, ix, 1, XBlock.TopLeft[ib]);
+				zstop = XEv.zs[read];
+
+
+
+			}
+			else if (XBlock.level[XBlock.TopLeft[ib]] > XBlock.level[ib])
+			{
+
+				if (ix < (XParam.blkwidth / 2))
+				{
+
+					jj = ix * 2;
+					int bb = XBlock.TopLeft[ib];;
+
+					ii = memloc(XParam.halowidth, blkmemwidth, jj, 3, bb);
+					ir = memloc(XParam.halowidth, blkmemwidth, jj, 2, bb);
+					it = memloc(XParam.halowidth, blkmemwidth, jj + 1, 3, bb);
+					itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, 2, bb);
+
+					zstop = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+				}
+				//now find out aboy lefttop block
+				if (XBlock.TopRight[ib] == ib)
+				{
+					if (ix >= (XParam.blkwidth / 2))
+					{
+						//
+
+						read = memloc(XParam.halowidth, blkmemwidth, ix, XParam.blkwidth - 1, ib);
+
+						zstop = XEv.zs[read];
+					}
+				}
+				else
+				{
+					if (ix >= (XParam.blkwidth / 2))
+					{
+						//
+						jj = (ix - XParam.blkwidth / 2) * 2;
+						ii = memloc(XParam.halowidth, blkmemwidth, jj, 3, XBlock.TopRight[ib]);
+						ir = memloc(XParam.halowidth, blkmemwidth, jj, 2, XBlock.TopRight[ib]);
+						it = memloc(XParam.halowidth, blkmemwidth, jj + 1, 3, XBlock.TopRight[ib]);
+						itr = memloc(XParam.halowidth, blkmemwidth, jj + 1, 2, XBlock.TopRight[ib]);
+
+						zstop = T(0.25) * (XEv.zs[ii] + XEv.zs[ir] + XEv.zs[it] + XEv.zs[itr]);
+					}
+				}
+
+			}
+			else if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib]) // Neighbour is coarser; using barycentric interpolation (weights are precalculated) for the Halo 
+			{
+				jj = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? ceil(ix * (T)0.5) : ceil(ix * (T)0.5) + XParam.blkwidth / 2;
+				T jr = ceil(ix * (T)0.5) * 2 > ix ? T(0.25) : T(0.75);
+
+				ii = memloc(XParam.halowidth, blkmemwidth, jj, 0, XBlock.TopLeft[ib]);
+				ir = memloc(XParam.halowidth, blkmemwidth, jj, 1, XBlock.TopLeft[ib]);
+				it = memloc(XParam.halowidth, blkmemwidth, jj - 1, 0, XBlock.TopLeft[ib]);
+				itr = memloc(XParam.halowidth, blkmemwidth, jj - 1, 1, XBlock.TopLeft[ib]);
+
+				zstop = BilinearInterpolation(XEv.zs[it], XEv.zs[itr], XEv.zs[ii], XEv.zs[ir], T(0.0), T(1.0), T(0.0), T(1.0), jr, T(0.25));
+			}
+
+
+			if (utils::sq(dzsdyi) > utils::sq(XGrad.dzbdy[i]))
+			{
+				T botzs, topzs;
+				botzs = zsi - XEv.h[i] - delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+				topzs = zsi - XEv.h[i] + delta * T(0.5) * (dzsdyi - XGrad.dhdy[i]);
+
+				if (botzs > zsbot || topzs > zstop)
+				{
+					XGrad.dzsdy[i] = XGrad.dhdy[i] + XGrad.dzbdy[i];
+				}
+
+			}
+		}
+	}
+
+
+}
 
 
 template <class T> void gradientHalo(Param XParam, BlockP<T>XBlock, T* a, T* dadx, T* dady)

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -291,12 +291,12 @@ template <class T> void gradientHalo(Param XParam, BlockP<T>XBlock, T* a, T* dad
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			gradientHaloLeft(XParam, XBlock, ib, iy, a, dadx, dady);
-			//gradientHaloRight(XParam, XBlock, ib, iy, a, dadx, dady);
+			gradientHaloRight(XParam, XBlock, ib, iy, a, dadx, dady);
 		}
 		for (int ix = 0; ix < XParam.blkwidth; ix++)
 		{
 			gradientHaloBot(XParam, XBlock, ib, ix, a, dadx, dady);
-			//gradientHaloTop(XParam, XBlock, ib, ix, a, dadx, dady);
+			gradientHaloTop(XParam, XBlock, ib, ix, a, dadx, dady);
 		}
 	}
 }

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -268,6 +268,22 @@ template <class T> void gradientCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 		conserveElevationGradHalo(XParam, XBlock, XEv.h, XEv.zs, zb, XGrad.dhdx, XGrad.dzsdx, XGrad.dhdy, XGrad.dzsdy);
 
 	}
+	else
+	{
+		refine_linear(XParam,XBlock, XEv.h, XGrad.dhdx, XGrad.dhdy);
+		refine_linear(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
+		refine_linear(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
+
+		RecalculateZs(XParam, XBlock, XEv, zb);
+				
+
+		gradientHalo(XParam, XBlock, XEv.h, XGrad.dhdx, XGrad.dhdy);
+		gradientHalo(XParam, XBlock, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
+		gradientHalo(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
+		gradientHalo(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdy);
+	}
+
+
 	//conserveElevationGradHalo(XParam, XBlock, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
 	//conserveElevationGradHalo(XParam, XBlock, XEv.u, XGrad.dudx, XGrad.dudy);
 	//conserveElevationGradHalo(XParam, XBlock, XEv.v, XGrad.dvdx, XGrad.dvdyythhhhhhhhhg);

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -151,10 +151,9 @@ template <class T> void fillHaloTopRightC(Param XParam, BlockP<T> XBlock, T* z)
 		ib = XBlock.active[ibl];
 		fillRightFlux(XParam,false, ib, XBlock, z);
 		fillTopFlux(XParam,false, ib, XBlock, z);
+
 	}
-	//fillBot(XParam, ib, XBlock, z);
-	//fill bot
-	//fill top
+	
 
 
 }

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -1,7 +1,14 @@
 ﻿#include "Halo.h"
 
 
-
+/*! \fn void void fillHaloD(Param XParam, int ib, BlockP<T> XBlock, T* z)
+* \brief Wrapping function for calculating halos on CPU on every side of a block of a single variable
+* 
+* ## Description
+* This fuction is a wraping fuction of the halo functions for CPU. It is called from another wraping function to keep things clean.
+* In a sense this is the third (and last) layer of wrapping
+* 
+*/
 template <class T> void fillHaloD(Param XParam, int ib, BlockP<T> XBlock, T* z)
 {
 	
@@ -18,6 +25,14 @@ template <class T> void fillHaloD(Param XParam, int ib, BlockP<T> XBlock, T* z)
 template void fillHaloD<double>(Param XParam, int ib, BlockP<double> XBlock, double* z);
 template void fillHaloD<float>(Param XParam, int ib, BlockP<float> XBlock, float* z);
 
+/*! \fn void fillHaloC(Param XParam, BlockP<T> XBlock, T* z)
+* \brief Wrapping function for calculating halos for each block of a single variable on CPU.
+*
+* ## Description
+* This function is a wraping fuction of the halo functions on CPU. It is called from the main Halo CPU function.
+* This is layer 2 of 3 wrap so the candy doesn't stick too much.
+*
+*/
 template <class T> void fillHaloC(Param XParam, BlockP<T> XBlock, T* z)
 {
 	int ib;
@@ -30,6 +45,17 @@ template <class T> void fillHaloC(Param XParam, BlockP<T> XBlock, T* z)
 template void fillHaloC<float>(Param XParam, BlockP<float> XBlock, float* z);
 template void fillHaloC<double>(Param XParam, BlockP<double> XBlock, double* z);
 
+/*! \fn void RecalculateZs(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb)
+* \brief Recalculate water surface after recalculating the values on the halo on the CPU
+*
+* ## Description
+* Recalculate water surface after recalculating the values on the halo on the CPU. zb (bottom elevation) on each halo is calculated
+* at the start of the loop or as part of the initial condition. When conserve-elevation is not required, only h is recalculated on the halo at ever 1/2 steps.  
+* zs then needs to be recalculated to obtain a mass-conservative solution (if zs is conserved then mass conservation is not garanteed)
+* 
+* ## Warning
+* This function calculate zs everywhere in the block... this is a bit unecessary. Instead it should recalculate only where there is a prolongation or a restiction
+*/
 template <class T> void RecalculateZs(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb)
 {
 	int ib,n,left, right, top,bot;
@@ -70,7 +96,17 @@ template void RecalculateZs<float>(Param XParam, BlockP<float> XBlock, EvolvingP
 template void RecalculateZs<double>(Param XParam, BlockP<double> XBlock, EvolvingP<double> Xev, double* zb);
 
 
-
+/*! \fn void RecalculateZs(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb)
+* \brief Recalculate water surface after recalculating the values on the halo on the GPU
+*
+* ## Description
+* Recalculate water surface after recalculating the values on the halo on the CPU. zb (bottom elevation) on each halo is calculated
+* at the start of the loop or as part of the initial condition. When conserve-elevation is not required, only h is recalculated on the halo at ever 1/2 steps.
+* zs then needs to be recalculated to obtain a mass-conservative solution (if zs is conserved then mass conservation is not garanteed)
+*
+* ## Warning
+* This function calculate zs everywhere in the block... this is a bit unecessary. Instead it should recalculate only where there is a prolongation or a restiction
+*/
 template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb)
 {
 	unsigned int blkmemwidth = XParam.blkmemwidth;
@@ -97,6 +133,16 @@ template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlo
 template __global__ void RecalculateZsGPU<float>(Param XParam, BlockP<float> XBlock, EvolvingP<float> Xev, float* zb);
 template __global__ void RecalculateZsGPU<double>(Param XParam, BlockP<double> XBlock, EvolvingP<double> Xev, double* zb);
 
+/*! \fn void fillHaloF(Param XParam, bool doProlongation, BlockP<T> XBlock, T* z)
+* \brief Wrapping function for calculating flux in the halos for a block and a single variable on CPU.
+* ## Depreciated
+* This function is was never sucessful and will never be used. It is fundamentally flawed because is doesn't preserve the balance of fluxes on the restiction interface
+* It should be deleted soon
+* ## Description
+* 
+* 
+*
+*/
 template <class T> void fillHaloF(Param XParam, bool doProlongation, BlockP<T> XBlock, T* z)
 {
 	int ib;
@@ -113,7 +159,14 @@ template <class T> void fillHaloF(Param XParam, bool doProlongation, BlockP<T> X
 template void fillHaloF<float>(Param XParam, bool doProlongation, BlockP<float> XBlock, float* z);
 template void fillHaloF<double>(Param XParam, bool doProlongation, BlockP<double> XBlock, double* z);
 
-
+/*! \fn void fillHaloGPU(Param XParam, BlockP<T> XBlock, cudaStream_t stream, T* z)
+* \brief Wrapping function for calculating halos for each block of a single variable on GPU.
+*
+* ## Description
+* This function is a wraping fuction of the halo functions on GPU. It is called from the main Halo GPU function.
+* The present imnplementation is naive and slow one that calls the rather complex fillLeft type functions
+* 
+*/
 template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, cudaStream_t stream, T* z)
 {
 
@@ -140,6 +193,14 @@ template void fillHaloGPU<double>(Param XParam, BlockP<double> XBlock, cudaStrea
 template void fillHaloGPU<float>(Param XParam, BlockP<float> XBlock, cudaStream_t stream, float* z);
 
 
+/*! \fn void  fillHaloTopRightC(Param XParam, BlockP<T> XBlock, T* z)
+* \brief Wrapping function for calculating flux for halos for each block of a single variable on GPU.
+*
+* ## Description
+* This function is a wraping function of the halo flux functions on GPU. It is called from the main Halo GPU function.
+* The present imnplementation is naive and slow one that calls the rather complex fillLeft type functions
+*
+*/
 template <class T> void fillHaloTopRightC(Param XParam, BlockP<T> XBlock, T* z)
 {
 	// for flux term and actually most terms, only top and right neighbours are needed!

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -521,7 +521,7 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 
 
 	fillHaloLeftRightGPU(XParam, XBlock, streams[0], Flux.Fhu);
-	fillHaloLeftRightGPU(XParam, XBlock, streams[1], Flux.Fhv);
+	fillHaloLeftRightGPU(XParam, XBlock, streams[1], Flux.Su);
 	fillHaloLeftRightGPU(XParam, XBlock, streams[2], Flux.Fqux);
 	fillHaloLeftRightGPU(XParam, XBlock, streams[3], Flux.Fqvx);
 
@@ -529,7 +529,7 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 
 	fillHaloBotTopGPU(XParam, XBlock, streams[4], Flux.Fquy);
 	fillHaloBotTopGPU(XParam, XBlock, streams[5], Flux.Fqvy);
-	fillHaloBotTopGPU(XParam, XBlock, streams[6], Flux.Su);
+	fillHaloBotTopGPU(XParam, XBlock, streams[6], Flux.Fhv);
 	fillHaloBotTopGPU(XParam, XBlock, streams[7], Flux.Sv);
 
 	for (int i = 0; i < num_streams; i++)

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -427,8 +427,86 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 template void fillHaloGPU<float>(Param XParam, BlockP<float> XBlock, FluxP<float> Flux);
 template void fillHaloGPU<double>(Param XParam, BlockP<double> XBlock, FluxP<double> Flux);
 
+template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBlock, T* z, T * dzdx)
+{
+	if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib])
+	{
+		double ilevdx = calcres(XParam.dx, XBlock.level[ib]+1);
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			int jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ceil(j * (T)0.5) : ceil(j * (T)0.5) + XParam.blkwidth / 2;
+			int il = memloc(XParam, XParam.blkwidth - 1, jj - 1, XBlock.LeftBot[ib]);
+			int write = memloc(XParam, -1, j, ib);
+			T slope = dzdx[il];
+			T newz = z[il] - dzdx[il] * ilevdx;
+
+			z[write] = newz;
 
 
+		}
+	}
+}
+
+template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx)
+{
+	if (XBlock.level[XBlock.RightBot[ib]] < XBlock.level[ib])
+	{
+		double ilevdx = calcres(XParam.dx, XBlock.level[ib] + 1);
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			int jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? ceil(j * (T)0.5) : ceil(j * (T)0.5) + XParam.blkwidth / 2;
+			int il = memloc(XParam, 0, jj - 1, XBlock.RightBot[ib]);
+			int write = memloc(XParam, XParam.blkwidth, j, ib);
+			T slope = dzdx[il];
+			T newz = z[il] + dzdx[il] * ilevdx;
+
+			z[write] = newz;
+
+
+		}
+	}
+}
+
+
+template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy)
+{
+	if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib])
+	{
+		double ilevdx = calcres(XParam.dx, XBlock.level[ib] + 1);
+		for (int i = 0; i < XParam.blkwidth; i++)
+		{
+			int ii = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ceil(i * (T)0.5) : ceil(i * (T)0.5) + XParam.blkwidth / 2;
+			int jl = memloc(XParam,  ii - 1, XParam.blkwidth - 1, XBlock.BotLeft[ib]);
+			int write = memloc(XParam, i, -1, ib);
+			T slope = dzdx[jl];
+			T newz = z[jl] - dzdy[jl] * ilevdx;
+
+			z[write] = newz;
+
+
+		}
+	}
+}
+
+template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy)
+{
+	if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
+	{
+		double ilevdx = calcres(XParam.dx, XBlock.level[ib] + 1);
+		for (int i = 0; i < XParam.blkwidth; i++)
+		{
+			int ii = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? ceil(i * (T)0.5) : ceil(i * (T)0.5) + XParam.blkwidth / 2;
+			int jl = memloc(XParam, ii - 1, 0, XBlock.TopLeft[ib]);
+			int write = memloc(XParam, i, XParam.blkwidth, ib);
+			T slope = dzdx[jl];
+			T newz = z[jl] + dzdy[jl] * ilevdx;
+
+			z[write] = newz;
+
+
+		}
+	}
+}
 
 template <class T> void fillLeft(Param XParam, int ib, BlockP<T> XBlock, T* &z)
 {

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -232,6 +232,48 @@ template <class T> void fillHaloTopRightGPU(Param XParam, BlockP<T> XBlock, cuda
 template void fillHaloTopRightGPU<double>(Param XParam, BlockP<double> XBlock, cudaStream_t stream, double* z);
 template void fillHaloTopRightGPU<float>(Param XParam, BlockP<float> XBlock, cudaStream_t stream, float* z);
 
+template <class T> void fillHaloLeftRightGPU(Param XParam, BlockP<T> XBlock, cudaStream_t stream, T* z)
+{
+
+	dim3 blockDimHaloLR(1, 16, 1);
+	dim3 blockDimHaloBT(16, 1, 1);
+	dim3 gridDim(XParam.nblk, 1, 1);
+
+
+	//fillLeft << <gridDim, blockDimHaloLR, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, XBlock.LeftBot, XBlock.LeftTop, XBlock.RightBot, XBlock.BotRight, XBlock.TopRight, a);
+	//fillRightFlux << <gridDim, blockDimHaloLR, 0, stream >> > (XParam.halowidth,false, XBlock.active, XBlock.level, XBlock.RightBot, XBlock.RightTop, XBlock.LeftBot, XBlock.BotLeft, XBlock.TopLeft, z);
+	HaloFluxGPULR << <gridDim, blockDimHaloLR, 0, stream >> > (XParam, XBlock, z);
+
+	//fillBot << <gridDim, blockDimHaloBT, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, XBlock.BotLeft, XBlock.BotRight, XBlock.TopLeft, XBlock.LeftTop, XBlock.RightTop, a);
+	//fillTopFlux << <gridDim, blockDimHaloBT, 0, stream >> > (XParam.halowidth,false, XBlock.active, XBlock.level, XBlock.TopLeft, XBlock.TopRight, XBlock.BotLeft, XBlock.LeftBot, XBlock.RightBot, z);
+	//HaloFluxGPUBT << <gridDim, blockDimHaloBT, 0, stream >> > (XParam, XBlock, z);
+	CUDA_CHECK(cudaStreamSynchronize(stream));
+
+}
+template void fillHaloLeftRightGPU<double>(Param XParam, BlockP<double> XBlock, cudaStream_t stream, double* z);
+template void fillHaloLeftRightGPU<float>(Param XParam, BlockP<float> XBlock, cudaStream_t stream, float* z);
+
+template <class T> void fillHaloBotTopGPU(Param XParam, BlockP<T> XBlock, cudaStream_t stream, T* z)
+{
+
+	dim3 blockDimHaloLR(1, 16, 1);
+	dim3 blockDimHaloBT(16, 1, 1);
+	dim3 gridDim(XParam.nblk, 1, 1);
+
+
+	//fillLeft << <gridDim, blockDimHaloLR, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, XBlock.LeftBot, XBlock.LeftTop, XBlock.RightBot, XBlock.BotRight, XBlock.TopRight, a);
+	//fillRightFlux << <gridDim, blockDimHaloLR, 0, stream >> > (XParam.halowidth,false, XBlock.active, XBlock.level, XBlock.RightBot, XBlock.RightTop, XBlock.LeftBot, XBlock.BotLeft, XBlock.TopLeft, z);
+	//HaloFluxGPULR << <gridDim, blockDimHaloLR, 0, stream >> > (XParam, XBlock, z);
+
+	//fillBot << <gridDim, blockDimHaloBT, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, XBlock.BotLeft, XBlock.BotRight, XBlock.TopLeft, XBlock.LeftTop, XBlock.RightTop, a);
+	//fillTopFlux << <gridDim, blockDimHaloBT, 0, stream >> > (XParam.halowidth,false, XBlock.active, XBlock.level, XBlock.TopLeft, XBlock.TopRight, XBlock.BotLeft, XBlock.LeftBot, XBlock.RightBot, z);
+	HaloFluxGPUBT << <gridDim, blockDimHaloBT, 0, stream >> > (XParam, XBlock, z);
+	CUDA_CHECK(cudaStreamSynchronize(stream));
+
+}
+template void fillHaloBotTopGPU<double>(Param XParam, BlockP<double> XBlock, cudaStream_t stream, double* z);
+template void fillHaloBotTopGPU<float>(Param XParam, BlockP<float> XBlock, cudaStream_t stream, float* z);
+
 
 template <class T> void fillHalo(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T*zb)
 {
@@ -478,17 +520,17 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 	}
 
 
-	fillHaloTopRightGPU(XParam, XBlock, streams[0], Flux.Fhu);
-	fillHaloTopRightGPU(XParam, XBlock, streams[1], Flux.Fhv);
-	fillHaloTopRightGPU(XParam, XBlock, streams[2], Flux.Fqux);
-	fillHaloTopRightGPU(XParam, XBlock, streams[3], Flux.Fquy);
+	fillHaloLeftRightGPU(XParam, XBlock, streams[0], Flux.Fhu);
+	fillHaloLeftRightGPU(XParam, XBlock, streams[1], Flux.Fhv);
+	fillHaloLeftRightGPU(XParam, XBlock, streams[2], Flux.Fqux);
+	fillHaloLeftRightGPU(XParam, XBlock, streams[3], Flux.Fqvx);
 
 	
 
-	fillHaloTopRightGPU(XParam, XBlock, streams[4], Flux.Fqvx);
-	fillHaloTopRightGPU(XParam, XBlock, streams[5], Flux.Fqvy);
-	fillHaloTopRightGPU(XParam, XBlock, streams[6], Flux.Su);
-	fillHaloTopRightGPU(XParam, XBlock, streams[7], Flux.Sv);
+	fillHaloBotTopGPU(XParam, XBlock, streams[4], Flux.Fquy);
+	fillHaloBotTopGPU(XParam, XBlock, streams[5], Flux.Fqvy);
+	fillHaloBotTopGPU(XParam, XBlock, streams[6], Flux.Su);
+	fillHaloBotTopGPU(XParam, XBlock, streams[7], Flux.Sv);
 
 	for (int i = 0; i < num_streams; i++)
 	{

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -66,6 +66,9 @@ template <class T> void RecalculateZs(Param XParam, BlockP<T> XBlock, EvolvingP<
 		
 	}
 }
+template void RecalculateZs<float>(Param XParam, BlockP<float> XBlock, EvolvingP<float> Xev, float* zb);
+template void RecalculateZs<double>(Param XParam, BlockP<double> XBlock, EvolvingP<double> Xev, double* zb);
+
 
 
 template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb)
@@ -91,6 +94,8 @@ template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlo
 	*/
 	
 }
+template __global__ void RecalculateZsGPU<float>(Param XParam, BlockP<float> XBlock, EvolvingP<float> Xev, float* zb);
+template __global__ void RecalculateZsGPU<double>(Param XParam, BlockP<double> XBlock, EvolvingP<double> Xev, double* zb);
 
 template <class T> void fillHaloF(Param XParam, bool doProlongation, BlockP<T> XBlock, T* z)
 {
@@ -437,7 +442,7 @@ template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBloc
 			int jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ceil(j * (T)0.5) : ceil(j * (T)0.5) + XParam.blkwidth / 2;
 			int il = memloc(XParam, XParam.blkwidth - 1, jj - 1, XBlock.LeftBot[ib]);
 			int write = memloc(XParam, -1, j, ib);
-			T slope = dzdx[il];
+			
 			T newz = z[il] - dzdx[il] * ilevdx;
 
 			z[write] = newz;
@@ -446,6 +451,9 @@ template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBloc
 		}
 	}
 }
+template void refine_linear_Left<float>(Param XParam, int ib, BlockP<float> XBlock, float* z, float* dzdx);
+template void refine_linear_Left<double>(Param XParam, int ib, BlockP<double> XBlock, double* z, double* dzdx);
+
 
 template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx)
 {
@@ -457,7 +465,7 @@ template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlo
 			int jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? ceil(j * (T)0.5) : ceil(j * (T)0.5) + XParam.blkwidth / 2;
 			int il = memloc(XParam, 0, jj - 1, XBlock.RightBot[ib]);
 			int write = memloc(XParam, XParam.blkwidth, j, ib);
-			T slope = dzdx[il];
+			
 			T newz = z[il] + dzdx[il] * ilevdx;
 
 			z[write] = newz;
@@ -466,7 +474,8 @@ template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlo
 		}
 	}
 }
-
+template void refine_linear_Right<float>(Param XParam, int ib, BlockP<float> XBlock, float* z, float* dzdx);
+template void refine_linear_Right<double>(Param XParam, int ib, BlockP<double> XBlock, double* z, double* dzdx);
 
 template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy)
 {
@@ -478,7 +487,7 @@ template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock
 			int ii = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ceil(i * (T)0.5) : ceil(i * (T)0.5) + XParam.blkwidth / 2;
 			int jl = memloc(XParam,  ii - 1, XParam.blkwidth - 1, XBlock.BotLeft[ib]);
 			int write = memloc(XParam, i, -1, ib);
-			T slope = dzdx[jl];
+			
 			T newz = z[jl] - dzdy[jl] * ilevdx;
 
 			z[write] = newz;
@@ -487,6 +496,8 @@ template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock
 		}
 	}
 }
+template void refine_linear_Bot<float>(Param XParam, int ib, BlockP<float> XBlock, float* z, float* dzdy);
+template void refine_linear_Bot<double>(Param XParam, int ib, BlockP<double> XBlock, double* z, double* dzdy);
 
 template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy)
 {
@@ -498,7 +509,7 @@ template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock
 			int ii = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? ceil(i * (T)0.5) : ceil(i * (T)0.5) + XParam.blkwidth / 2;
 			int jl = memloc(XParam, ii - 1, 0, XBlock.TopLeft[ib]);
 			int write = memloc(XParam, i, XParam.blkwidth, ib);
-			T slope = dzdx[jl];
+			
 			T newz = z[jl] + dzdy[jl] * ilevdx;
 
 			z[write] = newz;
@@ -507,6 +518,23 @@ template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock
 		}
 	}
 }
+template void refine_linear_Top<float>(Param XParam, int ib, BlockP<float> XBlock, float* z, float* dzdy);
+template void refine_linear_Top<double>(Param XParam, int ib, BlockP<double> XBlock, double* z, double* dzdy);
+
+template <class T> void refine_linear(Param XParam, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy)
+{
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+		int ib = XBlock.active[ibl];
+		refine_linear_Left(XParam, ib, XBlock, z, dzdx);
+		refine_linear_Right(XParam, ib, XBlock, z, dzdx);
+		refine_linear_Top(XParam, ib, XBlock, z, dzdy);
+		refine_linear_Bot(XParam, ib, XBlock, z, dzdy);
+	}
+}
+template void refine_linear<float>(Param XParam, BlockP<float> XBlock, float* z, float* dzdx, float* dzdy);
+template void refine_linear<double>(Param XParam, BlockP<double> XBlock, double* z, double* dzdx, double* dzdy);
+
 
 template <class T> void fillLeft(Param XParam, int ib, BlockP<T> XBlock, T* &z)
 {

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -149,8 +149,8 @@ template <class T> void fillHaloTopRightC(Param XParam, BlockP<T> XBlock, T* z)
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		ib = XBlock.active[ibl];
-		fillRightFlux(XParam,false, ib, XBlock, z);
-		fillTopFlux(XParam,false, ib, XBlock, z);
+		fillRightFlux(XParam,true, ib, XBlock, z);
+		fillTopFlux(XParam,true, ib, XBlock, z);
 
 	}
 	

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -521,7 +521,7 @@ template <class T> void fillLeft(Param XParam, int ib, BlockP<T> XBlock, T* &z)
 			for (int j = (XParam.blkwidth / 2); j < (XParam.blkwidth); j++)
 			{
 				//
-				jj = (j - 8) * 2;
+				jj = (j - (XParam.blkwidth / 2)) * 2;
 				bb = XBlock.LeftTop[ib];
 
 				//read = memloc(XParam, 0, j, ib);// 1 + (j + XParam.halowidth) * XParam.blkmemwidth + ib * XParam.blksize;
@@ -979,7 +979,7 @@ template <class T> void fillRight(Param XParam, int ib, BlockP<T> XBlock, T*& z)
 			for (int j = (XParam.blkwidth / 2); j < (XParam.blkwidth); j++)
 			{
 				write = memloc(XParam, XParam.blkwidth, j, ib);
-				jj = (j - 8) * 2;
+				jj = (j - (XParam.blkwidth / 2)) * 2;
 				ii = memloc(XParam, 0, jj, XBlock.RightTop[ib]);
 				ir = memloc(XParam, 1, jj, XBlock.RightTop[ib]);
 				it = memloc(XParam, 0, jj + 1, XBlock.RightTop[ib]);
@@ -1036,7 +1036,7 @@ template <class T> void fillRight(Param XParam, int ib, BlockP<T> XBlock, T*& z)
 			for (int j = (XParam.blkwidth / 2); j < (XParam.blkwidth); j++)
 			{
 				//
-				jj = (j - 8) * 2;
+				jj = (j - (XParam.blkwidth / 2)) * 2;
 				bb = XBlock.RightTop[ib];
 
 				//read = memloc(XParam, 0, j, ib);// 1 + (j + XParam.halowidth) * XParam.blkmemwidth + ib * XParam.blksize;

--- a/src/Halo.h
+++ b/src/Halo.h
@@ -49,7 +49,7 @@ template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlo
 template <class T> void refine_linear(Param XParam, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy);
 template <class T> void refine_linearGPU(Param XParam, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy);
 
-template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx);
+template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy);
 template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy);
 template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy);
 template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx);

--- a/src/Halo.h
+++ b/src/Halo.h
@@ -43,6 +43,15 @@ template <class T> void fillCorners(Param XParam, int ib, BlockP<T> XBlock, T*& 
 template <class T> void fillCorners(Param XParam, BlockP<T> XBlock, T*& z);
 template <class T> void fillCorners(Param XParam, BlockP<T> XBlock, EvolvingP<T>& Xev);
 
+template <class T> void RecalculateZs(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
+template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
+
+template <class T> void refine_linear(Param XParam, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy);
+
+template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx);
+template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy);
+template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy);
+template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx);
 
 // GPU versions
 template <class T> __global__ void fillLeft(int halowidth, int* active, int* level, int* leftbot, int* lefttop, int* rightbot, int* botright, int* topright, T* a);

--- a/src/Halo.h
+++ b/src/Halo.h
@@ -47,6 +47,7 @@ template <class T> void RecalculateZs(Param XParam, BlockP<T> XBlock, EvolvingP<
 template <class T> __global__ void RecalculateZsGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 
 template <class T> void refine_linear(Param XParam, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy);
+template <class T> void refine_linearGPU(Param XParam, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy);
 
 template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdx);
 template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock, T* z, T* dzdy);

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -168,7 +168,7 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 	if (XForcing.rivers.size() > 0)
 	{
 		//
-		double xx, yy;
+		double xl, yb, xr, yt ;
 		int n,ib;
 		double levdx;
 		double dischargeArea = 0.0;
@@ -189,11 +189,15 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 						int n = (i + XParam.halowidth) + (j + XParam.halowidth) * XParam.blkmemwidth + ib * XParam.blksize;
 						
 						
-						xx = XParam.xo + XModel.blocks.xo[ib] + i * levdx;
-						yy = XParam.yo + XModel.blocks.yo[ib] + j * levdx;
+						xl = XParam.xo + XModel.blocks.xo[ib] + i * levdx - 0.5 * levdx;
+						yb = XParam.yo + XModel.blocks.yo[ib] + j * levdx - 0.5 * levdx;
+
+						xr = XParam.xo + XModel.blocks.xo[ib] + i * levdx + 0.5 * levdx;
+						yt = XParam.yo + XModel.blocks.yo[ib] + j * levdx + 0.5 * levdx;
 						// the conditions are that the discharge area as defined by the user have to include at least a model grid node
 						// This could be really annoying and there should be a better way to deal wiith this like polygon intersection
-						if (xx >= XForcing.rivers[Rin].xstart && xx <= XForcing.rivers[Rin].xend && yy >= XForcing.rivers[Rin].ystart && yy <= XForcing.rivers[Rin].yend)
+						//if (xx >= XForcing.rivers[Rin].xstart && xx <= XForcing.rivers[Rin].xend && yy >= XForcing.rivers[Rin].ystart && yy <= XForcing.rivers[Rin].yend)
+						if (OBBdetect(xl, xr, yb, yt, XForcing.rivers[Rin].xstart, XForcing.rivers[Rin].xend, XForcing.rivers[Rin].ystart, XForcing.rivers[Rin].yend))
 						{
 
 							// This cell belongs to the river discharge area

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -142,7 +142,7 @@ template <class T> void FindTSoutNodes(Param& XParam, BlockP<T> XBlock, Bndblock
 
 			ib = XBlock.active[blk];
 			levdx = calcres(XParam.dx,XBlock.level[ib]);
-			if (XParam.TSnodesout[o].x >= (XParam.xo + XBlock.xo[ib]) && XParam.TSnodesout[o].x <= (XParam.xo + XBlock.xo[ib] + (T)(XParam.blkwidth - 1) * levdx) && XParam.TSnodesout[o].y >= (XParam.yo + XBlock.yo[o]) && XParam.TSnodesout[o].y <= (XParam.yo + XBlock.yo[ib] + (T)(XParam.blkwidth - 1) * levdx))
+			if (XParam.TSnodesout[o].x >= (XParam.xo + XBlock.xo[ib]) && XParam.TSnodesout[o].x <= (XParam.xo + XBlock.xo[ib] + (T)(XParam.blkwidth - 1) * levdx) && XParam.TSnodesout[o].y >= (XParam.yo + XBlock.yo[ib]) && XParam.TSnodesout[o].y <= (XParam.yo + XBlock.yo[ib] + (T)(XParam.blkwidth - 1) * levdx))
 			{
 				XParam.TSnodesout[o].block = ib;
 				XParam.TSnodesout[o].i = min(max((int)round((XParam.TSnodesout[o].x - (XParam.xo + XBlock.xo[ib])) / levdx), 0), XParam.blkwidth - 1);

--- a/src/InitialConditions.h
+++ b/src/InitialConditions.h
@@ -11,6 +11,7 @@
 #include "Write_txtlog.h"
 #include "GridManip.h"
 #include "InitEvolv.h"
+#include "Gradients.h"
 
 
 template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcing, Model<T> &XModel);
@@ -25,6 +26,8 @@ template <class T> void FindTSoutNodes(Param& XParam, BlockP<T> XBlock, Bndblock
 template <class T> void Calcbndblks(Param& XParam, Forcing<float>& XForcing, BlockP<T> XBlock);
 template <class T> void Findbndblks(Param XParam, Model<T> XModel, Forcing<float>& XForcing);
 
+template <class T> void InitzbgradientCPU(Param XParam, Model<T> XModel);
+template <class T> void InitzbgradientGPU(Param XParam, Model<T> XModel);
 
 template <class T> void calcactiveCellCPU(Param XParam, BlockP<T> XBlock, T* zb);
 

--- a/src/InitialConditions.h
+++ b/src/InitialConditions.h
@@ -25,5 +25,8 @@ template <class T> void FindTSoutNodes(Param& XParam, BlockP<T> XBlock, Bndblock
 template <class T> void Calcbndblks(Param& XParam, Forcing<float>& XForcing, BlockP<T> XBlock);
 template <class T> void Findbndblks(Param XParam, Model<T> XModel, Forcing<float>& XForcing);
 
+
+template <class T> void calcactiveCellCPU(Param XParam, BlockP<T> XBlock, T* zb);
+
 // End of global definition;
 #endif

--- a/src/Kurganov.cu
+++ b/src/Kurganov.cu
@@ -402,6 +402,7 @@ template <class T> __host__ void updateKurgXCPU(Param XParam, BlockP<T> XBlock, 
 					{
 						int jj = RBLB == ib ? floor(iy * (T)0.5) : floor(iy * (T)0.5) + XParam.blkwidth / 2;
 						int ilc = memloc(halowidth, blkmemwidth, XParam.blkwidth - 1, jj, LB);
+						//int ilc = memloc(halowidth, blkmemwidth, -1, iy, ib);
 						hn = XEv.h[ilc];
 						zn = zb[ilc];
 					}

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -34,6 +34,8 @@ template <class T> void MainLoop(Param &XParam, Forcing<float> XForcing, Model<T
 
 		gradientHaloGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
 		refine_linearGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
 		gradientHaloGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
 	}
 

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -104,12 +104,21 @@ template <class T> void DebugLoop(Param& XParam, Forcing<float> XForcing, Model<
 	// fill halo for zb
 	// only need to do that once 
 	fillHaloC(XParam, XModel.blocks, XModel.zb);
+	gradientC(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 	if (XParam.GPUDEVICE >= 0)
 	{
+		dim3 blockDim(16, 16, 1);
+		dim3 gridDim(XParam.nblk, 1, 1);
 		CUDA_CHECK(cudaStreamCreate(&XLoop.streams[0]));
 		fillHaloGPU(XParam, XModel_g.blocks, XLoop.streams[0], XModel_g.zb);
-
 		cudaStreamDestroy(XLoop.streams[0]);
+
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+
+		gradientHaloGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+
 	}
 
 

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -18,6 +18,9 @@ template <class T> void MainLoop(Param &XParam, Forcing<float> XForcing, Model<T
 	gradientC(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 
+	refine_linear(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+
 	if (XParam.GPUDEVICE >= 0)
 	{
 		dim3 blockDim(16, 16, 1);
@@ -30,8 +33,8 @@ template <class T> void MainLoop(Param &XParam, Forcing<float> XForcing, Model<T
 		CUDA_CHECK(cudaDeviceSynchronize());
 
 		gradientHaloGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
-
-		
+		refine_linearGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+		gradientHaloGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
 	}
 
 

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -15,12 +15,23 @@ template <class T> void MainLoop(Param &XParam, Forcing<float> XForcing, Model<T
 	// fill halo for zb
 	// only need to do that once 
 	fillHaloC(XParam, XModel.blocks, XModel.zb);
+	gradientC(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+
 	if (XParam.GPUDEVICE >= 0)
 	{
+		dim3 blockDim(16, 16, 1);
+		dim3 gridDim(XParam.nblk, 1, 1);
 		CUDA_CHECK(cudaStreamCreate(&XLoop.streams[0]));
 		fillHaloGPU(XParam, XModel_g.blocks, XLoop.streams[0], XModel_g.zb);
-
 		cudaStreamDestroy(XLoop.streams[0]);
+
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+
+		gradientHaloGPU(XParam, XModel_g.blocks, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+
+		
 	}
 
 

--- a/src/Mainloop.h
+++ b/src/Mainloop.h
@@ -17,6 +17,8 @@
 
 template <class T> void MainLoop(Param& XParam, Forcing<float> XForcing, Model<T>& XModel, Model<T>& XModel_g);
 
+template <class T> void DebugLoop(Param& XParam, Forcing<float> XForcing, Model<T>& XModel, Model<T>& XModel_g);
+
 template <class T> __host__ double initdt(Param XParam, Loop<T> XLoop, Model<T> XModel);
 
 template <class T> Loop<T> InitLoop(Param& XParam, Model<T>& XModel);

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -67,6 +67,9 @@ void AllocateCPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 	AllocateCPU(nblk, blksize, XModel.grad.dhdy, XModel.grad.dzsdy, XModel.grad.dudy, XModel.grad.dvdy);
 	AllocateCPU(nblk, blksize, XModel.grad.dhdx, XModel.grad.dzsdx, XModel.grad.dudx, XModel.grad.dvdx);
 
+	AllocateCPU(nblk, blksize, XModel.grad.dzbdx);
+	AllocateCPU(nblk, blksize, XModel.grad.dzbdy);
+
 	AllocateCPU(nblk, blksize, XModel.flux.Fhu, XModel.flux.Fhv, XModel.flux.Fqux, XModel.flux.Fquy);
 
 	AllocateCPU(nblk, blksize, XModel.flux.Fqvx, XModel.flux.Fqvy, XModel.flux.Su, XModel.flux.Sv);

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -43,6 +43,9 @@ void AllocateCPU(int nx, int ny, GradientsP<T>& Grad)
 {
 	AllocateCPU(nx, ny, Grad.dhdx, Grad.dzsdx, Grad.dudx, Grad.dvdx);
 	AllocateCPU(nx, ny, Grad.dhdy, Grad.dzsdy, Grad.dudy, Grad.dvdy);
+	
+	AllocateCPU(nx, ny, Grad.dzbdx);
+	AllocateCPU(nx, ny, Grad.dzbdy);
 }
 template void AllocateCPU<float>(int nx, int ny, GradientsP<float>& Grad);
 template void AllocateCPU<double>(int nx, int ny, GradientsP<double>& Grad);
@@ -195,6 +198,9 @@ void ReallocArray(int nblk, int blksize, Param XParam, Model<T>& XModel)
 	ReallocArray(nblk, blksize, XModel.grad.dhdy, XModel.grad.dzsdy, XModel.grad.dudy, XModel.grad.dvdy);
 	ReallocArray(nblk, blksize, XModel.grad.dhdx, XModel.grad.dzsdx, XModel.grad.dudx, XModel.grad.dvdx);
 
+	ReallocArray(nblk, blksize, XModel.grad.dzbdx);
+	ReallocArray(nblk, blksize, XModel.grad.dzbdy);
+
 	ReallocArray(nblk, blksize, XModel.flux.Fhu, XModel.flux.Fhv, XModel.flux.Fqux, XModel.flux.Fquy);
 
 	ReallocArray(nblk, blksize, XModel.flux.Fqvx, XModel.flux.Fqvy, XModel.flux.Su, XModel.flux.Sv);
@@ -274,6 +280,8 @@ void AllocateGPU(int nx, int ny, GradientsP<T>& Grad)
 {
 	AllocateGPU(nx, ny, Grad.dhdx, Grad.dzsdx, Grad.dudx, Grad.dvdx);
 	AllocateGPU(nx, ny, Grad.dhdy, Grad.dzsdy, Grad.dudy, Grad.dvdy);
+	AllocateGPU(nx, ny, Grad.dzbdy);
+	AllocateGPU(nx, ny, Grad.dzbdx);
 }
 template void AllocateGPU<float>(int nx, int ny, GradientsP<float>& Grad);
 template void AllocateGPU<double>(int nx, int ny, GradientsP<double>& Grad);

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -75,6 +75,7 @@ void AllocateCPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	//Allocate block info
 	AllocateCPU(nblk, 1, XModel.blocks.active);
+	AllocateCPU(nblk, blksize, XModel.blocks.activeCell);
 	AllocateCPU(nblk, 1, XModel.blocks.level);
 
 	AllocateCPU(nblk, 1, XModel.blocks.BotLeft, XModel.blocks.BotRight, XModel.blocks.LeftBot, XModel.blocks.LeftTop);
@@ -205,6 +206,7 @@ void ReallocArray(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	//Allocate block info
 	ReallocArray(nblk, 1, XModel.blocks.active);
+	ReallocArray(nblk, blksize, XModel.blocks.activeCell);
 	ReallocArray(nblk, 1, XModel.blocks.level);
 
 	ReallocArray(nblk, 1, XModel.blocks.BotLeft, XModel.blocks.BotRight, XModel.blocks.LeftBot, XModel.blocks.LeftTop);
@@ -300,6 +302,7 @@ void AllocateGPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	//Allocate block info
 	AllocateGPU(nblk, 1, XModel.blocks.active);
+	AllocateGPU(nblk, blksize, XModel.blocks.activeCell);
 	AllocateGPU(nblk, 1, XModel.blocks.level);
 
 	AllocateGPU(nblk, 1, XModel.blocks.BotLeft, XModel.blocks.BotRight, XModel.blocks.LeftBot, XModel.blocks.LeftTop);

--- a/src/Mesh.cu
+++ b/src/Mesh.cu
@@ -220,6 +220,8 @@ template <class T> void InitBlockxoyo(Param XParam, Forcing<float> XForcing, Blo
 					double x = XParam.xo + (double(i) + XParam.blkwidth * nblkx)*levdx + 0.5 * levdx;
 					double y = XParam.yo + (double(j) + XParam.blkwidth * nblky)*levdx + 0.5 * levdx;
 
+					int n = memloc(XParam, i, j, blkid);
+
 					//x = max(min(x, XParam.Bathymetry.xmax), XParam.Bathymetry.xo);
 					//y = max(min(y, XParam.Bathymetry.ymax), XParam.Bathymetry.yo);
 					
@@ -254,7 +256,12 @@ template <class T> void InitBlockxoyo(Param XParam, Forcing<float> XForcing, Blo
 						//printf("q = %f\t q11=%f\t, q12=%f\t, q21=%f\t, q22=%f\t, x1=%f\t, x2=%f\t, y1=%f\t, y2=%f\t, x=%f\t, y=%f\t\n", q, q11, q12, q21, q22, x1, x2, y1, y2, x, y);
 						//printf("mloc: %i\n", mloc);
 						if (q >= XParam.mask)
+						{
 							nmask++;
+							XBlock.activeCell[n] = 0;
+						}
+						else
+							XBlock.activeCell[n] = 1;
 					}
 					
 

--- a/src/Mesh.cu
+++ b/src/Mesh.cu
@@ -258,10 +258,8 @@ template <class T> void InitBlockxoyo(Param XParam, Forcing<float> XForcing, Blo
 						if (q >= XParam.mask)
 						{
 							nmask++;
-							XBlock.activeCell[n] = 0;
+
 						}
-						else
-							XBlock.activeCell[n] = 1;
 					}
 					
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -15,6 +15,7 @@ public:
 	double dt=0.0; // Model time step in s.
 	double CFL=0.5; // Current Freidrich Limiter
 	double theta=1.3; // minmod limiter can be used to tune the momentum dissipation (theta=1 gives minmod, the most dissipative limiter and theta = 2 gives	superbee, the least dissipative).
+	double VelThreshold = -1.0; // Using Velocity threshold if the the velocuity exceeds that threshold. use 16.0 to use or negative value (-1) to turn off
 	int frictionmodel=0; //
 	double cf=0.0001; // bottom friction for flow model cf
 	double Cd=0.002; // Wind drag coeff

--- a/src/Param.h
+++ b/src/Param.h
@@ -133,6 +133,12 @@ public:
 
 	bool outvort = false;
 
+	// WARNING FOR DEBUGGING PURPOSE ONLY
+	// For debugging one can shift the output by 1 or -1 in the i and j direction.
+	// this will save the value in the halo to the output file allowing debugging of values there.
+	int outishift = 0;
+	int outjshift = 0;
+
 	// info of the mapped cf
 	//inputmap roughnessmap;
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -397,8 +397,24 @@ Param readparamstr(std::string line, Param param)
 		param.resetmax = std::stoi(parametervalue);
 	}
 
+	// WARNING FOR DEBUGGING PURPOSE ONLY
+	// For debugging one can shift the output by 1 or -1 in the i and j direction.
+	// this will save the value in the halo to the output file allowing debugging of values there.
+	parameterstr = "outishift";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		param.outishift = std::stoi(parametervalue);
+	}
+	parameterstr = "outjshift";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		param.outjshift = std::stoi(parametervalue);
+	}
 
-	
+	////////////////////////////////////////////////////////////////
+	// 
 
 	parameterstr = "nx";
 	parametervalue = findparameter(parameterstr, line);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -664,15 +664,15 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 					{
 						int jj = BLTL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + XParam.blkwidth / 2;
 						int itop = memloc(halowidth, blkmemwidth, jj, 0, TL);
-						//hi = XEv.h[itop];
-						//zi = zb[itop];
+						hi = XEv.h[itop];
+						zi = zb[itop];
 					}
 					if ((iy == 0) && levBL < lev)//(ix==16) i.e. in the bot halo
 					{
 						int jj = TLBL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + XParam.blkwidth / 2;
 						int ibc = memloc(halowidth, blkmemwidth, jj, XParam.blkwidth - 1, BL);
-						//hn = XEv.h[ibc];
-						//zn = zb[ibc];
+						hn = XEv.h[ibc];
+						zn = zb[ibc];
 					}
 
 					sl = ga * (hi + hCNr) * (zi - zCN);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -664,15 +664,15 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 					{
 						int jj = BLTL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + XParam.blkwidth / 2;
 						int itop = memloc(halowidth, blkmemwidth, jj, 0, TL);
-						hi = XEv.h[itop];
-						zi = zb[itop];
+						//hi = XEv.h[itop];
+						//zi = zb[itop];
 					}
 					if ((iy == 0) && levBL < lev)//(ix==16) i.e. in the bot halo
 					{
 						int jj = TLBL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + XParam.blkwidth / 2;
 						int ibc = memloc(halowidth, blkmemwidth, jj, XParam.blkwidth - 1, BL);
-						hn = XEv.h[ibc];
-						zn = zb[ibc];
+						//hn = XEv.h[ibc];
+						//zn = zb[ibc];
 					}
 
 					sl = ga * (hi + hCNr) * (zi - zCN);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -1,7 +1,24 @@
 #include "Reimann.h"
 
 
-
+/*! \fn void UpdateButtingerXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+* \brief "Adaptive” second-order hydrostatic reconstruction. GPU version for t X-axis
+*
+* ## Description
+* This function computes the flux term at the cell interface using the hydrostatic reconstruction from Buttinger et al (2019).
+* This reconstruction is safe for steep slope with thin water depth and is well-balanced meaning that it conserve the "lake-at-rest" states.
+*
+* For optimising the code on CPU and GPU there are 4 versions of this function: X or Y and CPU or GPU
+*
+* ## Where does this come from:
+* This scheme was adapted/modified from the Basilisk / B-Flood source code. I (CypB) changed the zr and zl term back to the Audusse type reconstruction
+* http://basilisk.fr/sandbox/b-flood/saint-venant-topo.h
+*
+* Reference:
+* Kirstetter, G., Delestre, O., Lagrée, P.-Y., Popinet, S., and Josserand, C.: B-flood 1.0: an open-source Saint-Venant model for flash flood simulation using adaptive refinement, Geosci. Model Dev. Discuss. [preprint], https://doi.org/10.5194/gmd-2021-15, in review, 2021.*
+* Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
+* structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
+*/
 template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
 {
 	unsigned int halowidth = XParam.halowidth;
@@ -170,6 +187,24 @@ template __global__ void UpdateButtingerXGPU(Param XParam, BlockP<float> XBlock,
 template __global__ void UpdateButtingerXGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
 
 
+/*! \fn void UpdateButtingerXCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+* \brief "Adaptive” second-order hydrostatic reconstruction. CPU version for the X-axis
+*
+* ## Description
+* This function computes the flux term at the cell interface using the hydrostatic reconstruction from Buttinger et al (2019).
+* This reconstruction is safe for steep slope with thin water depth and is well-balanced meaning that it conserve the "lake-at-rest" states.
+*
+* For optimising the code on CPU and GPU there are 4 versions of this function: X or Y and CPU or GPU
+*
+* ## Where does this come from:
+* This scheme was adapted/modified from the Basilisk / B-Flood source code. I (CypB) changed the zr and zl term back to the Audusse type reconstruction
+* http://basilisk.fr/sandbox/b-flood/saint-venant-topo.h
+*
+* Reference:
+* Kirstetter, G., Delestre, O., Lagrée, P.-Y., Popinet, S., and Josserand, C.: B-flood 1.0: an open-source Saint-Venant model for flash flood simulation using adaptive refinement, Geosci. Model Dev. Discuss. [preprint], https://doi.org/10.5194/gmd-2021-15, in review, 2021.*
+* Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
+* structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
+*/
 template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
 {
 
@@ -350,6 +385,25 @@ template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBl
 template __host__ void UpdateButtingerXCPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
 template __host__ void UpdateButtingerXCPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
 
+
+/*! \fn void UpdateButtingerYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+* \brief "Adaptive” second-order hydrostatic reconstruction. GPU version for the Y-axis
+*
+* ## Description
+* This function computes the flux term at the cell interface using the hydrostatic reconstruction from Buttinger et al (2019).
+* This reconstruction is safe for steep slope with thin water depth and is well-balanced meaning that it conserve the "lake-at-rest" states.
+*
+* For optimising the code on CPU and GPU there are 4 versions of this function: X or Y and CPU or GPU
+*
+* ## Where does this come from:
+* This scheme was adapted/modified from the Basilisk / B-Flood source code. I (CypB) changed the zr and zl term back to the Audusse type reconstruction
+* http://basilisk.fr/sandbox/b-flood/saint-venant-topo.h
+*
+* Reference:
+* Kirstetter, G., Delestre, O., Lagrée, P.-Y., Popinet, S., and Josserand, C.: B-flood 1.0: an open-source Saint-Venant model for flash flood simulation using adaptive refinement, Geosci. Model Dev. Discuss. [preprint], https://doi.org/10.5194/gmd-2021-15, in review, 2021.*
+* Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
+* structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
+*/
 template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
 {
 	unsigned int halowidth = XParam.halowidth;
@@ -517,7 +571,24 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 template __global__ void UpdateButtingerYGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
 template __global__ void UpdateButtingerYGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
 
-
+/*! \fn void UpdateButtingerYCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+* \brief "Adaptive” second-order hydrostatic reconstruction. CPU version for the Y-axis
+*
+* ## Description
+* This function computes the flux term at the cell interface using the hydrostatic reconstruction from Buttinger et al (2019).
+* This reconstruction is safe for steep slope with thin water depth and is well-balanced meaning that it conserve the "lake-at-rest" states.
+*
+* For optimising the code on CPU and GPU there are 4 versions of this function: X or Y and CPU or GPU
+*
+* ## Where does this come from:
+* This scheme was adapted/modified from the Basilisk / B-Flood source code. I (CypB) changed the zr and zl term back to the Audusse type reconstruction
+* http://basilisk.fr/sandbox/b-flood/saint-venant-topo.h
+*
+* Reference:
+* Kirstetter, G., Delestre, O., Lagrée, P.-Y., Popinet, S., and Josserand, C.: B-flood 1.0: an open-source Saint-Venant model for flash flood simulation using adaptive refinement, Geosci. Model Dev. Discuss. [preprint], https://doi.org/10.5194/gmd-2021-15, in review, 2021.*
+* Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
+* structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
+*/
 template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
 {
 
@@ -703,30 +774,47 @@ template __host__ void UpdateButtingerYCPU(Param XParam, BlockP<double> XBlock, 
 
 
 
-
+/*! \fn T hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T &fh, T &fq)
+* \brief Calculate the  Harten-Lax-van Leer-contact (HLLC) flux.
+*
+* ## Description
+* This an implementation of the HLLC solver. 
+* 
+*
+* ## Where does this come from:
+* This scheme was adapted/modified from the Basilisk source code.
+* http://basilisk.fr/src/riemann.h
+* 
+* Reference:
+* (Basilisk reference the scheme from Kurganov reference below)
+* Kurganov, A., & Levy, D. (2002). Central-upwind schemes for the
+*    Saint-Venant system. Mathematical Modelling and Numerical
+*    Analysis, 36(3), 397-425.
+*
+*/
 template <class T> __host__ __device__ T hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T &fh, T &fq)
 {
 	T cp, cmo , dt, ustar, cstar, SL, SR, fhm, fum,fhp, fup,dlt;
 	cmo = sqrt(g * hm);
 	cp = sqrt(g * hp);
-	ustar = (um + up) / 2. + cmo - cp;
-	cstar = (cmo + cp) / 2. + (um - up) / 4.;
-	SL = hm == 0. ? up - 2. * cp : min(um - cmo, ustar - cstar);
-	SR = hp == 0. ? um + 2. * cmo : max(up + cp, ustar + cstar);
+	ustar = (um + up) / T(2.) + cmo - cp;
+	cstar = (cmo + cp) / T(2.) + (um - up) / T(4.);
+	SL = hm == T(0.) ? up - T(2.) * cp : min(um - cmo, ustar - cstar);
+	SR = hp == T(0.) ? um + T(2.) * cmo : max(up + cp, ustar + cstar);
 
-	if (0. <= SL) {
+	if (T(0.) <= SL) {
 		fh = um * hm;
-		fq = hm * (um * um + g * hm / 2.);
+		fq = hm * (um * um + g * hm / T(2.));
 	}
-	else if (0. >= SR) {
+	else if (T(0.) >= SR) {
 		fh = up * hp;
-		fq = hp * (up * up + g * hp / 2.);
+		fq = hp * (up * up + g * hp / T(2.));
 	}
 	else {
 		fhm = um * hm;
-		fum = hm * (um * um + g * hm / 2.);
+		fum = hm * (um * um + g * hm / T(2.));
 		fhp = up * hp;
-		fup = hp * (up * up + g * hp / 2.);
+		fup = hp * (up * up + g * hp / T(2.));
 		fh = (SR * fhm - SL * fhp + SL * SR * (hp - hm)) / (SR - SL);
 		fq = (SR * fum - SL * fup + SL * SR * (hp * up - hm * um)) / (SR - SL);
 	}

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -74,8 +74,8 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 		etal = XEv.zs[ileft] + dx * XGrad.dzsdx[ileft];
 
 		//define the topography term at the interfaces
-		zr = zi - dx * XGrad.dzbdx[i];
-		zl = zn + dx * XGrad.dzbdx[ileft];
+		zr = etar - hr;// zi - dx * XGrad.dzbdx[i];
+		zl = etal - hl;// zn + dx * XGrad.dzbdx[ileft];
 
 		//define the Audusse terms
 		zA = max(zr, zl);
@@ -252,8 +252,8 @@ template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBl
 					etal = XEv.zs[ileft] + dx * XGrad.dzsdx[ileft];
 
 					//define the topography term at the interfaces
-					zr = zi - dx * XGrad.dzbdx[i];
-					zl = zn + dx * XGrad.dzbdx[ileft];
+					zr = etar - hr;// zi - dx * XGrad.dzbdx[i];
+					zl = etal - hl;// zn + dx * XGrad.dzbdx[ileft];
 
 					//define the Audusse terms
 					zA = max(zr, zl);
@@ -422,8 +422,8 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 		etal = XEv.zs[ibot] + dx * XGrad.dzsdy[ibot];
 
 		//define the topography term at the interfaces
-		zr = zi - dx * XGrad.dzbdy[i];
-		zl = zn + dx * XGrad.dzbdy[ibot];
+		zr = etar - hr;// zi - dx * XGrad.dzbdy[i];
+		zl = etal - hl;// zn + dx * XGrad.dzbdy[ibot];
 
 		//define the Audusse terms
 		zA = max(zr, zl);
@@ -603,8 +603,8 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 					etal = XEv.zs[ibot] + dx * XGrad.dzsdy[ibot];
 
 					//define the topography term at the interfaces
-					zr = zi - dx * XGrad.dzbdy[i];
-					zl = zn + dx * XGrad.dzbdy[ibot];
+					zr = etar - hr;// zi - dx * XGrad.dzbdy[i];
+					zl = etal - hl;// zn + dx * XGrad.dzbdy[ibot];
 
 					//define the Audusse terms
 					zA = max(zr, zl);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -354,8 +354,8 @@ template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBl
 					if ((ix == 0) && levLB < lev)//(ix==16) i.e. in the right halo if you 
 					{
 						int jj = RBLB == ib ? floor(iy * (T)0.5) : floor(iy * (T)0.5) + XParam.blkwidth / 2;
-						int ilc = memloc(halowidth, blkmemwidth, XParam.blkwidth - 1, jj, LB);
-						//int ilc = memloc(halowidth, blkmemwidth, -1, iy, ib);
+						int ilc = memloc(halowidth, blkmemwidth, XParam.blkwidth- 1, jj, LB);
+						
 						hn = XEv.h[ilc];
 						zn = zb[ilc];
 					}
@@ -742,6 +742,8 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 					{
 						int jj = TLBL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + XParam.blkwidth / 2;
 						int ibc = memloc(halowidth, blkmemwidth, jj, XParam.blkwidth - 1, BL);
+						// Warning I think the above is wrong and should be as below to be consistent with halo flux scheme:
+						//int ibc = memloc(halowidth, blkmemwidth, jj, XParam.blkwidth, BL);
 						hn = XEv.h[ibc];
 						zn = zb[ibc];
 					}

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -1,5 +1,5 @@
 #include "Reimann.h"
-/*
+
 template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
 {
 	unsigned int halowidth = XParam.halowidth;
@@ -11,6 +11,14 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 	unsigned int ib = XBlock.active[ibl];
 
 	int lev = XBlock.level[ib];
+	int RB, LBRB, LB, RBLB, levRB, levLB;
+	RB = XBlock.RightBot[ib];
+	levRB = XBlock.level[RB];
+	LBRB = XBlock.LeftBot[RB];
+
+	LB = XBlock.LeftBot[ib];
+	levLB = XBlock.level[LB];
+	RBLB = XBlock.RightBot[LB];
 
 	T epsi = nextafter(T(1.0), T(2.0)) - T(1.0);
 	T eps = T(XParam.eps) + epsi;
@@ -38,6 +46,8 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 	{
 		T dx, zi, zn, hr, hl, etar, etal, zr, zl, zA, zCN, hCNr, hCNl;
 		T ui, vi, uli, vli, dhdxi, dhdxil, dudxi, dudxil, dvdxi,dvdxil;
+
+		T ga = g * T(0.5);
 		// along X
 		dx = delta * T(0.5);
 		zi = zb[i];
@@ -62,8 +72,8 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 		etal = XEv.zs[ileft] + dx * XGrad.dzsdx[ileft];
 
 		//define the topography term at the interfaces
-		zr = zi - dx * dzbdx[i];
-		zl = zn + dx * dzbdx[ileft];
+		zr = zi - dx * XGrad.dzbdx[i];
+		zl = zn + dx * XGrad.dzbdx[ileft];
 
 		//define the Audusse terms
 		zA = max(zr, zl);
@@ -75,7 +85,7 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 		
 		//Velocity reconstruction
 		//To avoid high velocities near dry cells, we reconstruct velocities according to Bouchut.
-		T ul, ur, vl, vr;
+		T ul, ur, vl, vr,sl,sr;
 		if (hi > eps) {
 			ur = ui - (1. + dx * dhdxi / hi) * dx * dudxi;
 			vr = vi - (1. + dx * dhdxi / hi) * dx * dvdxi;
@@ -100,7 +110,8 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 
 
 		//solver below also modifies fh and fu
-		dt = hllc(g, delta, epsi, CFL, cm, fmu, hp, hm, up, um, fh, fu);
+		dt = hllc(g, delta, epsi, CFL, cm, fmu, hCNl, hCNr, ul, ur, fh, fu);
+		//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
 
 		if (dt < dtmax[i])
 		{
@@ -133,8 +144,8 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 			zn = zb[ilc];
 		}
 
-		sl = ga * (utils::sq(hp) - utils::sq(hl) + (hl + hi) * (zi - zl));
-		sr = ga * (utils::sq(hm) - utils::sq(hr) + (hr + hn) * (zn - zr));
+		sl = ga * (hi + hCNr) * (zi - zCN);
+		sr = ga * (hCNl + hn) * (zn - zCN);
 
 		////Flux update
 
@@ -153,7 +164,176 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 	}
 
 }
+template __global__ void UpdateButtingerXGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
+template __global__ void UpdateButtingerXGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
 
+
+template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+{
+	unsigned int halowidth = XParam.halowidth;
+	unsigned int blkmemwidth = blockDim.x + halowidth * 2;
+	unsigned int blksize = blkmemwidth * blkmemwidth;
+	int ix = threadIdx.x;
+	int iy = threadIdx.y;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int lev = XBlock.level[ib];
+	int TL, BLTL, BL, TLBL, levTL, levBL;
+	TL = XBlock.TopLeft[ib];
+	levTL = XBlock.level[TL];
+	BLTL = XBlock.BotLeft[TL];
+
+	BL = XBlock.BotLeft[ib];
+	levBL = XBlock.level[BL];
+	TLBL = XBlock.TopLeft[BL];
+
+	T epsi = nextafter(T(1.0), T(2.0)) - T(1.0);
+	T eps = T(XParam.eps) + epsi;
+	T delta = calcres(T(XParam.dx), lev);
+	T g = T(XParam.g);
+	T CFL = T(XParam.CFL);
+
+	int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
+	int ibot = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
+
+
+
+
+	T dhdyi = XGrad.dhdy[i];
+	T dhdymin = XGrad.dhdy[ibot];
+	T cm = T(1.0);
+	T fmu = T(1.0);
+
+	T hi = XEv.h[i];
+
+	T hn = XEv.h[ibot];
+
+
+	if (hi > eps || hn > eps)
+	{
+		T dx, zi, zn, hr, hl, etar, etal, zr, zl, zA, zCN, hCNr, hCNl;
+		T ui, vi, uli, vli, dhdyi, dhdyil, dudyi, dudyil, dvdyi, dvdyil;
+
+		T ga = g * T(0.5);
+		// along X
+		dx = delta * T(0.5);
+		zi = zb[i];
+		zn = zb[ibot];
+
+		ui = XEv.u[i];
+		vi = XEv.v[i];
+		uli = XEv.u[ibot];
+		vli = XEv.v[ibot];
+
+		dhdyi = XGrad.dhdy[i];
+		dhdyil = XGrad.dhdy[ibot];
+		dudyi = XGrad.dudy[i];
+		dudyil = XGrad.dudy[ibot];
+		dvdyi = XGrad.dvdy[i];
+		dvdyil = XGrad.dvdy[ibot];
+
+
+		hr = hi - dx * dhdyi;
+		hl = hn + dx * dhdyil;
+		etar = XEv.zs[i] - dx * XGrad.dzsdy[i];
+		etal = XEv.zs[ibot] + dx * XGrad.dzsdy[ibot];
+
+		//define the topography term at the interfaces
+		zr = zi - dx * XGrad.dzbdy[i];
+		zl = zn + dx * XGrad.dzbdy[ibot];
+
+		//define the Audusse terms
+		zA = max(zr, zl);
+
+		// Now the CN terms
+		zCN = min(zA, min(etal, etar));
+		hCNr = max(T(0.0), min(etar - zCN, hr));
+		hCNl = max(T(0.0), min(etal - zCN, hl));
+
+		//Velocity reconstruction
+		//To avoid high velocities near dry cells, we reconstruct velocities according to Bouchut.
+		T ul, ur, vl, vr, sl, sr;
+		if (hi > eps) {
+			ur = ui - (1. + dx * dhdyi / hi) * dx * dudyi;
+			vr = vi - (1. + dx * dhdyi / hi) * dx * dvdyi;
+		}
+		else {
+			ur = ui - dx * dudyi;
+			vr = vi - dx * dvdyi;
+		}
+		if (hn > eps) {
+			ul = uli + (1. - dx * dhdyil / hn) * dx * dudyil;
+			vl = vli + (1. - dx * dhdyil / hn) * dx * dvdyil;
+		}
+		else {
+			ul = uli + dx * dudyil;
+			vl = vli + dx * dvdyil;
+		}
+
+
+
+
+		T fh, fu, fv, dt;
+
+
+		//solver below also modifies fh and fu
+		dt = hllc(g, delta, epsi, CFL, cm, fmu, hCNl, hCNr, vl, vr, fh, fu);
+		//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
+
+		if (dt < dtmax[i])
+		{
+			dtmax[i] = dt;
+		}
+		else
+		{
+			dtmax[i] = T(1.0) / epsi;
+		}
+
+		fv = (fh > 0. ? ul : ur) * fh;
+
+
+		// Topographic source term
+
+		// In the case of adaptive refinement, care must be taken to ensure
+		// well-balancing at coarse/fine faces (see [notes/balanced.tm]()). 
+		if ((iy == blockDim.x) && levTL < lev)//(ix==16) i.e. in the right halo
+		{
+			int jj = BLTL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + blockDim.x / 2;
+			int itop = memloc(halowidth, blkmemwidth, jj, 0, TL);;
+			hi = XEv.h[itop];
+			zi = zb[itop];
+		}
+		if ((iy == 0) && levBL < lev)//(ix==16) i.e. in the right halo
+		{
+			int jj = TLBL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + blockDim.x / 2;
+			int ibc = memloc(halowidth, blkmemwidth, jj, blockDim.x - 1, BL);
+			hn = XEv.h[ibc];
+			zn = zb[ibc];
+		}
+
+		sl = ga * (hi + hCNr) * (zi - zCN);
+		sr = ga * (hCNl + hn) * (zn - zCN);
+
+		////Flux update
+
+		XFlux.Fhv[i] = fmu * fh;
+		XFlux.Fqvy[i] = fmu * (fu - sl);
+		XFlux.Sv[i] = fmu * (fu - sr);
+		XFlux.Fquy[i] = fmu * fv;
+	}
+	else
+	{
+		dtmax[i] = T(1.0) / epsi;
+		XFlux.Fhv[i] = T(0.0);
+		XFlux.Fqvy[i] = T(0.0);
+		XFlux.Sv[i] = T(0.0);
+		XFlux.Fquy[i] = T(0.0);
+	}
+
+}
+template __global__ void UpdateButtingerYGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
+template __global__ void UpdateButtingerYGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
 
 
 template <class T> __host__ __device__ T hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T &fh, T &fq)
@@ -196,4 +376,3 @@ template <class T> __host__ __device__ T hllc(T g, T delta, T epsi, T CFL, T cm,
 	return dt;
 }
 
-*/

--- a/src/Reimann.h
+++ b/src/Reimann.h
@@ -8,6 +8,7 @@
 #include "MemManagement.h"
 #include "Util_CPU.h"
 
-
+template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
+template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 
 #endif

--- a/src/Reimann.h
+++ b/src/Reimann.h
@@ -9,6 +9,7 @@
 #include "Util_CPU.h"
 
 template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
+template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
-
+template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 #endif

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -75,6 +75,8 @@ template <class T> void SetupGPU(Param XParam, Model<T> XModel,Forcing<float> &X
 		}
 
 		Initmaparray(XModel_g);
+
+		InitzbgradientGPU(XParam, XModel_g);
 	}
 }
 template void SetupGPU<float>(Param XParam, Model<float> XModel, Forcing<float>& XForcing, Model<float>& XModel_g);

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -1270,6 +1270,46 @@ template<class T> bool CPUGPUtest(Param XParam, Model<T> XModel, Model<T> XModel
 	return test;
 }
 
+/*! \fn T ValleyBathy(T x, T y, T slope, T center)
+* \brief	create V shape Valley basin
+*
+* This function creates a simple V shape Valley basin
+*
+*
+*/
+template <class T> T ValleyBathy(T x, T y, T slope, T center)
+{
+
+
+	T bathy;
+
+	bathy = (abs(x - center) + y) * slope;
+
+
+	return bathy;
+}
+
+
+/*! \fn T ThackerBathy(T x, T y, T L, T D)
+* \brief	create a parabolic bassin
+*
+* This function creates a parabolic bassin. The function returns a single value of the bassin
+*
+* Borrowed from Buttinger et al. 2019.
+*
+* ### Reference
+* Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
+* structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
+*/
+template <class T> T ThackerBathy(T x, T y, T L, T D)
+{
+
+
+	T bathy = D * ((x * x + y * y) / (L * L) - 1.0);
+
+
+	return bathy;
+}
 
 /*! \fn
 * \brief	Simulate the Lake-at-rest in a parabolic bassin
@@ -1384,26 +1424,7 @@ template <class T> bool ThackerLakeAtRest(Param XParam,T zsinit)
 template bool ThackerLakeAtRest<float>(Param XParam,float zsinit);
 template bool ThackerLakeAtRest<double>(Param XParam, double zsinit);
 
-/*! \fn T ThackerBathy(T x, T y, T L, T D)
-* \brief	create a parabolic bassin
-*
-* This function creates a parabolic bassin. The function returns a single value of the bassin
-*
-* Borrowed from Buttinger et al. 2019.
-*
-* ### Reference
-* Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
-* structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
-*/
-template <class T> T ThackerBathy(T x, T y, T L, T D)
-{
 
-
-	T bathy = D * ((x * x + y * y) / (L * L) - 1.0);
-
-
-	return bathy;
-}
 
 /*! \fn bool RiverVolumeAdapt(Param XParam)
 * \brief	Wraping function for RiverVolumeAdapt(Param XParam, T slope, bool bottop, bool flip)
@@ -1745,24 +1766,6 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 
 }
 
-/*! \fn T ValleyBathy(T x, T y, T slope, T center)
-* \brief	create V shape Valley basin
-*
-* This function creates a simple V shape Valley basin
-*
-*
-*/
-template <class T> T ValleyBathy(T x, T y, T slope, T center)
-{
-
-
-	T bathy;
-	
-	bathy = (abs(x - center)+y) * slope;
-
-
-	return bathy;
-}
 
 
 /*! \fn

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -633,12 +633,12 @@ template <class T> bool MassConserveSteepSlope(T zsnit, int gpu)
 
 	//Output times for comparisons
 	XParam.endtime = 1.0;
-	XParam.outputtimestep = 0.035;
+	XParam.outputtimestep = 0.04;//0.035;
 
 	XParam.smallnc = 0;
 
-	XParam.cf = 0.0;
-	XParam.frictionmodel = 0;
+	XParam.cf = 0.001;
+	XParam.frictionmodel = 1;
 
 	XParam.conserveElevation = false;
 
@@ -730,7 +730,7 @@ template <class T> bool MassConserveSteepSlope(T zsnit, int gpu)
 
 	InitSave2Netcdf(XParam, XModel);
 	XLoop.nextoutputtime = XParam.outputtimestep;
-	XLoop.dtmax = initdt(XParam, XLoop, XModel);
+	XLoop.dtmax = 0.025;// initdt(XParam, XLoop, XModel);
 
 
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -16,6 +16,7 @@
 * Test 3 Test Reduction algorithm
 * Test 4 Compare resuts between the CPU and GPU Flow functions (GPU required)
 * Test 5 Lake at rest test for Ardusse/kurganov reconstruction/scheme
+* Test 999 RUne the main loop and engine in debug mode
 */
 template <class T> void Testing(Param XParam, Forcing<float> XForcing, Model<T> XModel, Model<T> XModel_g)
 {
@@ -106,7 +107,11 @@ template <class T> void Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		log("\t Mass conservation Test");
 		MassConserveSteepSlope(XParam.zsinit, XParam.GPUDEVICE);
 	}
-	
+	if (XParam.test == 999)
+	{
+		//
+		DebugLoop(XParam, XForcing, XModel, XModel_g); 
+	}
 
 	
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -1432,7 +1432,7 @@ template <class T> void RiverVolumeAdapt(Param XParam, T maxslope)
 	ftocB = RiverVolumeAdapt(XParam, maxslope, true, false);
 	ftocC = RiverVolumeAdapt(XParam, maxslope, false, true);
 	ftocD = RiverVolumeAdapt(XParam, maxslope, true, true);
-	if (UnitestA && UnitestB && UnitestC && UnitestD)
+	if (ftocA && ftocB && ftocC && ftocD)
 	{
 		log("River Volume Conservation Test: Flow from fine to coarse adapted mesh: Success");
 	}

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -16,7 +16,7 @@
 * Test 3 Test Reduction algorithm
 * Test 4 Compare resuts between the CPU and GPU Flow functions (GPU required)
 * Test 5 Lake at rest test for Ardusse/kurganov reconstruction/scheme
-* Test 999 RUne the main loop and engine in debug mode
+* Test 999 Run the main loop and engine in debug mode
 */
 template <class T> void Testing(Param XParam, Forcing<float> XForcing, Model<T> XModel, Model<T> XModel_g)
 {
@@ -287,6 +287,13 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 		CompareCPUvsGPU(XParam, XModel, XModel_g, outv, false);
 	}
 	bool modelgood = true;
+
+	fillHaloC(XParam, XModel.blocks, XModel.zb);
+	gradientC(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+
+	refine_linear(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 
 	while (XLoop.totaltime < XLoop.nextoutputtime)
 	{

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -1356,13 +1356,27 @@ template <class T> T ThackerBathy(T x, T y, T L, T D)
 }
 
 
+
+template <class T> T ValleyBathy(T x, T y, bool flowleft, T slope, T xcenter)
+{
+
+
+	T bathy;
+	
+	bathy = (abs(x - xcenter)+y) * slope;
+
+
+	return bathy;
+}
+
+
 /*! \fn 
 *	Simulate the first predictive step and check wether the lake at rest is preserved
 *	
 */
 template <class T> bool LakeAtRest(Param XParam, Model<T> XModel)
 {
-	T epsi = T(0.000000001);
+	T epsi = T(1e-5);
 	int ib;
 
 	bool test = true;

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -249,6 +249,43 @@ template __global__ void AddrainforcingGPU<float>(Param XParam, BlockP<float> XB
 template __global__ void AddrainforcingGPU<double>(Param XParam, BlockP<double> XBlock, DynForcingP<float> Rain, AdvanceP<double> XAdv);
 
 
+template <class T> __global__ void AddrainforcingImplicitGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, DynForcingP<float> Rain, EvolvingP<T> XEv)
+{
+	unsigned int halowidth = XParam.halowidth;
+	unsigned int blkmemwidth = blockDim.x + halowidth * 2;
+	unsigned int blksize = blkmemwidth * blkmemwidth;
+	unsigned int ix = threadIdx.x;
+	unsigned int iy = threadIdx.y;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+	T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+
+	T Rainhh;
+
+	T x = XParam.xo + XBlock.xo[ib] + ix * delta;
+	T y = XParam.yo + XBlock.yo[ib] + iy * delta;
+	if (Rain.uniform)
+	{
+		Rainhh = Rain.nowvalue;
+	}
+	else
+	{
+		Rainhh = T(interpDyn2BUQ(x, y, Rain.GPU));
+	}
+
+
+	Rainhh = Rainhh / T(1000.0) / T(3600.0) * XLoop.dt; // convert from mm/hrs to m/s
+
+	XEv.h[i] += Rainhh * XBlock.activeCell[i];
+	XEv.zs[i] += Rainhh * XBlock.activeCell[i];
+}
+template __global__ void AddrainforcingImplicitGPU<float>(Param XParam, Loop<float> XLoop, BlockP<float> XBlock, DynForcingP<float> Rain, EvolvingP<float> XEv);
+template __global__ void AddrainforcingImplicitGPU<double>(Param XParam, Loop<double> XLoop, BlockP<double> XBlock, DynForcingP<float> Rain, EvolvingP<double> XEv);
+
+
 template <class T> __host__ void AddrainforcingCPU(Param XParam, BlockP<T> XBlock, DynForcingP<float> Rain, AdvanceP<T> XAdv)
 {
 	int ib;
@@ -295,6 +332,52 @@ template <class T> __host__ void AddrainforcingCPU(Param XParam, BlockP<T> XBloc
 template __host__ void AddrainforcingCPU<float>(Param XParam, BlockP<float> XBlock, DynForcingP<float> Rain, AdvanceP<float> XAdv);
 template __host__ void AddrainforcingCPU<double>(Param XParam, BlockP<double> XBlock, DynForcingP<float> Rain, AdvanceP<double> XAdv);
 
+template <class T> __host__ void AddrainforcingImplicitCPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, DynForcingP<float> Rain, EvolvingP<T> XEv)
+{
+	int ib;
+	int halowidth = XParam.halowidth;
+	int blkmemwidth = XParam.blkmemwidth;
+
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+		ib = XBlock.active[ibl];
+
+		for (int iy = 0; iy < XParam.blkwidth; iy++)
+		{
+			for (int ix = 0; ix < XParam.blkwidth; ix++)
+			{
+
+				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+				T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+
+				T Rainhh;
+
+				T x = XParam.xo + XBlock.xo[ib] + ix * delta;
+				T y = XParam.yo + XBlock.yo[ib] + iy * delta;
+
+				if (Rain.uniform)
+				{
+					Rainhh = Rain.nowvalue;
+				}
+				else
+				{
+					Rainhh = interp2BUQ(x, y, Rain);
+				}
+
+
+
+
+				Rainhh = Rainhh / T(1000.0) / T(3600.0) * XLoop.dt; // convert from mm/hrs to m/s
+
+				XEv.h[i] += Rainhh * XBlock.activeCell[i];
+				XEv.zs[i] += Rainhh * XBlock.activeCell[i];
+			}
+		}
+	}
+}
+template __host__ void AddrainforcingImplicitCPU<float>(Param XParam, Loop<float> XLoop, BlockP<float> XBlock, DynForcingP<float> Rain, EvolvingP<float> XEv);
+template __host__ void AddrainforcingImplicitCPU<double>(Param XParam, Loop<double> XLoop, BlockP<double> XBlock, DynForcingP<float> Rain, EvolvingP<double> XEv);
 
 template <class T> __global__ void AddwindforcingGPU(Param XParam, BlockP<T> XBlock, DynForcingP<float> Uwind, DynForcingP<float> Vwind, AdvanceP<T> XAdv)
 {

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -47,7 +47,7 @@ template <class T> void Forcingthisstep(Param XParam, Loop<T> XLoop, DynForcingP
 		while (difft < 0.0)
 		{
 			Rstepinbnd++;
-			difft = XDynForcing.unidata[Rstepinbnd].time - XParam.totaltime;
+			difft = XDynForcing.unidata[Rstepinbnd].time - XLoop.totaltime;
 		}
 
 		XDynForcing.nowvalue = T(interptime(XDynForcing.unidata[Rstepinbnd].wspeed, XDynForcing.unidata[Rstepinbnd - 1].wspeed, XDynForcing.unidata[Rstepinbnd].time - XDynForcing.unidata[Rstepinbnd - 1].time, XLoop.totaltime - XDynForcing.unidata[Rstepinbnd - 1].time));
@@ -364,8 +364,6 @@ template <class T> __host__ void AddrainforcingImplicitCPU(Param XParam, Loop<T>
 				{
 					Rainhh = interp2BUQ(x, y, Rain);
 				}
-
-
 
 
 				Rainhh = Rainhh / T(1000.0) / T(3600.0) * XLoop.dt; // convert from mm/hrs to m/s

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -243,7 +243,7 @@ template <class T> __global__ void AddrainforcingGPU(Param XParam, BlockP<T> XBl
 
 	Rainhh = Rainhh / T(1000.0) / T(3600.0); // convert from mm/hrs to m/s
 
-	XAdv.dh[i] += Rainhh;
+	XAdv.dh[i] += Rainhh * XBlock.activeCell[i];
 }
 template __global__ void AddrainforcingGPU<float>(Param XParam, BlockP<float> XBlock, DynForcingP<float> Rain, AdvanceP<float> XAdv);
 template __global__ void AddrainforcingGPU<double>(Param XParam, BlockP<double> XBlock, DynForcingP<float> Rain, AdvanceP<double> XAdv);
@@ -287,7 +287,7 @@ template <class T> __host__ void AddrainforcingCPU(Param XParam, BlockP<T> XBloc
 
 				Rainhh = Rainhh / T(1000.0) / T(3600.0); // convert from mm/hrs to m/s
 
-				XAdv.dh[i] += Rainhh;
+				XAdv.dh[i] += Rainhh * XBlock.activeCell[i];
 			}
 		}
 	}

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -181,9 +181,18 @@ template <class T> __host__ void InjectRiverCPU(Param XParam, River XRiver, T qn
 	int halowidth = XParam.halowidth;
 	int blkmemwidth = XParam.blkmemwidth;
 
+	T xllo, yllo, xl, yb, xr, yt, levdx;
+
 	for (int ibl = 0; ibl < nblkriver; ibl++)
 	{
 		ib = Riverblks[ibl];
+
+		levdx = calcres(XParam.dx, XBlock.level[ib]);
+
+		xllo = XParam.xo + XBlock.xo[ib];
+		yllo = XParam.yo + XBlock.yo[ib];
+
+
 
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
@@ -196,10 +205,19 @@ template <class T> __host__ void InjectRiverCPU(Param XParam, River XRiver, T qn
 
 				T Rainhh;
 
-				T x = XParam.xo + XBlock.xo[ib] + ix * delta;
-				T y = XParam.yo + XBlock.yo[ib] + iy * delta;
+				//T x = XParam.xo + XBlock.xo[ib] + ix * delta;
+				//T y = XParam.yo + XBlock.yo[ib] + iy * delta;
 
-				if (x >= XRiver.xstart && x <= XRiver.xend && y >= XRiver.ystart && y <= XRiver.yend)
+				//if (x >= XRiver.xstart && x <= XRiver.xend && y >= XRiver.ystart && y <= XRiver.yend)
+				xl = xllo + ix * levdx - 0.5 * levdx;
+				yb = yllo + iy * levdx - 0.5 * levdx;
+
+				xr = xllo + ix * levdx + 0.5 * levdx;
+				yt = yllo + iy * levdx + 0.5 * levdx;
+				// the conditions are that the discharge area as defined by the user have to include at least a model grid node
+				// This could be really annoying and there should be a better way to deal wiith this like polygon intersection
+				//if (xx >= XForcing.rivers[Rin].xstart && xx <= XForcing.rivers[Rin].xend && yy >= XForcing.rivers[Rin].ystart && yy <= XForcing.rivers[Rin].yend)
+				if (OBBdetect(xl, xr, yb, yt, T(XRiver.xstart),T(XRiver.xend), T(XRiver.ystart), T(XRiver.yend)))
 				{
 					XAdv.dh[i] += qnow / XRiver.disarea;
 

--- a/src/Updateforcing.h
+++ b/src/Updateforcing.h
@@ -20,7 +20,9 @@ template <class T> __host__ void AddwindforcingCPU(Param XParam, BlockP<T> XBloc
 template <class T> __global__ void AddwindforcingGPU(Param XParam, BlockP<T> XBlock, DynForcingP<float> Uwind, DynForcingP<float> Vwind, AdvanceP<T> XAdv);
 
 template <class T> __host__ void AddrainforcingCPU(Param XParam, BlockP<T> XBlock, DynForcingP<float> Rain, AdvanceP<T> XAdv);
+template <class T> __host__ void AddrainforcingImplicitCPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, DynForcingP<float> Rain, EvolvingP<T> XEv);
 template <class T> __global__ void AddrainforcingGPU(Param XParam, BlockP<T> XBlock, DynForcingP<float> Rain, AdvanceP<T> XAdv);
+template <class T> __global__ void AddrainforcingImplicitGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, DynForcingP<float> Rain, EvolvingP<T> XEv);
 
 template <class T> __host__ void AddRiverForcing(Param XParam, Loop<T> XLoop, std::vector<River> XRivers, Model<T> XModel);
 

--- a/src/Updateforcing.h
+++ b/src/Updateforcing.h
@@ -10,6 +10,7 @@
 #include "MemManagement.h"
 #include "ReadForcing.h"
 #include "GridManip.h"
+#include "Util_CPU.h"
 
 template <class T> void updateforcing(Param XParam, Loop<T> XLoop, Forcing<float>& XForcing);
 

--- a/src/Util_CPU.cu
+++ b/src/Util_CPU.cu
@@ -46,8 +46,10 @@ namespace utils {
 		return !(b<a) ? a : b;     // or: return comp(a,b)?b:a; for version (2)
 	}
 
-
-	template <class T> __host__ __device__ const T& nearest(const T& a, const T& b, const T& c) {
+	/*! \fn template <class T> const T& nearest(const T& a, const T& b, const T& c)
+	* Generic nearest value function with 3 parameter
+	*/
+		template <class T> __host__ __device__ const T& nearest(const T& a, const T& b, const T& c) {
 		return abs(b - c) > abs(a - c) ? a : b;     // Nearest element to c
 	}
 
@@ -172,3 +174,21 @@ template <class T> __host__ __device__ T minmod2(T theta, T s0, T s1, T s2)
 
 template __host__ __device__ float minmod2(float theta, float s0, float s1, float s2);
 template __host__ __device__ double minmod2(double theta, double s0, double s1, double s2);
+
+/*! \fn OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax)
+	* Overlaping Bounding Box to detect which cell river falls into. It is the simplest version of the algorythm where the bounding box are paralle;l to the axis
+	*/
+template <class T> __host__ bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax)
+{
+	bool overlap = false;
+
+	bool testX = Bxmin <= Axmax && Bxmax >= Axmin;
+	bool testY = Bymin <= Aymax && Bymax >= Aymin;
+
+	overlap = testX && testY;
+
+	return overlap;
+}
+
+template __host__ bool OBBdetect(float Axmin, float Axmax, float Aymin, float Aymax, float Bxmin, float Bxmax, float Bymin, float Bymax);
+template __host__ bool OBBdetect(double Axmin, double Axmax, double Aymin, double Aymax, double Bxmin, double Bxmax, double Bymin, double Bymax);

--- a/src/Util_CPU.cu
+++ b/src/Util_CPU.cu
@@ -178,7 +178,7 @@ template __host__ __device__ double minmod2(double theta, double s0, double s1, 
 /*! \fn OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax)
 	* Overlaping Bounding Box to detect which cell river falls into. It is the simplest version of the algorythm where the bounding box are paralle;l to the axis
 	*/
-template <class T> __host__ bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax)
+template <class T> __host__  __device__  bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax)
 {
 	bool overlap = false;
 
@@ -190,5 +190,5 @@ template <class T> __host__ bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T
 	return overlap;
 }
 
-template __host__ bool OBBdetect(float Axmin, float Axmax, float Aymin, float Aymax, float Bxmin, float Bxmax, float Bymin, float Bymax);
-template __host__ bool OBBdetect(double Axmin, double Axmax, double Aymin, double Aymax, double Bxmin, double Bxmax, double Bymin, double Bymax);
+template __host__  __device__  bool OBBdetect(float Axmin, float Axmax, float Aymin, float Aymax, float Bxmin, float Bxmax, float Bymin, float Bymax);
+template __host__  __device__  bool OBBdetect(double Axmin, double Axmax, double Aymin, double Aymax, double Bxmin, double Bxmax, double Bymin, double Bymax);

--- a/src/Util_CPU.cu
+++ b/src/Util_CPU.cu
@@ -145,6 +145,7 @@ template <class T>
 __host__ __device__ T calcres(T dx, int level)
 {
 	return level < 0 ? dx * (1 << abs(level)) : dx / (1 << level);
+	//should be 1<< -level
 }
 
 template __host__ __device__ double calcres<double>(double dx, int level);

--- a/src/Util_CPU.h
+++ b/src/Util_CPU.h
@@ -26,5 +26,7 @@ template <class T>  __host__ __device__ T BarycentricInterpolation(T q1, T x1, T
 
 template <class T> __host__ __device__ T calcres(T dx, int level);
 template <class T> __host__ __device__ T minmod2(T theta, T s0, T s1, T s2);
+
+template <class T> __host__ bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax);
 // End of global definition
 #endif

--- a/src/Util_CPU.h
+++ b/src/Util_CPU.h
@@ -27,6 +27,6 @@ template <class T>  __host__ __device__ T BarycentricInterpolation(T q1, T x1, T
 template <class T> __host__ __device__ T calcres(T dx, int level);
 template <class T> __host__ __device__ T minmod2(T theta, T s0, T s1, T s2);
 
-template <class T> __host__ bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax);
+template <class T> __host__  __device__  bool OBBdetect(T Axmin, T Axmax, T Aymin, T Aymax, T Bxmin, T Bxmax, T Bymin, T Bymax);
 // End of global definition
 #endif

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -630,6 +630,8 @@ template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activebl
 	float scalefactor = XParam.scalefactor;
 	float addoffset = XParam.addoffset;
 
+
+
 	status = nc_open(XParam.outfile.c_str(), NC_WRITE, &ncid);
 	if (status != NC_NOERR) handle_ncerror(status);
 	//read id from time dimension
@@ -680,7 +682,8 @@ template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activebl
 		{
 			for (int i = 0; i < XParam.blkwidth; i++)
 			{
-				int n = (i + XParam.halowidth) + (j + XParam.halowidth) * XParam.blkmemwidth + bl * XParam.blksize;
+				//int n = (i + XParam.halowidth) + (j + XParam.halowidth) * XParam.blkmemwidth + bl * XParam.blksize;
+				int n = memloc(XParam, i + XParam.outishift, j + XParam.outjshift, bl);
 				int r = i + j * XParam.blkwidth;
 				if (smallnc > 0)
 				{


### PR DESCRIPTION
## Fix flow bug in adaptive case
### New refine linear scheme
The previous iteration of the refine linear scheme was wrong. this new one is now, more in line with Basilisk.

### New Fill-Halo for fluxes
This new fill halo for fluxes is bug fix from the previous iteration. This scheme now conserves mass.

## New Engine
Implement the Buttinger et al. 2019 Scheme as a replacement for the kurganov scheme. The new scheme is identical to the basilisk implementation in BFlood but fixes a Lake at rest issue. 

### More stable==Faster
This new scheme handles the flow over steep topography very well, removing some spurious velocity that plagued the model time step. Early real world test in Waikanae suggest a **40% speed gain!**

### Two new tests 
I also added 2 test to verify some of the validity f the new scheme:
* Parabolic Lake-at-rest
* 12 scenario of river flow in in a valley (left right top botom uniform coasrse to fine et fine to coarse) 

## New stability check
An additional limiter applied at advection step prevents negative depth. This seem to help on some instability at partially wet cell or cells drying out rapidely

