### PR TITLE
Map output timesteps rounding error

### DIFF
--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -69,8 +69,6 @@ struct DynForcingP: public forcingmap
 
 	T clampedge=0.0;
 
-	double to, tmax;
-
 };
 
 

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -69,6 +69,8 @@ struct DynForcingP: public forcingmap
 
 	T clampedge=0.0;
 
+	double to, tmax;
+
 };
 
 

--- a/src/Input.h
+++ b/src/Input.h
@@ -36,6 +36,7 @@ public:
 	std::vector<int> i, j, block; // one river can spring across multiple cells
 	double disarea; // discharge area
 	double xstart,xend, ystart,yend; // location of the discharge as a rectangle
+	double to, tmax;
 	std::string Riverflowfile; // river flow input time[s] flow in m3/s
 	std::vector<Flowin> flowinput; // vector to store the data of the river flow input file
 	

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -221,7 +221,7 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop,Model<T> XModel, 
 {
 	XLoop.nstepout++;
 
-	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.00001) && XParam.outputtimestep > 0.0)
+	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.5) && XParam.outputtimestep > 0.0)
 	{
 		char buffer[256];
 		sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -176,13 +176,13 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			XForcing.rivers[Rin].tmax = XForcing.rivers[Rin].flowinput[nt-1].time;
 			if ( XForcing.rivers[Rin].tmax < XParam.endtime)
 			{
-				log("\nWARNING: change of simulation endtime to fit the time range of the River number " + std::to_string(Rin));
 				XParam.endtime = XForcing.rivers[Rin].tmax;
+				log("\nWARNING: simulation endtime reduced to " + std::to_string(XParam.endtime) + " to fit the time range of the River number " + std::to_string(Rin));
 			}
 			if (XForcing.rivers[Rin].to > XParam.totaltime)
 			{
-				log("\nWARNING: change of simulation initial time to fit the time range of the River number " + std::to_string(Rin));
 				XParam.totaltime = XForcing.rivers[Rin].to;
+				log("\nWARNING: simulation initial time increased to " + std::to_string(XParam.totaltime) + " to fit the time range of the River number " + std::to_string(Rin));
 			}
 		}
 	}
@@ -218,13 +218,13 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			nt = XForcing.UWind.unidata.size();
 			if (XForcing.UWind.unidata[nt - 1].time < XParam.endtime || XForcing.VWind.unidata[nt - 1].time < XParam.endtime)
 			{
-				log("\nWARNING: change of simulation endtime to fit the time range of the wind forcing. ");
-				XParam.endtime = utils::min(UWind.unidata[nt - 1].time, XForcing.VWind.unidata[nt - 1].time);
+				XParam.endtime = min(XForcing.UWind.unidata[nt - 1].time, XForcing.VWind.unidata[nt - 1].time);
+				log("\nWARNING: simulation endtime reduced to " + std::to_string(XParam.endtime) + " to fit the time range of the wind forcing. ");
 			}
 			if (XForcing.UWind.unidata[0].time > XParam.totaltime || XForcing.VWind.unidata[0].time > XParam.totaltime)
 			{
-				log("\nWARNING: change of simulation initial time to fit the time range of the wind forcing. ");
-				XParam.totaltime = utils::max(XForcing.UWind.unidata[0].time, XForcing.VWind.unidata[0].time);
+				XParam.totaltime = max(XForcing.UWind.unidata[0].time, XForcing.VWind.unidata[0].time);
+				log("\nWARNING: simulation initial time increased to " + std::to_string(XParam.totaltime) + " to fit the time range of the wind forcing. ");
 			}
 			
 		}
@@ -233,8 +233,9 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			//
 			//readDynforcing(gpgpu, XParam.totaltime, XForcing.UWind);
 			//readDynforcing(gpgpu, XParam.totaltime, XForcing.VWind);
-			InitDynforcing(gpgpu, XParam.totaltime, XForcing.UWind);
-			InitDynforcing(gpgpu, XParam.totaltime, XForcing.VWind);
+			InitDynforcing(gpgpu, XParam, XForcing.UWind);
+			InitDynforcing(gpgpu, XParam, XForcing.VWind);
+
 
 			
 		}
@@ -256,7 +257,7 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 		}
 		else
 		{
-			InitDynforcing(gpgpu, XParam.totaltime, XForcing.Atmp);
+			InitDynforcing(gpgpu, XParam, XForcing.Atmp);
 			//readDynforcing(gpgpu, XParam.totaltime, XForcing.Atmp);
 		}
 	}
@@ -275,7 +276,7 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 		}
 		else
 		{
-			InitDynforcing(gpgpu, XParam.totaltime, XForcing.Rain);
+			InitDynforcing(gpgpu, XParam, XForcing.Rain);
 			//readDynforcing(gpgpu, XParam.totaltime, XForcing.Rain);
 		}
 	}
@@ -349,15 +350,27 @@ template void readstaticforcing<StaticForcingP<int>>(int step, StaticForcingP<in
 * 
 * Used for Rain, wind, Atm pressure
 */
-void InitDynforcing(bool gpgpu,double totaltime,DynForcingP<float>& Dforcing)
+void InitDynforcing(bool gpgpu,Param& XParam,DynForcingP<float>& Dforcing)
 {
 	Dforcing = readforcinghead(Dforcing);
+
+	//Sanity check on the time range of the forcing
+	if (Dforcing.tmax < XParam.endtime)
+	{
+		XParam.endtime = Dforcing.tmax;
+		log("\nWARNING: simulation endtime reduced to " + std::to_string(XParam.endtime) + " to fit the time range provided in " + Dforcing.inputfile);
+	}
+	if (Dforcing.to > XParam.totaltime)
+	{
+		XParam.totaltime = Dforcing.to;
+		log("\nWARNING: simulation initial time increased to " + std::to_string(XParam.totaltime) + " to fit the time provided in " + Dforcing.inputfile);
+	}
 
 
 	if (Dforcing.nx > 0 && Dforcing.ny > 0)
 	{
 		AllocateCPU(Dforcing.nx, Dforcing.ny, Dforcing.now, Dforcing.before, Dforcing.after, Dforcing.val);
-		readforcingdata(totaltime, Dforcing);
+		readforcingdata(XParam.totaltime, Dforcing);
 		if (gpgpu)
 		{ 
 			AllocateGPU(Dforcing.nx, Dforcing.ny, Dforcing.now_g);
@@ -1255,7 +1268,6 @@ DynForcingP<float> readforcinghead(DynForcingP<float> Fmap)
 	{
 		log("Forcing file needs to be a .nc file you also need to specify the netcdf variable name like this ncfile.nc?myvar");
 	}
-	
 
 
 	return Fmap;

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -28,6 +28,8 @@
 template <class T>
 void readforcing(Param & XParam, Forcing<T> & XForcing)
 {
+	int nt;
+
 	//=================
 	// Read Bathymetry
 	log("\nReading bathymetry grid data...");
@@ -169,7 +171,7 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			XForcing.rivers[Rin].flowinput = readFlowfile(XForcing.rivers[Rin].Riverflowfile);
 
 			//Check the time range of the river forcing
-			int nt = XForcing.rivers[Rin].flowinput.size();
+			nt = XForcing.rivers[Rin].flowinput.size();
 			XForcing.rivers[Rin].to = XForcing.rivers[Rin].flowinput[0].time;
 			XForcing.rivers[Rin].tmax = XForcing.rivers[Rin].flowinput[nt-1].time;
 			if (XForcing.rivers[Rin].to > XParam.totaltime || XForcing.rivers[Rin].tmax < XParam.endtime)
@@ -205,6 +207,14 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			for (int n = 0; n < XForcing.UWind.unidata.size(); n++)
 			{
 				XForcing.UWind.unidata[n].wspeed = XForcing.UWind.unidata[n].uwind;
+			}
+
+			nt = XForcing.UWind.unidata.size();
+			if (XForcing.UWind.unidata[0].time > XParam.totaltime || XForcing.UWind.unidata[nt - 1].time < XParam.endtime 
+				|| XForcing.VWind.unidata[0].time > XParam.totaltime || XForcing.VWind.unidata[nt - 1].time < XParam.endtime)
+			{
+				log("\nFATAL ERROR on the time range for the wind forcing ");
+				exit(1);
 			}
 			
 		}

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -167,6 +167,16 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 		{
 			// Now read the discharge input and store to  
 			XForcing.rivers[Rin].flowinput = readFlowfile(XForcing.rivers[Rin].Riverflowfile);
+
+			//Check the time range of the river forcing
+			int nt = XForcing.rivers[Rin].flowinput.size();
+			XForcing.rivers[Rin].to = XForcing.rivers[Rin].flowinput[0].time;
+			XForcing.rivers[Rin].tmax = XForcing.rivers[Rin].flowinput[nt-1].time;
+			if (XForcing.rivers[Rin].to > XParam.totaltime || XForcing.rivers[Rin].tmax < XParam.endtime)
+			{
+				log("\nFATAL ERROR on the time range for the River number " + std::to_string(Rin));
+				exit(1);
+			}
 		}
 	}
 

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -174,10 +174,15 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			nt = XForcing.rivers[Rin].flowinput.size();
 			XForcing.rivers[Rin].to = XForcing.rivers[Rin].flowinput[0].time;
 			XForcing.rivers[Rin].tmax = XForcing.rivers[Rin].flowinput[nt-1].time;
-			if (XForcing.rivers[Rin].to > XParam.totaltime || XForcing.rivers[Rin].tmax < XParam.endtime)
+			if ( XForcing.rivers[Rin].tmax < XParam.endtime)
 			{
-				log("\nFATAL ERROR on the time range for the River number " + std::to_string(Rin));
-				exit(1);
+				log("\nWARNING: change of simulation endtime to fit the time range of the River number " + std::to_string(Rin));
+				XParam.endtime = XForcing.rivers[Rin].tmax;
+			}
+			if (XForcing.rivers[Rin].to > XParam.totaltime)
+			{
+				log("\nWARNING: change of simulation initial time to fit the time range of the River number " + std::to_string(Rin));
+				XParam.totaltime = XForcing.rivers[Rin].to;
 			}
 		}
 	}
@@ -209,12 +214,17 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 				XForcing.UWind.unidata[n].wspeed = XForcing.UWind.unidata[n].uwind;
 			}
 
+			//Sanity check on the time range of the forcing
 			nt = XForcing.UWind.unidata.size();
-			if (XForcing.UWind.unidata[0].time > XParam.totaltime || XForcing.UWind.unidata[nt - 1].time < XParam.endtime 
-				|| XForcing.VWind.unidata[0].time > XParam.totaltime || XForcing.VWind.unidata[nt - 1].time < XParam.endtime)
+			if (XForcing.UWind.unidata[nt - 1].time < XParam.endtime || XForcing.VWind.unidata[nt - 1].time < XParam.endtime)
 			{
-				log("\nFATAL ERROR on the time range for the wind forcing ");
-				exit(1);
+				log("\nWARNING: change of simulation endtime to fit the time range of the wind forcing. ");
+				XParam.endtime = utils::min(UWind.unidata[nt - 1].time, XForcing.VWind.unidata[nt - 1].time);
+			}
+			if (XForcing.UWind.unidata[0].time > XParam.totaltime || XForcing.VWind.unidata[0].time > XParam.totaltime)
+			{
+				log("\nWARNING: change of simulation initial time to fit the time range of the wind forcing. ");
+				XParam.totaltime = utils::max(XForcing.UWind.unidata[0].time, XForcing.VWind.unidata[0].time);
 			}
 			
 		}

--- a/src/ReadForcing.h
+++ b/src/ReadForcing.h
@@ -37,7 +37,7 @@ void readbathyHeadMD(std::string filename, int &nx, int &ny, double &dx, double 
 template <class T> void readbathyMD(std::string filename, T*& zb);
 template <class T> void readXBbathy(std::string filename, int nx, int ny, T*& zb);
 
-void InitDynforcing(bool gpgpu, double totaltime, DynForcingP<float>& Dforcing);
+void InitDynforcing(bool gpgpu, Param& XParam, DynForcingP<float>& Dforcing);
 
 void readbathyASCHead(std::string filename, int &nx, int &ny, double &dx, double &xo, double &yo, double &grdalpha);
 template <class T> void readbathyASCzb(std::string filename, int nx, int ny, T*& zb);

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1160,6 +1160,11 @@ void checkparamsanity(Param & XParam, Forcing<float> & XForcing)
 		XParam.outputtimestep = XParam.endtime;
 		//otherwise there is really no point running the model
 	}
+	if (XParam.outputtimestep > XParam.endtime)
+	{
+		XParam.outputtimestep = XParam.endtime;
+		//otherwise, no final output
+	}
 
 	
 
@@ -1224,7 +1229,7 @@ void checkparamsanity(Param & XParam, Forcing<float> & XForcing)
 */
 double setendtime(Param XParam,Forcing<float> XForcing)
 {
-	//endtime cannot be bigger thn the smallest time set in a boundary
+	//endtime cannot be bigger than the smallest time set in a boundary
 	SLTS tempSLTS;
 	double endtime = XParam.endtime;
 	if (XForcing.left.on)
@@ -1247,6 +1252,11 @@ double setendtime(Param XParam,Forcing<float> XForcing)
 	{
 		tempSLTS = XForcing.bot.data.back();
 		endtime = utils::min(endtime, tempSLTS.time);
+	}
+
+	if (endtime < XParam.endtime)
+	{
+		log("WARNING: Boundary definition too short, endtime of the simulation reduced to : " + std::to_string(endtime));
 	}
 
 	return endtime;

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1256,7 +1256,7 @@ double setendtime(Param XParam,Forcing<float> XForcing)
 
 	if (endtime < XParam.endtime)
 	{
-		log("WARNING: Boundary definition too short, endtime of the simulation reduced to : " + std::to_string(endtime));
+		log("\nWARNING: Boundary definition too short, endtime of the simulation reduced to : " + std::to_string(endtime));
 	}
 
 	return endtime;

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -3140,7 +3140,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 		XForcing.Rain.varname = "myrainforcing";
 		
 
-		InitDynforcing(gpgpu, XParam.totaltime, XForcing.Rain);
+		InitDynforcing(gpgpu, XParam, XForcing.Rain);
 
 		//readDynforcing(gpgpu, XParam.totaltime, XForcing.Rain);
 


### PR DESCRIPTION
The error was coming from the user.
 - [x] : Add a sanity check on the outputtimestep to force a final output
 - [x] : Add some log to communicate to the user the change of endtime if boundaries are not defined long enough
 - [x] : River: Add a t0/tmax for the river and log+modify simu range
 - [x] : Wind Time serie: add sanity check, log and modify simu range 
 - [x] : Dynamic forcings (Atm, Rain, Wind): add sanity check, log and modify simu range 
 - [x] : tested with River TS and Dynamic forcing