### PR TITLE
Fix Spherical Grid capability (#78)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,8 +339,11 @@ Write_netcdf.o:./src/Write_netcdf.cu
 
 Write_txtlog.o:./src/Write_txtlog.cpp
 	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
+	
+Spherical.o:./src/Spherical.cu
+	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
 
-BG_Flood: BG_Flood.o AdaptCriteria.o Adaptation.o Advection.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o
+BG_Flood: BG_Flood.o AdaptCriteria.o Adaptation.o Advection.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o Spherical.o
 	$(EXEC) $(NVCC) $(ALL_LDFLAGS) $(GENCODE_FLAGS) -o $@ $+ $(LIBRARIES)
 	$(EXEC) mkdir -p ../../bin/$(TARGET_ARCH)/$(TARGET_OS)/$(BUILD_TYPE)
 	$(EXEC) cp $@ ../../bin/$(TARGET_ARCH)/$(TARGET_OS)/$(BUILD_TYPE)
@@ -349,7 +352,7 @@ run: build
 	$(EXEC) ./BG_Flood
 
 clean:
-	rm -f BG_Flood AdaptCriteria.o Adaptation.o Advection.o BG_Flood.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o
+	rm -f BG_Flood AdaptCriteria.o Adaptation.o Advection.o BG_Flood.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o Spherical.o
 	rm -rf ../../bin/$(TARGET_ARCH)/$(TARGET_OS)/$(BUILD_TYPE)/template
 
 clobber: clean

--- a/doc/codemap.md
+++ b/doc/codemap.md
@@ -1,0 +1,7 @@
+```mermaid
+  graph TD;
+      A-->B;
+      A-->C;
+      B-->D;
+      C-->D;
+```

--- a/src/Adaptation.cu
+++ b/src/Adaptation.cu
@@ -140,7 +140,8 @@ template <class T> bool refinesanitycheck(Param XParam, BlockP<T> XBlock,  bool*
 		{
 			coarsen[ib] = false;
 		}
-
+		// Warning, Here cancelling all coasening because of a bug
+		// This could become an option for optimising the refinment process ??
 		coarsen[ib] = false;
 	}
 

--- a/src/Adaptation.cu
+++ b/src/Adaptation.cu
@@ -140,6 +140,8 @@ template <class T> bool refinesanitycheck(Param XParam, BlockP<T> XBlock,  bool*
 		{
 			coarsen[ib] = false;
 		}
+
+		coarsen[ib] = false;
 	}
 
 

--- a/src/Adaptation.h
+++ b/src/Adaptation.h
@@ -13,6 +13,7 @@
 #include "InitialConditions.h"
 #include "Testing.h"
 
+
 template <class T> void Adaptation(Param& XParam, Forcing<float> XForcing, Model<T>& XModel);
 template <class T> void InitialAdaptation(Param& XParam, Forcing<float> &XForcing, Model<T>& XModel);
 template <class T> bool refinesanitycheck(Param XParam, BlockP<T> XBlock, bool*& refine, bool*& coarsen);

--- a/src/Advection.cu
+++ b/src/Advection.cu
@@ -67,6 +67,7 @@ template <class T>__global__ void updateEVGPU(Param XParam, BlockP<T> XBlock, Ev
 	itop = memloc(halowidth, blkmemwidth, ix, iy + 1, ib);
 
 	T yup = T(iy) + T(1.0);
+	T ydwn = T(iy);
 
 	if (iy == XParam.blkwidth - 1)
 	{
@@ -74,17 +75,28 @@ template <class T>__global__ void updateEVGPU(Param XParam, BlockP<T> XBlock, Ev
 		{
 			yup = iy + 0.75;
 		}
-		if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
-		{
-			yup = iy + 1.000;
-		}
+		//if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
+		//{
+		//	yup = iy + 1.000;
+		//}
 	}
+
+	if (iy == 0)
+	{
+		if (XBlock.level[XBlock.BotLeft[ib]] > XBlock.level[ib])
+		{
+			ydwn = iy - 0.25 ;
+		}
+		
+	}
+
+
 
 
 
 	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 	T fmu = T(1.0);
-	T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
+	T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, ydwn) : T(1.0);
 	T fmup = T(1.0);
 	T fmvp = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, yup) : T(1.0);
 
@@ -161,24 +173,30 @@ template <class T>__host__ void updateEVCPU(Param XParam, BlockP<T> XBlock, Evol
 
 
 				T yup = T(iy) + T(1.0);
+				T ydwn = T(iy);
 
 				if (iy == XParam.blkwidth - 1)
 				{
 					if (XBlock.level[XBlock.TopLeft[ib]] > XBlock.level[ib])
 					{
-						yup = iy + 0.75;
+						yup = iy + T(0.75);
 					}
-					if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
+					
+				}
+				if (iy == 0)
+				{
+					if (XBlock.level[XBlock.BotLeft[ib]] > XBlock.level[ib])
 					{
-						yup = iy + 1.5;
+						ydwn = iy - T(0.25);
 					}
+
 				}
 
 
 
 				T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 				T fmu = T(1.0);
-				T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
+				T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, ydwn) : T(1.0);
 				T fmup = T(1.0);
 				T fmvp = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, yup) : T(1.0);
 

--- a/src/Advection.cu
+++ b/src/Advection.cu
@@ -116,14 +116,7 @@ template <class T>__global__ void updateEVGPU(Param XParam, BlockP<T> XBlock, Ev
 	XAdv.dhu[i] += hi * (ga * hi * dmdl + fG * vvi);// This term is == 0 so should be commented here
 	XAdv.dhv[i] += hi * (ga * hi * dmdt - fG * uui);// Need double checking before doing that
 
-	if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
-	{
-		if (iy == XParam.blkwidth - 1)
-		{
-			printf("XAdv.dh[i]=%e, XAdv.dhv[i]=%e, XAdv.dhv[i]=%e, dmdt=%e \n", XAdv.dh[i], XAdv.dhv[i], XAdv.dhu[i], dmdt);
-		}
-
-	}
+	
 	
 }
 template __global__ void updateEVGPU<float>(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, FluxP<float> XFlux, AdvanceP<float> XAdv);

--- a/src/Advection.cu
+++ b/src/Advection.cu
@@ -37,34 +37,58 @@ struct SharedMemory<double>
 
 template <class T>__global__ void updateEVGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, FluxP<T> XFlux, AdvanceP<T> XAdv)
 {
-	
-	unsigned int halowidth = XParam.halowidth;
-	unsigned int blkmemwidth = blockDim.x + halowidth * 2;
+
+	int halowidth = XParam.halowidth;
+	int blkmemwidth = blockDim.x + halowidth * 2;
 	//unsigned int blksize = blkmemwidth * blkmemwidth;
-	unsigned int ix = threadIdx.x;
-	unsigned int iy = threadIdx.y;
-	unsigned int ibl = blockIdx.x;
-	unsigned int ib = XBlock.active[ibl];
+	int ix = threadIdx.x;
+	int iy = threadIdx.y;
+	int ibl = blockIdx.x;
+	int ib = XBlock.active[ibl];
+
+	int lev = XBlock.level[ib];
 
 	//T eps = T(XParam.eps);
-	T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	T delta = calcres(T(XParam.delta), lev);
 	T g = T(XParam.g);
-	
 
-	T fc = (T)XParam.lat * pi / T(21600.0);
+	T ybo = T(XParam.yo + XBlock.yo[ib]);
+
+
+	T fc = 0.0;// XParam.spherical ? sin((ybo + calcres(T(XParam.dx), lev) * iy) * pi / 180.0) * pi / T(21600.0) : sin(T(XParam.lat * pi / 180.0)) * pi / T(21600.0); // 2*(2*pi/24/3600)
+	// fc should be pi / T(21600.0) * sin(phi)
+
 
 	int iright, itop;
-	
+
 	int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
-	
+
 	iright = memloc(halowidth, blkmemwidth, ix + 1, iy, ib);
 	itop = memloc(halowidth, blkmemwidth, ix, iy + 1, ib);
 
-	
+	T yup = T(iy) + T(1.0);
 
-	T cm = T(1.0);// 0.1;
+	if (iy == XParam.blkwidth - 1)
+	{
+		if (XBlock.level[XBlock.TopLeft[ib]] > XBlock.level[ib])
+		{
+			yup = iy + 0.75;
+		}
+		if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
+		{
+			yup = iy + 1.000;
+		}
+	}
+
+
+
+	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 	T fmu = T(1.0);
-	T fmv = T(1.0);
+	T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
+	T fmup = T(1.0);
+	T fmvp = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, yup) : T(1.0);
+
+
 
 	T hi = XEv.h[i];
 	T uui = XEv.u[i];
@@ -73,24 +97,33 @@ template <class T>__global__ void updateEVGPU(Param XParam, BlockP<T> XBlock, Ev
 
 	T cmdinv, ga;
 
-	cmdinv = T(1.0)/ (cm * delta);
+	cmdinv = T(1.0) / (cm * delta);
 	ga = T(0.5) * g;
-		
+
 
 	XAdv.dh[i] = T(-1.0) * (XFlux.Fhu[iright] - XFlux.Fhu[i] + XFlux.Fhv[itop] - XFlux.Fhv[i]) * cmdinv;
-		
+
 
 
 	//double dmdl = (fmu[xplus + iy*nx] - fmu[i]) / (cm * delta);
 	//double dmdt = (fmv[ix + yplus*nx] - fmv[i]) / (cm  * delta);
-	T dmdl = (fmu - fmu) / (cm * delta);// absurd if not spherical!
-	T dmdt = (fmv - fmv) / (cm * delta);
+	T dmdl = (fmup - fmu) * cmdinv;// absurd if not spherical!
+	T dmdt = (fmvp - fmv) * cmdinv;;
 	T fG = vvi * dmdl - uui * dmdt;
 	XAdv.dhu[i] = (XFlux.Fqux[i] + XFlux.Fquy[i] - XFlux.Su[iright] - XFlux.Fquy[itop]) * cmdinv + fc * hi * vvi;
 	XAdv.dhv[i] = (XFlux.Fqvy[i] + XFlux.Fqvx[i] - XFlux.Sv[itop] - XFlux.Fqvx[iright]) * cmdinv - fc * hi * uui;
-		
+
 	XAdv.dhu[i] += hi * (ga * hi * dmdl + fG * vvi);// This term is == 0 so should be commented here
 	XAdv.dhv[i] += hi * (ga * hi * dmdt - fG * uui);// Need double checking before doing that
+
+	if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
+	{
+		if (iy == XParam.blkwidth - 1)
+		{
+			printf("XAdv.dh[i]=%e, XAdv.dhv[i]=%e, XAdv.dhv[i]=%e, dmdt=%e \n", XAdv.dh[i], XAdv.dhv[i], XAdv.dhu[i], dmdt);
+		}
+
+	}
 	
 }
 template __global__ void updateEVGPU<float>(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, FluxP<float> XFlux, AdvanceP<float> XAdv);
@@ -103,22 +136,28 @@ template <class T>__host__ void updateEVCPU(Param XParam, BlockP<T> XBlock, Evol
 	//T eps = T(XParam.eps);
 	T delta;
 	T g = T(XParam.g);
+
+	T ybo;
 	
 
-	int ib;
+	int ib,lev;
 	int halowidth = XParam.halowidth;
 	int blkmemwidth = XParam.blkmemwidth;
 
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		ib = XBlock.active[ibl];
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		lev = XBlock.level[ib];
+		delta = calcres(T(XParam.delta), lev);
+
+		ybo = XParam.yo + XBlock.yo[ib];
+
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < XParam.blkwidth; ix++)
 			{
 
-				T fc = T(XParam.lat * pi / 21600.0);
+				T fc = XParam.spherical ? sin((ybo + calcres(T(XParam.dx), lev) * iy) * pi / 180.0) * pi / T(21600.0) : sin(T(XParam.lat * pi / 180.0)) * pi / T(21600.0); // 2*(2*pi/24/3600)
 
 				int iright, itop;
 
@@ -128,10 +167,27 @@ template <class T>__host__ void updateEVCPU(Param XParam, BlockP<T> XBlock, Evol
 				itop = memloc(halowidth, blkmemwidth, ix, iy + 1, ib);
 
 
+				T yup = T(iy) + T(1.0);
 
-				T cm = T(1.0);// 0.1;
+				if (iy == XParam.blkwidth - 1)
+				{
+					if (XBlock.level[XBlock.TopLeft[ib]] > XBlock.level[ib])
+					{
+						yup = iy + 0.75;
+					}
+					if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
+					{
+						yup = iy + 1.5;
+					}
+				}
+
+
+
+				T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 				T fmu = T(1.0);
-				T fmv = T(1.0);
+				T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
+				T fmup = T(1.0);
+				T fmvp = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, yup) : T(1.0);
 
 				T hi = XEv.h[i];
 				T uui = XEv.u[i];
@@ -150,8 +206,8 @@ template <class T>__host__ void updateEVCPU(Param XParam, BlockP<T> XBlock, Evol
 
 				//double dmdl = (fmu[xplus + iy*nx] - fmu[i]) / (cm * delta);
 				//double dmdt = (fmv[ix + yplus*nx] - fmv[i]) / (cm  * delta);
-				T dmdl = (fmu - fmu) / (cm * delta);// absurd if not spherical!
-				T dmdt = (fmv - fmv) / (cm * delta);
+				T dmdl = (fmup - fmu) / (cm * delta);// absurd if not spherical!
+				T dmdt = (fmvp - fmv) / (cm * delta);
 				T fG = vvi * dmdl - uui * dmdt;
 				XAdv.dhu[i] = (XFlux.Fqux[i] + XFlux.Fquy[i] - XFlux.Su[iright] - XFlux.Fquy[itop]) * cmdinv + fc * hi * vvi;
 				XAdv.dhv[i] = (XFlux.Fqvy[i] + XFlux.Fqvx[i] - XFlux.Sv[itop] - XFlux.Fqvx[iright]) * cmdinv - fc * hi * uui;

--- a/src/Advection.h
+++ b/src/Advection.h
@@ -6,6 +6,7 @@
 #include "Arrays.h"
 #include "Forcing.h"
 #include "MemManagement.h"
+#include "Spherical.h"
 
 template <class T> __global__ void updateEVGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, FluxP<T> XFlux, AdvanceP<T> XAdv);
 template <class T> __host__ void updateEVCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, FluxP<T> XFlux, AdvanceP<T> XAdv);

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -6,10 +6,11 @@
 #include "General.h"
 #include "MemManagement.h"
 #include "Util_CPU.h"
+#include "Updateforcing.h"
 
 
 
-template <class T> void Flowbnd(Param XParam, Loop<T>& XLoop, BlockP<T> XBlock, bndparam side, EvolvingP<T> XEv);
+template <class T> void Flowbnd(Param XParam, Loop<T>& XLoop, BlockP<T> XBlock, bndparam side, DynForcingP<float> Atmp, EvolvingP<T> XEv);
 __host__ __device__ int Inside(int halowidth, int blkmemwidth, int isright, int istop, int ix, int iy, int ib);
 __host__ __device__ bool isbnd(int isright, int istop, int blkwidth, int ix, int iy);
 
@@ -19,7 +20,8 @@ template <class T> __global__ void maskbndGPUtop(Param XParam, BlockP<T> XBlock,
 template <class T> __global__ void maskbndGPUright(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 template <class T> __global__ void maskbndGPUbot(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 
-template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T> XBlock, float itime, T* zs, T* h, T* un, T* ut);
+template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut);
+template <class T> __host__ void bndCPU(Param XParam, bndparam side, BlockP<T> XBlock, std::vector<double> zsbndvec, std::vector<double> uubndvec, std::vector<double> vvbndvec, DynForcingP<float> Atmp, T* zs, T* h, T* un, T* ut);
 
 
 __device__ __host__ void findmaskside(int side, bool &isleftbot, bool& islefttop, bool& istopleft, bool& istopright, bool& isrighttop, bool& isrightbot, bool& isbotright, bool& isbotleft);

--- a/src/ConserveElevation.cu
+++ b/src/ConserveElevation.cu
@@ -787,7 +787,7 @@ template <class T> void conserveElevationGHLeft(Param XParam, int ib, int ibLB, 
 {
 	int ibn;
 	int ihalo, jhalo, ip, jp, iq, jq;
-	T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	T delta = calcres(T(XParam.delta), XBlock.level[ib]);
 	ihalo = -1;
 	ip = 0;
 
@@ -871,7 +871,7 @@ template <class T> __global__ void conserveElevationGHLeft(Param XParam, BlockP<
 	int ip, jp, iq, jq;
 
 	int ihalo, jhalo, ibn;
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 
 	ihalo = -1;
@@ -926,7 +926,7 @@ template <class T> void conserveElevationGHRight(Param XParam, int ib, int ibRB,
 {
 	int ibn;
 	int ihalo, jhalo, ip, jp, iq, jq;
-	T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	T delta = calcres(T(XParam.delta), XBlock.level[ib]);
 	ihalo = XParam.blkwidth;
 	ip = XParam.blkwidth-1;
 
@@ -1004,7 +1004,7 @@ template <class T> __global__ void conserveElevationGHRight(Param XParam, BlockP
 
 	int ihalo, jhalo, iq, jq, ip, jp, ibn;
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 	ihalo = blockDim.y;
 	jhalo = iy;
@@ -1061,7 +1061,7 @@ template <class T> void conserveElevationGHTop(Param XParam, int ib, int ibTL, i
 {
 	int ibn;
 	int ihalo, jhalo, ip, jp, iq, jq;
-	T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	T delta = calcres(T(XParam.delta), XBlock.level[ib]);
 	jhalo = XParam.blkwidth;
 	jp = XParam.blkwidth - 1;
 
@@ -1137,7 +1137,7 @@ template <class T> __global__ void conserveElevationGHTop(Param XParam, BlockP<T
 
 
 	int ihalo, jhalo, iq, jq, ip, jp, ibn;
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 	ihalo = ix;
 	jhalo = iy+1;
@@ -1192,7 +1192,7 @@ template <class T> void conserveElevationGHBot(Param XParam, int ib, int ibBL, i
 {
 	int ibn;
 	int ihalo, jhalo, ip, jp, iq, jq;
-	T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	T delta = calcres(T(XParam.delta), XBlock.level[ib]);
 	jhalo = -1;
 	jp = 0;
 
@@ -1269,7 +1269,7 @@ template <class T> __global__ void conserveElevationGHBot(Param XParam, BlockP<T
 	int ip, jp, iq, jq;
 
 	int ihalo, jhalo, ibn;
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 	ihalo = ix;
 	jhalo = -1;

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -34,7 +34,10 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 		cudaStreamDestroy(atmpstreams[0]);
 
 		//Calc dpdx and dpdy
-		gradient<< < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
+
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
+
+		
 		CUDA_CHECK(cudaDeviceSynchronize());
 		gradientHaloGPU(XParam, XModel.blocks, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 		//
@@ -42,7 +45,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 		refine_linearGPU(XParam, XModel.blocks, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 
-		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 		CUDA_CHECK(cudaDeviceSynchronize());
 
 		gradientHaloGPU(XParam, XModel.blocks, XModel.Patm, XModel.datmpdx, XModel.datmpdy);

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -325,7 +325,7 @@ template <class T> void HalfStepGPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 		cudaStreamDestroy(atmpstreams[0]);
 
 		//Calc dpdx and dpdy
-		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 		CUDA_CHECK(cudaDeviceSynchronize());
 		gradientHaloGPU(XParam, XModel.blocks, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 		//
@@ -333,7 +333,7 @@ template <class T> void HalfStepGPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 
 		refine_linearGPU(XParam, XModel.blocks, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 
-		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel.Patm, XModel.datmpdx, XModel.datmpdy);
 		CUDA_CHECK(cudaDeviceSynchronize());
 
 		gradientHaloGPU(XParam, XModel.blocks, XModel.Patm, XModel.datmpdx, XModel.datmpdy);

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -7,7 +7,7 @@
 
 struct TexSetP
 {
-	float xo, yo, dx; // used to calculate coordinates insode the device function
+	float xo, yo, dx, dy; // used to calculate coordinates insode the device function
 	float nowvalue;
 	bool uniform;
 	cudaArray* CudArr;

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -206,19 +206,19 @@ template <class T> void gradientGPUnew(Param XParam, BlockP<T>XBlock, EvolvingP<
 	}
 
 	//gradient << < gridDim, blockDim, 0, streams[1] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
-	gradientSMC << < gridDim, blockDim, 0, streams[0] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
+	gradientSMC << < gridDim, blockDim, 0, streams[0] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdx, XGrad.dhdy);
 	//CUDA_CHECK(cudaDeviceSynchronize());
 
 	//gradient << < gridDim, blockDim, 0, streams[2] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
-	gradientSMC << < gridDim, blockDim, 0, streams[1] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
+	gradientSMC << < gridDim, blockDim, 0, streams[1] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
 	//CUDA_CHECK(cudaDeviceSynchronize());
 
 	//gradient << < gridDim, blockDim, 0, streams[3] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
-	gradientSMC << < gridDim, blockDim, 0, streams[2] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
+	gradientSMC << < gridDim, blockDim, 0, streams[2] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudx, XGrad.dudy);
 	//CUDA_CHECK(cudaDeviceSynchronize());
 
 	//gradient << < gridDim, blockDim, 0, streams[0] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
-	gradientSMC << < gridDim, blockDim, 0, streams[3] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
+	gradientSMC << < gridDim, blockDim, 0, streams[3] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdx, XGrad.dvdy);
 	//CUDA_CHECK(cudaDeviceSynchronize());
 
 
@@ -292,42 +292,42 @@ template <class T> void gradientGPUnew(Param XParam, BlockP<T>XBlock, EvolvingP<
 
 
 
-		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx);
+		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth-1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdy);
+		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeY << < gridDim, blockDimBT, 0>> > (XParam.halowidth, XParam.blkwidth-1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx);
+		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdy);
+		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeY << < gridDim, blockDimBT, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx);
+		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudy);
+		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeY << < gridDim, blockDimBT, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx);
+		gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 
-		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdy);
+		gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdy);
 		//CUDA_CHECK(cudaDeviceSynchronize());
 		//gradientedgeY << < gridDim, blockDimBT, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdy);
 		CUDA_CHECK(cudaDeviceSynchronize());

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -3110,7 +3110,7 @@ template <class T> __global__ void gradientHaloLeftGPUnew(Param XParam, BlockP<T
 
 
 
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 		if (XBlock.LeftBot[ib] == ib)//The lower half is a boundary 
@@ -3387,7 +3387,7 @@ template <class T> __global__ void gradientHaloRightGPUnew(Param XParam, BlockP<
 
 
 
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 		if (XBlock.RightBot[ib] == ib)//The lower half is a boundary 
@@ -3672,7 +3672,7 @@ template <class T> __global__ void gradientHaloBotGPUnew(Param XParam, BlockP<T>
 
 
 
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 		if (XBlock.BotLeft[ib] == ib)//The lower half is a boundary 
@@ -3963,7 +3963,7 @@ template <class T> __global__ void gradientHaloTopGPUnew(Param XParam, BlockP<T>
 
 
 
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 		if (XBlock.TopLeft[ib] == ib)//The lower half is a boundary 

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -26,19 +26,19 @@ template <class T> void gradientGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 	dim3 gridDim(XParam.nblk, 1, 1);
 
 	//gradient << < gridDim, blockDim, 0, streams[1] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdx, XGrad.dhdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	//gradient << < gridDim, blockDim, 0, streams[2] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	//gradient << < gridDim, blockDim, 0, streams[3] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudx, XGrad.dudy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	//gradient << < gridDim, blockDim, 0, streams[0] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdx, XGrad.dvdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 
@@ -76,65 +76,66 @@ template <class T> void gradientGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 			{
 				conserveElevationGPU(XParam, XBlock, XEv, zb);
 			}
-
-			RecalculateZsGPU << < gridDim, blockDimfull, 0 >> > (XParam, XBlock, XEv, zb);
+      
+      RecalculateZsGPU << < gridDim, blockDimfull, 0 >> > (XParam, XBlock, XEv, zb);
 			CUDA_CHECK(cudaDeviceSynchronize());
+
+
+    
+		//gradient << < gridDim, blockDim, 0, streams[1] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdx, XGrad.dhdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+
+		//gradient << < gridDim, blockDim, 0, streams[2] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+
+		//gradient << < gridDim, blockDim, 0, streams[3] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudx, XGrad.dudy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+
+		//gradient << < gridDim, blockDim, 0, streams[0] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
+		gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdx, XGrad.dvdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+
+
 			/*
-			//gradient << < gridDim, blockDim, 0, streams[1] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
-			gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx, XGrad.dhdy);
-			CUDA_CHECK(cudaDeviceSynchronize());
-
-			//gradient << < gridDim, blockDim, 0, streams[2] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
-			gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx, XGrad.dzsdy);
-			CUDA_CHECK(cudaDeviceSynchronize());
-
-			//gradient << < gridDim, blockDim, 0, streams[3] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
-			gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx, XGrad.dudy);
-			CUDA_CHECK(cudaDeviceSynchronize());
-
-			//gradient << < gridDim, blockDim, 0, streams[0] >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
-			gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx, XGrad.dvdy);
-			CUDA_CHECK(cudaDeviceSynchronize());
-
-			*/
-
-			/*
-			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx);
+			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth-1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdy);
+			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.h, XGrad.dhdy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeY << < gridDim, blockDimBT, 0>> > (XParam.halowidth, XParam.blkwidth-1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.h, XGrad.dhdy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx);
+			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdy);
+			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.zs, XGrad.dzsdy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeY << < gridDim, blockDimBT, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.zs, XGrad.dzsdy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx);
+			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudy);
+			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.u, XGrad.dudy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeY << < gridDim, blockDimBT, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.u, XGrad.dudy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx);
+			gradientedgeX << < gridDim, blockDimLR2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeX << < gridDim, blockDimLR, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdx);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 
-			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdy);
+			gradientedgeY << < gridDim, blockDimBT2, 0 >> > (XParam.halowidth, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.delta, XEv.v, XGrad.dvdy);
 			//CUDA_CHECK(cudaDeviceSynchronize());
 			//gradientedgeY << < gridDim, blockDimBT, 0 >> > (XParam.halowidth, XParam.blkwidth - 1, XBlock.active, XBlock.level, (T)XParam.theta, (T)XParam.dx, XEv.v, XGrad.dvdy);
 			CUDA_CHECK(cudaDeviceSynchronize());
@@ -821,7 +822,7 @@ template <class T> void gradientC(Param XParam, BlockP<T> XBlock, T* a, T* dadx,
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		ib = XBlock.active[ibl];
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		delta = calcres(T(XParam.delta), XBlock.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < XParam.blkwidth; ix++)
@@ -947,7 +948,7 @@ template <class T> void WetsloperesetCPU(Param XParam, BlockP<T>XBlock, Evolving
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		ib = XBlock.active[ibl];
-		delta = calcres(T(XParam.dx), XBlock.level[ib]);
+		delta = calcres(T(XParam.delta), XBlock.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < XParam.blkwidth; ix++)
@@ -1011,7 +1012,7 @@ template <class T> __global__ void WetsloperesetXGPU(Param XParam, BlockP<T>XBlo
 
 	int lev = XBlock.level[ib];
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 
 	int i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
@@ -1050,7 +1051,7 @@ template <class T> __global__ void WetsloperesetYGPU(Param XParam, BlockP<T>XBlo
 
 	int lev = XBlock.level[ib];
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 
 	int i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
@@ -1091,7 +1092,7 @@ template <class T> __global__ void WetsloperesetHaloLeftGPU(Param XParam, BlockP
 	int lev = XBlock.level[ib];
 
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 	T zsi, zsright, zsleft;
 
@@ -1242,7 +1243,7 @@ template <class T> void WetsloperesetHaloLeftCPU(Param XParam, BlockP<T>XBlock, 
 		int lev = XBlock.level[ib];
 
 
-		T delta = calcres(XParam.dx, lev);
+		T delta = calcres(XParam.delta, lev);
 
 		T zsi, zsright, zsleft;
 
@@ -1395,7 +1396,7 @@ template <class T> __global__ void WetsloperesetHaloRightGPU(Param XParam, Block
 
 	int lev = XBlock.level[ib];
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 
 	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
@@ -1557,7 +1558,7 @@ template <class T> void WetsloperesetHaloRightCPU(Param XParam, BlockP<T>XBlock,
 
 			int lev = XBlock.level[ib];
 
-			T delta = calcres(XParam.dx, lev);
+			T delta = calcres(XParam.delta, lev);
 
 
 			i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
@@ -1713,7 +1714,7 @@ template <class T> __global__ void WetsloperesetHaloBotGPU(Param XParam, BlockP<
 
 	int lev = XBlock.level[ib];
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 
 	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
@@ -1870,7 +1871,7 @@ template <class T> void WetsloperesetHaloBotCPU(Param XParam, BlockP<T>XBlock, E
 
 		int lev = XBlock.level[ib];
 
-		T delta = calcres(XParam.dx, lev);
+		T delta = calcres(XParam.delta, lev);
 
 		for (int ix = 0; ix < XParam.blkwidth; ix++)
 		{
@@ -2026,7 +2027,7 @@ template <class T> __global__ void WetsloperesetHaloTopGPU(Param XParam, BlockP<
 
 	int lev = XBlock.level[ib];
 
-	T delta = calcres(XParam.dx, lev);
+	T delta = calcres(XParam.delta, lev);
 
 
 	i = memloc(XParam.halowidth, blkmemwidth, ix, iy, ib);
@@ -2182,7 +2183,7 @@ template <class T>  void WetsloperesetHaloTopCPU(Param XParam, BlockP<T>XBlock, 
 
 		int lev = XBlock.level[ib];
 
-		T delta = calcres(XParam.dx, lev);
+		T delta = calcres(XParam.delta, lev);
 
 		for (int ix = 0; ix < XParam.blkwidth; ix++)
 		{
@@ -2427,7 +2428,7 @@ template <class T> void gradientHaloLeft(Param XParam, BlockP<T>XBlock, int ib, 
 	
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.LeftBot[ib] == ib)//The lower half is a boundary 
@@ -2560,7 +2561,7 @@ template <class T> void gradientHaloRight(Param XParam, BlockP<T>XBlock, int ib,
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.RightBot[ib] == ib)//The lower half is a boundary 
@@ -2694,7 +2695,7 @@ template <class T> void gradientHaloBot(Param XParam, BlockP<T>XBlock, int ib, i
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.BotLeft[ib] == ib)//The lower half is a boundary 
@@ -2828,7 +2829,7 @@ template <class T> void gradientHaloTop(Param XParam, BlockP<T>XBlock, int ib, i
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.TopLeft[ib] == ib)//The lower half is a boundary 
@@ -2968,7 +2969,7 @@ template <class T> __global__ void gradientHaloLeftGPU(Param XParam, BlockP<T>XB
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.LeftBot[ib] == ib)//The lower half is a boundary 
@@ -3246,7 +3247,7 @@ template <class T> __global__ void gradientHaloRightGPU(Param XParam, BlockP<T>X
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.RightBot[ib] == ib)//The lower half is a boundary 
@@ -3526,7 +3527,7 @@ template <class T> __global__ void gradientHaloBotGPU(Param XParam, BlockP<T>XBl
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.BotLeft[ib] == ib)//The lower half is a boundary 
@@ -3815,7 +3816,7 @@ template <class T> __global__ void gradientHaloTopGPU(Param XParam, BlockP<T>XBl
 
 
 
-	delta = calcres(T(XParam.dx), XBlock.level[ib]);
+	delta = calcres(T(XParam.delta), XBlock.level[ib]);
 
 
 	if (XBlock.TopLeft[ib] == ib)//The lower half is a boundary 

--- a/src/GridManip.cu
+++ b/src/GridManip.cu
@@ -331,8 +331,8 @@ template <class T, class F> T blockmean(T x, T y,T dx, F forcing)
 	imin = max(ftoi(floor((xmin - forcing.xo) / forcing.dx)), 0);
 	imax = min(ftoi(floor((xmax - forcing.xo) / forcing.dx)), forcing.nx - 1);
 
-	jmin = max(ftoi(floor((ymin - forcing.yo) / forcing.dx)), 0);
-	jmax = min(ftoi(floor((ymax - forcing.yo) / forcing.dx)), forcing.ny - 1);
+	jmin = max(ftoi(floor((ymin - forcing.yo) / forcing.dy)), 0);
+	jmax = min(ftoi(floor((ymax - forcing.yo) / forcing.dy)), forcing.ny - 1);
 
 	//printf("imin=%d; imax=%d, jmin=%d, jmax=%d\t",imin, imax, jmin, jmax);
 
@@ -381,11 +381,11 @@ template <class T, class F> T interp2BUQ(T x, T y, F forcing)
 	x1 = forcing.xo + forcing.dx * cfi;
 	x2 = forcing.xo + forcing.dx * cfip;
 
-	cfj = utils::min(utils::max((int)floor((yi - forcing.yo) / forcing.dx), 0), forcing.ny - 2);
+	cfj = utils::min(utils::max((int)floor((yi - forcing.yo) / forcing.dy), 0), forcing.ny - 2);
 	cfjp = cfj + 1;
 
-	y1 = forcing.yo + forcing.dx * cfj;
-	y2 = forcing.yo + forcing.dx * cfjp;
+	y1 = forcing.yo + forcing.dy * cfj;
+	y2 = forcing.yo + forcing.dy * cfjp;
 
 	q11 = forcing.val[cfi + cfj * forcing.nx];
 	q12 = forcing.val[cfi + cfjp * forcing.nx];

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -757,7 +757,9 @@ template <class T> void refine_linear_Left(Param XParam, int ib, BlockP<T> XBloc
 {
 	if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib])
 	{
-		double ilevdx = calcres(XParam.dx, XBlock.level[ib])*T(0.5);
+
+		double ilevdx = calcres(XParam.delta, XBlock.level[ib])*T(0.5);
+
 		for (int j = 0; j < XParam.blkwidth; j++)
 		{
 			int jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? ftoi(floor(j * (T)0.5)) : ftoi(floor(j * (T)0.5) + XParam.blkwidth / 2);
@@ -792,7 +794,9 @@ template <class T> __global__ void refine_linear_LeftGPU(Param XParam, BlockP<T>
 	if (XBlock.level[XBlock.LeftBot[ib]] < XBlock.level[ib])
 	{
 		int j = iy;
-		double ilevdx = calcres(XParam.dx, XBlock.level[ib]) * T(0.5);
+
+		double ilevdx = calcres(XParam.delta, XBlock.level[ib]) * T(0.5);
+
 		
 		int jj = XBlock.RightBot[XBlock.LeftBot[ib]] == ib ? floor(j * (T)0.5) : floor(j * (T)0.5) + XParam.blkwidth / 2;
 		int il = memloc(XParam.halowidth, blkmemwidth, XParam.blkwidth - 1, jj, XBlock.LeftBot[ib]);
@@ -816,7 +820,9 @@ template <class T> void refine_linear_Right(Param XParam, int ib, BlockP<T> XBlo
 {
 	if (XBlock.level[XBlock.RightBot[ib]] < XBlock.level[ib])
 	{
-		T ilevdx = calcres(T(XParam.dx), XBlock.level[ib] ) * T(0.5);
+
+		T ilevdx = calcres(T(XParam.delta), XBlock.level[ib] ) * T(0.5);
+
 		for (int j = 0; j < XParam.blkwidth; j++)
 		{
 			int jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? ftoi(floor(j * (T)0.5)) : ftoi(floor(j * (T)0.5) + XParam.blkwidth / 2);
@@ -849,7 +855,9 @@ template <class T> __global__ void refine_linear_RightGPU(Param XParam, BlockP<T
 
 	if (XBlock.level[XBlock.RightBot[ib]] < XBlock.level[ib])
 	{
-		double ilevdx = calcres(XParam.dx, XBlock.level[ib]) * T(0.5);
+
+		double ilevdx = calcres(XParam.delta, XBlock.level[ib]) * T(0.5);
+
 		int j = iy;
 		int jj = XBlock.LeftBot[XBlock.RightBot[ib]] == ib ? floor(j * (T)0.5) : floor(j * (T)0.5) + XParam.blkwidth / 2;
 		int il = memloc(XParam.halowidth, blkmemwidth, 0, jj, XBlock.RightBot[ib]);
@@ -873,7 +881,9 @@ template <class T> void refine_linear_Bot(Param XParam, int ib, BlockP<T> XBlock
 {
 	if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib])
 	{
-		T ilevdx = calcres(T(XParam.dx), XBlock.level[ib]) * T(0.5);
+
+		T ilevdx = calcres(T(XParam.delta), XBlock.level[ib]) * T(0.5);
+
 		for (int i = 0; i < XParam.blkwidth; i++)
 		{
 			int ii = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? ftoi(floor(i * (T)0.5)) : ftoi(floor(i * (T)0.5) + XParam.blkwidth / 2);
@@ -906,7 +916,9 @@ template <class T> __global__ void refine_linear_BotGPU(Param XParam, BlockP<T> 
 
 	if (XBlock.level[XBlock.BotLeft[ib]] < XBlock.level[ib])
 	{
-		double ilevdx = calcres(XParam.dx, XBlock.level[ib]) * T(0.5);
+
+		double ilevdx = calcres(XParam.delta, XBlock.level[ib]) * T(0.5);
+
 		int i = ix;
 		int ii = XBlock.TopLeft[XBlock.BotLeft[ib]] == ib ? floor(i * (T)0.5) : floor(i * (T)0.5) + XParam.blkwidth / 2;
 		int jl = memloc(XParam.halowidth, blkmemwidth, ii, XParam.blkwidth - 1, XBlock.BotLeft[ib]);
@@ -930,7 +942,9 @@ template <class T> void refine_linear_Top(Param XParam, int ib, BlockP<T> XBlock
 {
 	if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
 	{
-		double ilevdx = calcres(XParam.dx, XBlock.level[ib]) * T(0.5);
+
+		double ilevdx = calcres(XParam.delta, XBlock.level[ib]) * T(0.5);
+
 		for (int i = 0; i < XParam.blkwidth; i++)
 		{
 			int ii = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? ftoi(floor(i * (T)0.5)) : ftoi(floor(i * (T)0.5) + XParam.blkwidth / 2);
@@ -961,8 +975,10 @@ template <class T> __global__ void refine_linear_TopGPU(Param XParam, BlockP<T> 
 	int ib = XBlock.active[ibl];
 	if (XBlock.level[XBlock.TopLeft[ib]] < XBlock.level[ib])
 	{
-		double ilevdx = calcres(XParam.dx, XBlock.level[ib]) * T(0.5);
-		int i = ix;
+
+		double ilevdx = calcres(XParam.delta, XBlock.level[ib]) * T(0.5);
+
+    int i = ix;
 		int ii = XBlock.BotLeft[XBlock.TopLeft[ib]] == ib ? floor(i * (T)0.5) : floor(i * (T)0.5) + XParam.blkwidth / 2;
 		int jl = memloc(XParam.halowidth, blkmemwidth, ii , 0, XBlock.TopLeft[ib]);
 		int write = memloc(XParam.halowidth, blkmemwidth, i, XParam.blkwidth, ib);

--- a/src/InitEvolv.cu
+++ b/src/InitEvolv.cu
@@ -319,7 +319,20 @@ void warmstart(Param XParam,Forcing<float> XForcing, BlockP<T> XBlock, T* zb, Ev
 
 				zsbnd = T(((zsleft / distleft) * lefthere + (zsright / distright) * righthere + (zstop / disttop) * tophere + (zsbot / distbot) * bothere) / ((1.0 / distleft) * lefthere + (1.0 / distright) * righthere + (1.0 / disttop) * tophere + (1.0 / distbot) * bothere));
 
+				if (XParam.atmpforcing)
+				{
+					float atmpi;
 
+					if (XForcing.Atmp.uniform)
+					{
+						atmpi = T(XForcing.Atmp.nowvalue);
+					}
+					else
+					{
+						atmpi = interp2BUQ(xi, yi, XForcing.Atmp);
+					}
+					zsbnd = zsbnd - (atmpi- XParam.Paref) * XParam.Pa2m;
+				}
 
 				XEv.zs[n] = utils::max(zsbnd, zb[n]);
 				XEv.h[n] = utils::max(XEv.zs[n] - zb[n], T(0.0));

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -260,7 +260,7 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 	if (XForcing.rivers.size() > 0)
 	{
 		//
-		double xl, yb, xr, yt ;
+		double xl, yb, xr, yt, xi,yi ;
 		int ib;
 		double levdx, levdelta;
 		double dischargeArea;
@@ -281,13 +281,16 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 					for (int i = 0; i < XParam.blkwidth; i++)
 					{
 						//int n = (i + XParam.halowidth) + (j + XParam.halowidth) * XParam.blkmemwidth + ib * XParam.blksize;
-						
-						
-						xl = XParam.xo + XModel.blocks.xo[ib] + i * levdx - 0.5 * levdx;
-						yb = XParam.yo + XModel.blocks.yo[ib] + j * levdx - 0.5 * levdx;
+						xi = XParam.xo + XModel.blocks.xo[ib] + i * levdx;
+						yi = XParam.yo + XModel.blocks.yo[ib] + j * levdx;
 
-						xr = XParam.xo + XModel.blocks.xo[ib] + i * levdx + 0.5 * levdx;
-						yt = XParam.yo + XModel.blocks.yo[ib] + j * levdx + 0.5 * levdx;
+
+						
+						xl = xi - 0.5 * levdx;
+						yb = yi - 0.5 * levdx;
+
+						xr = xi + 0.5 * levdx;
+						yt = yi + 0.5 * levdx;
 						// the conditions are that the discharge area as defined by the user have to include at least a model grid node
 						// This could be really annoying and there should be a better way to deal wiith this like polygon intersection
 						//if (xx >= XForcing.rivers[Rin].xstart && xx <= XForcing.rivers[Rin].xend && yy >= XForcing.rivers[Rin].ystart && yy <= XForcing.rivers[Rin].yend)
@@ -298,7 +301,14 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 							idis.push_back(i);
 							jdis.push_back(j);
 							blockdis.push_back(ib);
-							dischargeArea = dischargeArea + levdelta * levdelta;
+							if (XParam.spherical)
+							{
+								dischargeArea = dischargeArea + spharea(XParam.Radius, xi, yi, levdx);
+							}
+							else
+							{
+								dischargeArea = dischargeArea + levdelta * levdelta;
+							}
 						}
 					}
 				}

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -128,14 +128,14 @@ template <class T> void InitzbgradientGPU(Param XParam, Model<T> XModel)
 
 	cudaStreamDestroy(streams[0]);
 
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	gradientHaloGPU(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 
 	refine_linearGPU(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel.blocks.active, XModel.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	gradientHaloGPU(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
@@ -262,7 +262,7 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 		//
 		double xl, yb, xr, yt ;
 		int ib;
-		double levdx;
+		double levdx, levdelta;
 		double dischargeArea;
 		log("\tInitializing rivers");
 		//For each rivers
@@ -275,6 +275,7 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 			{
 				ib = XModel.blocks.active[ibl];
 				levdx = calcres(XParam.dx, XModel.blocks.level[ib]);
+				levdelta = calcres(XParam.delta, XModel.blocks.level[ib]);
 				for (int j = 0; j < XParam.blkwidth; j++)
 				{
 					for (int i = 0; i < XParam.blkwidth; i++)
@@ -297,7 +298,7 @@ template <class T> void InitRivers(Param XParam, Forcing<float> &XForcing, Model
 							idis.push_back(i);
 							jdis.push_back(j);
 							blockdis.push_back(ib);
-							dischargeArea = dischargeArea + levdx * levdx;
+							dischargeArea = dischargeArea + levdelta * levdelta;
 						}
 					}
 				}

--- a/src/InitialConditions.h
+++ b/src/InitialConditions.h
@@ -12,6 +12,7 @@
 #include "GridManip.h"
 #include "InitEvolv.h"
 #include "Gradients.h"
+#include "Spherical.h"
 
 
 template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcing, Model<T> &XModel);

--- a/src/Input.h
+++ b/src/Input.h
@@ -51,6 +51,7 @@ public:
 	double xmax = 0.0;
 	double ymax = 0.0;
 	double dx = 0.0;
+	double dy = 0.0;
 	double grdalpha=0.0;
 	bool flipxx = false;
 	bool flipyy = false;

--- a/src/Kurganov.h
+++ b/src/Kurganov.h
@@ -7,6 +7,7 @@
 #include "Forcing.h"
 #include "MemManagement.h"
 #include "Util_CPU.h"
+#include "Spherical.h"
 
 template <class T> __global__ void updateKurgXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 template <class T> __global__ void AddSlopeSourceXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* zb);

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -207,17 +207,17 @@ template <class T> void updateBnd(Param XParam, Loop<T> XLoop, Forcing<float> XF
 {
 	if (XParam.GPUDEVICE >= 0)
 	{
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.left, XModel_g.evolv);
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.right, XModel_g.evolv);
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.top, XModel_g.evolv);
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.bot, XModel_g.evolv);
+		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.left, XForcing.Atmp, XModel_g.evolv);
+		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.right, XForcing.Atmp, XModel_g.evolv);
+		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.top, XForcing.Atmp, XModel_g.evolv);
+		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.bot, XForcing.Atmp, XModel_g.evolv);
 	}
 	else
 	{
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.left, XModel.evolv);
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.right, XModel.evolv);
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.top, XModel.evolv);
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.bot, XModel.evolv);
+		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv);
+		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv);
+		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv);
+		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv);
 	}
 }
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -61,7 +61,7 @@ public:
 	double xmax = nan(""); // Grid xmax (if not alter by the user, will be defined based on the topography/bathymetry input map)
 	double grdalpha = nan(""); // Grid rotation Y axis from the North input in degrees but later converted to rad
 	int posdown = 0; // Flag for bathy input. Model requirement is positive up  so if posdown ==1 then zb=zb*-1.0f
-	int spherical = 0; // Flag for sperical coordinate (still in development)
+	bool spherical = 0; // Flag for sperical coordinate (still in development)
 	double Radius = 6371220.; //Earth radius [m]
 	double mask = 9999.0; //Mask any zb above this value. If the entire Block is masked then it is not allocated in the memory
 
@@ -197,8 +197,10 @@ public:
 	bool rainbnd = false; // when false it force the rain foring on the bnd cells to be null.
 
 	// This here should be stored in a structure at a later stage
+
 	std::string AdaptCrit;
 	int* AdaptCrit_funct_pointer;
+
 	std::string Adapt_arg1, Adapt_arg2, Adapt_arg3, Adapt_arg4, Adapt_arg5;
 	int adaptmaxiteration = 20; // Maximum number of iteration for adaptation. default 20
 

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -156,6 +156,7 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			XForcing.deform[nd].GPU.yo = float(XForcing.deform[nd].yo);
 			XForcing.deform[nd].GPU.uniform = false;
 			XForcing.deform[nd].GPU.dx = float(XForcing.deform[nd].dx);
+			XForcing.deform[nd].GPU.dy = float(XForcing.deform[nd].dy);
 		}
 		//log("...done");
 
@@ -409,6 +410,7 @@ void InitDynforcing(bool gpgpu,Param& XParam,DynForcingP<float>& Dforcing)
 			Dforcing.GPU.yo = float(Dforcing.yo);
 			Dforcing.GPU.uniform = Dforcing.uniform;
 			Dforcing.GPU.dx = float(Dforcing.dx);
+			Dforcing.GPU.dy = float(Dforcing.dy);
 		}
 		
 	}
@@ -666,7 +668,7 @@ std::vector<SLTS> readNestfile(std::string ncfile,std::string varname, int hor ,
 	std::vector<double> WLS,Unest,Vnest;
 	//Define NC file variables
 	int nnx, nny, nt, nbndpts, indxx, indyy, indx, indy,nx, ny;
-	double dx, xxo, yyo, to, xmax, ymax, tmax,xo,yo;
+	double dx, dy, xxo, yyo, to, xmax, ymax, tmax,xo,yo;
 	double * ttt, *zsa;
 	bool checkhh = false;
 	int iswet;
@@ -674,7 +676,7 @@ std::vector<SLTS> readNestfile(std::string ncfile,std::string varname, int hor ,
 	bool flipy = false;
 
 	// Read NC info
-	readgridncsize(ncfile,varname, nnx, nny, nt, dx, xxo, yyo, to, xmax, ymax, tmax, flipx, flipy);
+	readgridncsize(ncfile,varname, nnx, nny, nt, dx,dy, xxo, yyo, to, xmax, ymax, tmax, flipx, flipy);
 	
 	if (hor == 0)
 	{
@@ -1272,7 +1274,7 @@ DynForcingP<float> readforcinghead(DynForcingP<float> Fmap)
 	if (fileext.compare("nc") == 0)
 	{
 		log("Reading Forcing file as netcdf file");
-		readgridncsize(Fmap.inputfile,Fmap.varname, Fmap.nx, Fmap.ny, Fmap.nt, Fmap.dx, Fmap.xo, Fmap.yo, Fmap.to, Fmap.xmax, Fmap.ymax, Fmap.tmax, Fmap.flipxx, Fmap.flipyy);
+		readgridncsize(Fmap.inputfile,Fmap.varname, Fmap.nx, Fmap.ny, Fmap.nt, Fmap.dx, Fmap.dy, Fmap.xo, Fmap.yo, Fmap.to, Fmap.xmax, Fmap.ymax, Fmap.tmax, Fmap.flipxx, Fmap.flipyy);
 		
 		if (Fmap.nt > 1)
 		{
@@ -1317,6 +1319,7 @@ template<class T> T readforcinghead(T ForcingParam)
 		{
 			//log("'md' file");
 			readbathyHeadMD(ForcingParam.inputfile, ForcingParam.nx, ForcingParam.ny, ForcingParam.dx, ForcingParam.grdalpha);
+			ForcingParam.dy = ForcingParam.dx;
 			ForcingParam.xo = 0.0;
 			ForcingParam.yo = 0.0;
 			ForcingParam.xmax = ForcingParam.xo + (double(ForcingParam.nx) - 1.0) * ForcingParam.dx;
@@ -1328,7 +1331,7 @@ template<class T> T readforcinghead(T ForcingParam)
 			int dummy;
 			double dummyb, dummyc;
 			//log("netcdf file");
-			readgridncsize(ForcingParam.inputfile, ForcingParam.varname, ForcingParam.nx, ForcingParam.ny, dummy, ForcingParam.dx, ForcingParam.xo, ForcingParam.yo, dummyb, ForcingParam.xmax, ForcingParam.ymax, dummyc, ForcingParam.flipxx, ForcingParam.flipyy);
+			readgridncsize(ForcingParam.inputfile, ForcingParam.varname, ForcingParam.nx, ForcingParam.ny, dummy, ForcingParam.dx, ForcingParam.dy, ForcingParam.xo, ForcingParam.yo, dummyb, ForcingParam.xmax, ForcingParam.ymax, dummyc, ForcingParam.flipxx, ForcingParam.flipyy);
 			//log("For nc of bathy file please specify grdalpha in the BG_param.txt (default 0)");
 
 			//Check that the x and y variable are in crescent order:
@@ -1357,6 +1360,7 @@ template<class T> T readforcinghead(T ForcingParam)
 			readbathyASCHead(ForcingParam.inputfile, ForcingParam.nx, ForcingParam.ny, ForcingParam.dx, ForcingParam.xo, ForcingParam.yo, ForcingParam.grdalpha);
 			ForcingParam.xmax = ForcingParam.xo + (ForcingParam.nx-1)* ForcingParam.dx;
 			ForcingParam.ymax = ForcingParam.yo + (ForcingParam.ny-1)* ForcingParam.dx;
+
 			log("For asc of bathy file please specify grdalpha in the BG_param.txt (default 0)");
 		}
 
@@ -1368,7 +1372,7 @@ template<class T> T readforcinghead(T ForcingParam)
 
 
 		//printf("Bathymetry grid info: nx=%d\tny=%d\tdx=%lf\talpha=%f\txo=%lf\tyo=%lf\txmax=%lf\tymax=%lf\n", BathyParam.nx, BathyParam.ny, BathyParam.dx, BathyParam.grdalpha * 180.0 / pi, BathyParam.xo, BathyParam.yo, BathyParam.xmax, BathyParam.ymax);
-		log("Forcing grid info: nx=" + std::to_string(ForcingParam.nx) + " ny=" + std::to_string(ForcingParam.ny) + " dx=" + std::to_string(ForcingParam.dx) + " grdalpha=" + std::to_string(ForcingParam.grdalpha*180.0 / pi) + " xo=" + std::to_string(ForcingParam.xo) + " xmax=" + std::to_string(ForcingParam.xmax) + " yo=" + std::to_string(ForcingParam.yo) + " ymax=" + std::to_string(ForcingParam.ymax));
+		log("Forcing grid info: nx=" + std::to_string(ForcingParam.nx) + " ny=" + std::to_string(ForcingParam.ny) + " dx=" + std::to_string(ForcingParam.dx) + " dy=" + std::to_string(ForcingParam.dy) + " grdalpha=" + std::to_string(ForcingParam.grdalpha*180.0 / pi) + " xo=" + std::to_string(ForcingParam.xo) + " xmax=" + std::to_string(ForcingParam.xmax) + " yo=" + std::to_string(ForcingParam.yo) + " ymax=" + std::to_string(ForcingParam.ymax));
 
 
 

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -274,6 +274,9 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 		else
 		{
 			InitDynforcing(gpgpu, XParam, XForcing.Atmp);
+			// Deflault is zero wich is terrible so change to Paref so limitwaves generated at the edge of forcing
+			// Users should insure there forcing extend well beyond the intended model extent.
+			XForcing.Atmp.clampedge = XParam.Paref;
 			//readDynforcing(gpgpu, XParam.totaltime, XForcing.Atmp);
 		}
 	}

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -765,7 +765,7 @@ std::vector<SLTS> readNestfile(std::string ncfile,std::string varname, int hor ,
 
 			WLS.push_back(zsa[0]);
 
-			//printf("zs=%f\\n", zsa[0]);
+			printf("zs=%f\\n", zsa[0]);
 
 			// If true nesting then uu and vv are expected to be present in the netcdf file 
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -134,9 +134,7 @@ Param readparamstr(std::string line, Param param)
 	///////////////////////////////////////////////////////
 	// General parameters
 	//
-	std::vector<std::string> truestr = { "1","true","yes", "on" };
-	std::vector<std::string> falsestr = { "-1","false","no","off" };
-
+	
 	parameterstr = "test";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -215,19 +213,7 @@ Param readparamstr(std::string line, Param param)
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
-
-		//if (parametervalue.compare("true") == 0 || parametervalue.compare("True") == 0)
-		if (case_insensitive_compare(parametervalue, truestr) == 0)
-		{
-			param.conserveElevation = true;
-		}
-		//else if (parametervalue.compare("false") == 0 || parametervalue.compare("False") == 0)
-		else if (case_insensitive_compare(parametervalue, falsestr) == 0)
-		{
-			param.conserveElevation = false;
-		}
-
-
+		param.conserveElevation = readparambool(parametervalue, param.conserveElevation);
 	}
 
 	paramvec = { "wetdryfix","reminstab" };
@@ -235,18 +221,8 @@ Param readparamstr(std::string line, Param param)
 	if (!parametervalue.empty())
 	{
 
-		//if (parametervalue.compare("true") == 0 || parametervalue.compare("True") == 0)
-		if (case_insensitive_compare(parametervalue, truestr) == 0)
-		{
-			param.wetdryfix = true;
-		}
-		//else if (parametervalue.compare("false") == 0 || parametervalue.compare("False") == 0)
-		else if (case_insensitive_compare(parametervalue, falsestr) == 0)
-		{
-			param.wetdryfix = false;
-		}
-
-
+		param.wetdryfix = readparambool(parametervalue, param.wetdryfix);
+		
 	}
 
 
@@ -677,14 +653,8 @@ Param readparamstr(std::string line, Param param)
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		if (case_insensitive_compare(parametervalue, truestr) == 0)
-		{
-			param.rainbnd = true;
-		}
-		if (case_insensitive_compare(parametervalue, falsestr) == 0)
-		{
-			param.rainbnd = false;
-		}
+		param.rainbnd = readparambool(parametervalue, param.rainbnd);
+		
 	}
 		
 
@@ -708,7 +678,7 @@ Param readparamstr(std::string line, Param param)
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		param.spherical = std::stoi(parametervalue);
+		param.spherical = readparambool(parametervalue, param.spherical);
 	}
 
 	parameterstr = "Radius";
@@ -1530,5 +1500,21 @@ bndparam readbndline(std::string parametervalue)
 	return bnd;
 }
 
+bool readparambool(std::string paramstr,bool defaultval)
+{
+	bool out = defaultval;
+	std::vector<std::string> truestr = { "1","true","yes", "on" };
+	std::vector<std::string> falsestr = { "-1","false","no","off" };
 
+	if (case_insensitive_compare(paramstr, truestr) == 0)
+	{
+		out = true;
+	}
+	if (case_insensitive_compare(paramstr, falsestr) == 0)
+	{
+		out = false;
+	}
+
+	return out;
+}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1126,7 +1126,7 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 		//Geo grid
 
 		XParam.delta = XParam.dx * XParam.Radius * pi / 180.0;
-		XParam.engine = 2;
+		//XParam.engine = 2;
 
 		//printf("Using spherical coordinate; delta=%f rad\n", XParam.delta);
 		log("Using spherical coordinate; delta=" + std::to_string(XParam.delta));

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -162,7 +162,7 @@ Param readparamstr(std::string line, Param param)
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
-		std::vector<std::string> buttingerstr = { "b","butt","buttinger","2" };
+		std::vector<std::string> buttingerstr = { "b","butt","buttinger","1" };
 		std::size_t found;
 		bool foo = false;
 		for (int ii = 0; ii < buttingerstr.size(); ii++)
@@ -704,8 +704,8 @@ Param readparamstr(std::string line, Param param)
 	}
 	
 
-	parameterstr = "spherical";
-	parametervalue = findparameter(parameterstr, line);
+	paramvec = {"spherical", "geo"};
+	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
 		param.spherical = std::stoi(parametervalue);
@@ -1154,7 +1154,10 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	else
 	{
 		//Geo grid
+
 		XParam.delta = XParam.dx * XParam.Radius * pi / 180.0;
+		XParam.engine = 2;
+
 		//printf("Using spherical coordinate; delta=%f rad\n", XParam.delta);
 		log("Using spherical coordinate; delta=" + std::to_string(XParam.delta));
 		if (XParam.grdalpha != 0.0)

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -27,7 +27,7 @@ std::vector<std::string> split(const std::string &s, char delim);
 std::string trim(const std::string& str, const std::string& whitespace);
 std::size_t case_insensitive_compare(std::string s1, std::string s2);
 std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> vecstr);
-
+bool readparambool(std::string paramstr, bool defaultval);
 bndparam readbndline(std::string parametervalue);
 
 // End of global definition

--- a/src/Read_netcdf.cu
+++ b/src/Read_netcdf.cu
@@ -286,7 +286,7 @@ void readgridncsize(const std::string ncfilestr, const std::string varstr, int &
 	if (xcoord[0] > xcoord[nx - 1])
 		flipx = true;
 
-	if (ycoord[0] > ycoord[ny - 1])
+	if (ycoord[0] > ycoord[(ny - 1) * nx])
 		flipy = true;
 
 

--- a/src/Read_netcdf.cu
+++ b/src/Read_netcdf.cu
@@ -77,7 +77,7 @@ inline int nc_get_var1_T(int ncid, int varid, const size_t* startp, double * zsa
 
 
 
-void readgridncsize(const std::string ncfilestr, const std::string varstr, int &nx, int &ny, int &nt, double &dx, double &xo, double &yo, double &to, double &xmax, double &ymax, double &tmax, bool & flipx, bool & flipy)
+void readgridncsize(const std::string ncfilestr, const std::string varstr, int &nx, int &ny, int &nt, double &dx, double &dy, double &xo, double &yo, double &to, double &xmax, double &ymax, double &tmax, bool & flipx, bool & flipy)
 {
 	//read the dimentions of grid, levels and time
 	int status;
@@ -234,9 +234,10 @@ void readgridncsize(const std::string ncfilestr, const std::string varstr, int &
 
 	}
 
-	double dxx;
+	double dxx,ddy;
 	//check dx
-	dxx = (xcoord[nx - 1] - xcoord[0]) / (nx - 1.0);
+	dxx = abs(xcoord[nx - 1] - xcoord[0]) / (nx - 1.0);
+	ddy = abs(ycoord[(ny - 1) * nx]- ycoord[0]) / (ny - 1.0);
 	//log("xo=" + std::to_string(xcoord[0])+"; xmax="+ std::to_string(xcoord[nx - 1]) +"; nx="+ std::to_string(nx) +"; dxx=" +std::to_string(dxx));
 	//dyy = (float) abs(ycoord[0] - ycoord[(ny - 1)*nx]) / (ny - 1);
 
@@ -276,6 +277,7 @@ void readgridncsize(const std::string ncfilestr, const std::string varstr, int &
 	}
 
 	dx = dxx;
+	dy = ddy;
 
 	xo = utils::min(xcoord[0], xcoord[nx - 1]);
 	xmax = utils::max(xcoord[0], xcoord[nx - 1]);

--- a/src/Read_netcdf.h
+++ b/src/Read_netcdf.h
@@ -27,7 +27,7 @@ inline int nc_get_var1_T(int ncid, int varid, const size_t* startp, double * zsa
 //int readnczb(int nx, int ny, const std::string ncfile, double*& zb);
 std::string checkncvarname(int ncid, std::string stringA, std::string stringB, std::string stringC, std::string stringD, std::string stringE);
 
-void readgridncsize(const std::string ncfilestr, const std::string varstr, int& nx, int& ny, int& nt, double& dx, double& xo, double& yo, double& to, double& xmax, double& ymax, double& tmax, bool& flipx, bool& flipy);
+void readgridncsize(const std::string ncfilestr, const std::string varstr, int& nx, int& ny, int& nt, double& dx, double& dy, double& xo, double& yo, double& to, double& xmax, double& ymax, double& tmax, bool& flipx, bool& flipy);
 int readvarinfo(std::string filename, std::string Varname, size_t *&ddimU);
 int readnctime(std::string filename, double * &time);
 template <class T> int readncslev1(std::string filename, std::string varstr, size_t indx, size_t indy, size_t indt, bool checkhh, double eps, T * &zsa);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -433,7 +433,7 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 	//T dhdyi = XGrad.dhdy[i];
 	//T dhdymin = XGrad.dhdy[ibot];
 	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
-	T fmu = T(1.0);
+	T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
 
 	T hi = XEv.h[i];
 
@@ -508,7 +508,7 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 
 
 		//solver below also modifies fh and fu
-		dt = hllc(g, delta, epsi, CFL, cm, fmu, hCNl, hCNr, vl, vr, fh, fu);
+		dt = hllc(g, delta, epsi, CFL, cm, fmv, hCNl, hCNr, vl, vr, fh, fu);
 		//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
 
 		if (dt < dtmax[i])
@@ -544,10 +544,10 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 
 		////Flux update
 
-		XFlux.Fhv[i] = fmu * fh;
-		XFlux.Fqvy[i] = fmu * (fu - sl);
-		XFlux.Sv[i] = fmu * (fu - sr);
-		XFlux.Fquy[i] = fmu * fv;
+		XFlux.Fhv[i] = fmv * fh;
+		XFlux.Fqvy[i] = fmv * (fu - sl);
+		XFlux.Sv[i] = fmv * (fu - sr);
+		XFlux.Fquy[i] = fmv * fv;
 	}
 	else
 	{
@@ -628,7 +628,7 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 				//T dhdyi = XGrad.dhdy[i];
 				//T dhdymin = XGrad.dhdy[ibot];
 				T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
-				T fmu = T(1.0);
+				T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
 
 				T hi = XEv.h[i];
 
@@ -703,7 +703,7 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 
 
 					//solver below also modifies fh and fu
-					dt = hllc(g, delta, epsi, CFL, cm, fmu, hCNl, hCNr, vl, vr, fh, fu);
+					dt = hllc(g, delta, epsi, CFL, cm, fmv, hCNl, hCNr, vl, vr, fh, fu);
 					//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
 
 					if (dt < dtmax[i])
@@ -741,10 +741,10 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 
 					////Flux update
 
-					XFlux.Fhv[i] = fmu * fh;
-					XFlux.Fqvy[i] = fmu * (fu - sl);
-					XFlux.Sv[i] = fmu * (fu - sr);
-					XFlux.Fquy[i] = fmu * fv;
+					XFlux.Fhv[i] = fmv * fh;
+					XFlux.Fqvy[i] = fmv * (fu - sl);
+					XFlux.Sv[i] = fmv * (fu - sr);
+					XFlux.Fquy[i] = fmv * fv;
 				}
 				else
 				{

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -41,7 +41,7 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 
 	T epsi = nextafter(T(1.0), T(2.0)) - T(1.0);
 	T eps = T(XParam.eps) + epsi;
-	T delta = calcres(T(XParam.dx), lev);
+	T delta = calcres(T(XParam.delta), lev);
 	T g = T(XParam.g);
 	T CFL = T(XParam.CFL);
 
@@ -222,7 +222,7 @@ template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBl
 	{
 		ib = XBlock.active[ibl];
 		int lev = XBlock.level[ib];
-		delta = calcres(T(XParam.dx), lev);
+		delta = calcres(T(XParam.delta), lev);
 
 		// neighbours for source term
 
@@ -420,7 +420,7 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 
 	T epsi = nextafter(T(1.0), T(2.0)) - T(1.0);
 	T eps = T(XParam.eps) + epsi;
-	T delta = calcres(T(XParam.dx), lev);
+	T delta = calcres(T(XParam.delta), lev);
 	T g = T(XParam.g);
 	T CFL = T(XParam.CFL);
 
@@ -613,7 +613,7 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 
 		lev = XBlock.level[ib];
 
-		delta = calcres(T(XParam.dx), lev);
+		delta = calcres(T(XParam.delta), lev);
 
 		for (int iy = 0; iy < (XParam.blkwidth + XParam.halowidth); iy++)
 		{

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -48,12 +48,12 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 	int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 	int ileft = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
 
-
+	T ybo = T(XParam.yo + XBlock.yo[ib]);
 
 
 	//T dhdxi = XGrad.dhdx[i];
 	//T dhdxmin = XGrad.dhdx[ileft];
-	T cm = T(1.0);
+	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 	T fmu = T(1.0);
 
 	T hi = XEv.h[i];
@@ -241,12 +241,12 @@ template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBl
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int ileft = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
 
-
+				T ybo = T(XParam.yo + XBlock.yo[ib]);
 
 
 				//T dhdxi = XGrad.dhdx[i];
 				//T dhdxmin = XGrad.dhdx[ileft];
-				T cm = T(1.0);
+				T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 				T fmu = T(1.0);
 
 				T hi = XEv.h[i];
@@ -428,11 +428,11 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 	int ibot = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
 
 
-
+	T ybo = T(XParam.yo + XBlock.yo[ib]);
 
 	//T dhdyi = XGrad.dhdy[i];
 	//T dhdymin = XGrad.dhdy[ibot];
-	T cm = T(1.0);
+	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 	T fmu = T(1.0);
 
 	T hi = XEv.h[i];
@@ -622,12 +622,12 @@ template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBl
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int ibot = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
 
-
+				T ybo = T(XParam.yo + XBlock.yo[ib]);
 
 
 				//T dhdyi = XGrad.dhdy[i];
 				//T dhdymin = XGrad.dhdy[ibot];
-				T cm = T(1.0);
+				T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
 				T fmu = T(1.0);
 
 				T hi = XEv.h[i];

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -236,8 +236,8 @@ void AllocateTEX(int nx, int ny, TexSetP& Tex, float* input)
 	memset(&Tex.texDesc, 0, sizeof(cudaTextureDesc));
 	Tex.texDesc.addressMode[0] = cudaAddressModeClamp;
 	Tex.texDesc.addressMode[1] = cudaAddressModeClamp;
-	//Tex.texDesc.filterMode = cudaFilterModeLinear;
-	Tex.texDesc.filterMode = cudaFilterModePoint;
+	Tex.texDesc.filterMode = cudaFilterModeLinear;
+	//Tex.texDesc.filterMode = cudaFilterModePoint;
 	Tex.texDesc.normalizedCoords = false;
 
 	memset(&Tex.resDesc, 0, sizeof(cudaResourceDesc));

--- a/src/Spherical.cu
+++ b/src/Spherical.cu
@@ -65,7 +65,7 @@ __host__ __device__  T haversin(T Radius, T lon1, T lat1, T lon2, T lat2)
 
 	c = 2.0 * atan2(sqrt(a), sqrt(1.0 - a));
 
-	return Radius*c
+	return Radius * c;
 
 }
 
@@ -87,7 +87,8 @@ __host__ __device__  T spharea(T Radius, T lon, T lat, T dx)
 
 	T Area = T(0.5) * (a * b + c * b);
 
-	return Area
+	return Area;
 
 }
-
+template __host__ __device__  double spharea(double Radius, double lon, double lat, double dx);
+template __host__ __device__  float spharea(float Radius, float lon, float lat, float dx);

--- a/src/Spherical.cu
+++ b/src/Spherical.cu
@@ -2,7 +2,10 @@
 
 
 
-
+/*! \fn T calcCM(T Radius, T delta, T yo, int iy)
+* Scale factor for y face length (x face lengh scale is always 1 in spherical model assuming that lat long are entered)
+* 
+*/
 template <class T> 
 __host__ __device__ T calcCM(T Radius, T delta, T yo, int iy)
 {
@@ -40,5 +43,51 @@ __host__ __device__  T calcFM(T Radius, T delta, T yo, T iy)
 template __host__ __device__ double calcFM(double Radius, double delta, double yo, double iy);
 template __host__ __device__ float calcFM(float Radius, float delta, float yo, float iy);
 
+/*! \fn  T haversin(T Radius, T lon1, T lat1, T lon2, T lat2)
+* Classic haversin function 
+* The function is too slow to use directly in BG_flood engine but is more usable (i.e. naive) for model setup
+* 
+*/
+template <class T>
+__host__ __device__  T haversin(T Radius, T lon1, T lat1, T lon2, T lat2)
+{
+	T phi1, phi2, dphi, dlbda, a, c;
+	dphi = (lat2 - lat1) * T(pi / 180.0);
+	dlbda = (lon2 -lon1) * T(pi / 180.0);
 
+	phi1 = lat1 * T(pi / 180.0);
+	phi2 = lat2 * T(pi / 180.0);
+
+	T sindphid2 = sin(dphi / 2.0);
+	T sindlbdad2 = sin(dlbda / 2.0);
+	
+	a = sindphid2 * sindphid2 + cos(phi1) * cos(phi2) * sindlbdad2 * sindlbdad2;
+
+	c = 2.0 * atan2(sqrt(a), sqrt(1.0 - a));
+
+	return Radius*c
+
+}
+
+template <class T>
+__host__ __device__  T spharea(T Radius, T lon, T lat, T dx)
+{
+	T lon1, lon2, lat1, lat2;
+	lon1 = lon - T(0.5) * dx;
+	lon2 = lon + T(0.5) * dx;
+
+	lat1 = lat - T(0.5) * dx;
+	lat2 = lat + T(0.5) * dx;
+
+	T a, b, c;
+
+	a = haversin(Radius, lon1, lat1, lon2, lat1);
+	c = haversin(Radius, lon1, lat2, lon2, lat2);
+	b = haversin(Radius, lon1, lat1, lon1, lat2);
+
+	T Area = T(0.5) * (a * b + c * b);
+
+	return Area
+
+}
 

--- a/src/Spherical.cu
+++ b/src/Spherical.cu
@@ -1,0 +1,44 @@
+#include "Spherical.h"
+
+
+
+
+template <class T> 
+__host__ __device__ T calcCM(T Radius, T delta, T yo, int iy)
+{
+	T y = yo + (iy+0.5) * delta / Radius * T(180.0 / pi);
+	// THis should be the y of the face so fo the v face you need to remove 0.5*delta
+
+	T phi = y * T(pi / 180.0);
+
+	T dphi = delta / (T(2.0 * Radius));// dy*0.5f*pi/180.0f;
+
+	T cm = (sin(phi + dphi) - sin(phi - dphi)) / (2.0 * dphi);
+
+	return cm;
+}
+template __host__ __device__ double calcCM(double Radius, double delta, double yo, int iy);
+template __host__ __device__ float calcCM(float Radius, float delta, float yo, int iy);
+
+
+
+template <class T> 
+__host__ __device__  T calcFM(T Radius, T delta, T yo, T iy)
+{
+	T dy = delta / Radius * T(180.0 / pi);
+	T y = yo + iy * dy;
+	// THis should be the y of the face so fo the v face you need to remove 0.5*delta
+
+	T phi = y * T(pi / 180.0);
+
+	//T dphi = delta / (T(2.0 * Radius));// dy*0.5f*pi/180.0f;
+
+	T fmu = cos(phi);
+
+	return fmu;
+}
+template __host__ __device__ double calcFM(double Radius, double delta, double yo, double iy);
+template __host__ __device__ float calcFM(float Radius, float delta, float yo, float iy);
+
+
+

--- a/src/Spherical.h
+++ b/src/Spherical.h
@@ -11,6 +11,7 @@
 
 template <class T> __host__ __device__ T calcCM(T Radius, T delta, T yo, int iy);
 template <class T> __host__ __device__  T calcFM(T Radius, T delta, T yo, T iy);
+template <class T> __host__ __device__  T spharea(T Radius, T lon, T lat, T dx);
 
 
 #endif

--- a/src/Spherical.h
+++ b/src/Spherical.h
@@ -1,0 +1,16 @@
+#ifndef SPHERICAL_H
+#define SPHERICAL_H
+
+#include "General.h"
+#include "Param.h"
+#include "Arrays.h"
+#include "Forcing.h"
+#include "MemManagement.h"
+#include "Util_CPU.h"
+#include "Kurganov.h"
+
+template <class T> __host__ __device__ T calcCM(T Radius, T delta, T yo, int iy);
+template <class T> __host__ __device__  T calcFM(T Radius, T delta, T yo, T iy);
+
+
+#endif

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -700,7 +700,7 @@ template <class T> bool Rivertest(T zsnit, int gpu)
 	{
 		//printf("bl=%d\tblockxo[bl]=%f\tblockyo[bl]=%f\n", bl, blockxo[bl], blockyo[bl]);
 		int ib = XModel.blocks.active[ibl];
-		delta = calcres(T(XParam.dx), XModel.blocks.level[ib]);
+		delta = calcres(T(XParam.delta), XModel.blocks.level[ib]);
 
 
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
@@ -751,7 +751,7 @@ template <class T> bool Rivertest(T zsnit, int gpu)
 			{
 				//printf("bl=%d\tblockxo[bl]=%f\tblockyo[bl]=%f\n", bl, blockxo[bl], blockyo[bl]);
 				int ib = XModel.blocks.active[ibl];
-				delta = calcres(T(XParam.dx), XModel.blocks.level[ib]);
+				delta = calcres(T(XParam.delta), XModel.blocks.level[ib]);
 
 
 				for (int iy = 0; iy < XParam.blkwidth; iy++)
@@ -969,7 +969,7 @@ template <class T> bool MassConserveSteepSlope(T zsnit, int gpu)
 	{
 		//printf("bl=%d\tblockxo[bl]=%f\tblockyo[bl]=%f\n", bl, blockxo[bl], blockyo[bl]);
 		int ib = XModel.blocks.active[ibl];
-		delta = calcres(T(XParam.dx), XModel.blocks.level[ib]);
+		delta = calcres(T(XParam.delta), XModel.blocks.level[ib]);
 
 
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
@@ -1021,7 +1021,7 @@ template <class T> bool MassConserveSteepSlope(T zsnit, int gpu)
 			{
 				//printf("bl=%d\tblockxo[bl]=%f\tblockyo[bl]=%f\n", bl, blockxo[bl], blockyo[bl]);
 				int ib = XModel.blocks.active[ibl];
-				delta = calcres(T(XParam.dx), XModel.blocks.level[ib]);
+				delta = calcres(T(XParam.delta), XModel.blocks.level[ib]);
 
 
 				for (int iy = 0; iy < XParam.blkwidth; iy++)
@@ -1225,15 +1225,15 @@ template<class T> bool CPUGPUtest(Param XParam, Model<T> XModel, Model<T> XModel
 
 	//GPU gradients
 
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.evolv.h, XModel_g.grad.dhdx, XModel_g.grad.dhdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.evolv.h, XModel_g.grad.dhdx, XModel_g.grad.dhdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.evolv.zs, XModel_g.grad.dzsdx, XModel_g.grad.dzsdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.evolv.zs, XModel_g.grad.dzsdx, XModel_g.grad.dzsdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.evolv.u, XModel_g.grad.dudx, XModel_g.grad.dudy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.evolv.u, XModel_g.grad.dudx, XModel_g.grad.dudy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.evolv.v, XModel_g.grad.dvdx, XModel_g.grad.dvdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.evolv.v, XModel_g.grad.dvdx, XModel_g.grad.dvdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	std::string gradst[8] = { "dhdx","dzsdx","dudx","dvdx","dhdy","dzsdy","dudy","dvdy" };
@@ -1780,7 +1780,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		int ib = XModel.blocks.active[ibl];
-		T delta = calcres(XParam.dx, XModel.blocks.level[ib]);
+		T delta = calcres(XParam.delta, XModel.blocks.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < (XParam.blkwidth); ix++)
@@ -1801,7 +1801,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		int ib = XModel.blocks.active[ibl];
-		T delta = calcres(XParam.dx, XModel.blocks.level[ib]);
+		T delta = calcres(XParam.delta, XModel.blocks.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < (XParam.blkwidth); ix++)
@@ -2146,7 +2146,7 @@ template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		int ib = XModel.blocks.active[ibl];
-		T delta = calcres(XParam.dx, XModel.blocks.level[ib]);
+		T delta = calcres(XParam.delta, XModel.blocks.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < (XParam.blkwidth); ix++)
@@ -2167,7 +2167,7 @@ template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		int ib = XModel.blocks.active[ibl];
-		T delta = calcres(XParam.dx, XModel.blocks.level[ib]);
+		T delta = calcres(XParam.delta, XModel.blocks.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < (XParam.blkwidth); ix++)
@@ -2356,7 +2356,7 @@ template <class T> void testButtingerX(Param XParam, int ib, int ix, int iy, Mod
 	int ileft = memloc(XParam.halowidth, XParam.blkmemwidth, ix - 1, iy, ib);
 
 	int lev = XModel.blocks.level[ib];
-	T delta = calcres(T(XParam.dx), lev);
+	T delta = calcres(T(XParam.delta), lev);
 
 	T g = T(XParam.g);
 	T CFL = T(XParam.CFL);
@@ -2504,7 +2504,7 @@ template <class T> void testkurganovX(Param XParam, int ib, int ix, int iy, Mode
 	int ileft = memloc(XParam.halowidth, XParam.blkmemwidth, ix - 1, iy, ib);
 
 	int lev = XModel.blocks.level[ib];
-	T delta = calcres(T(XParam.dx), lev);
+	T delta = calcres(T(XParam.delta), lev);
 
 	T g = T(XParam.g);
 	T CFL = T(XParam.CFL);
@@ -2717,7 +2717,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		int ib = XModel.blocks.active[ibl];
-		T delta = calcres(XParam.dx, XModel.blocks.level[ib]);
+		T delta = calcres(XParam.delta, XModel.blocks.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < (XParam.blkwidth); ix++)
@@ -2738,7 +2738,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
 		int ib = XModel.blocks.active[ibl];
-		T delta = calcres(XParam.dx, XModel.blocks.level[ib]);
+		T delta = calcres(XParam.delta, XModel.blocks.level[ib]);
 		for (int iy = 0; iy < XParam.blkwidth; iy++)
 		{
 			for (int ix = 0; ix < (XParam.blkwidth); ix++)
@@ -2853,6 +2853,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 	XParam.yo = 0;
 	XParam.ymax = 0.196;
 	XParam.dx=(XParam.ymax - XParam.yo) / (1 << 1);
+	XParam.delta = XParam.dx;
 	double Xmax_exp = 28.0; //minimum Xmax position (adjust to have a "full blocks" config)
 	//Calculating xmax to have full blocs with at least a full block behaving as a reservoir
 	XParam.xmax = XParam.xo + (16 * XParam.dx) * std::ceil((Xmax_exp - XParam.xo) / (16 * XParam.dx)) + (16 * XParam.dx);
@@ -3194,7 +3195,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 
 			//Calculation of the flux at the bottom of the slope (x=24m)
 			ib = XModel.blocks.active[bl];
-			delta = calcres(T(XParam.dx), XModel.blocks.level[ib]);
+			delta = calcres(T(XParam.delta), XModel.blocks.level[ib]);
 
 			for (int iy = 0; iy < XParam.blkwidth; iy++)
 			{

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -863,7 +863,7 @@ template <class T> bool MassConserveSteepSlope(T zsnit, int gpu)
 	XForcing.Bathy[0].ny = 3;
 
 	XForcing.Bathy[0].dx = 1.0;
-
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
 	AllocateCPU(XForcing.Bathy[0].nx, XForcing.Bathy[0].ny, XForcing.Bathy[0].val);

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4270,6 +4270,8 @@ template <class T> int Testzbinit(Param XParam, Forcing<float> XForcing, Model<T
 
 	//InitSave2Netcdf(XParam, XModel);
 
+	return 1;
+
 }
 
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4203,7 +4203,7 @@ template <class T> int TestFirsthalfstep(Param XParam, Forcing<float> XForcing, 
 }
 
 
-template <class T> int Testzbinit(Param XParam, Forcing<float> XForcing, Model<T> XModel, Model<T> XModel_g)
+template <class T> void Testzbinit(Param XParam, Forcing<float> XForcing, Model<T> XModel, Model<T> XModel_g)
 {
 
 	// Setup Model(s)
@@ -4270,7 +4270,7 @@ template <class T> int Testzbinit(Param XParam, Forcing<float> XForcing, Model<T
 
 	//InitSave2Netcdf(XParam, XModel);
 
-	return 1;
+	
 
 }
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -378,6 +378,7 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 	XForcing.Bathy[0].ny = 3;
 
 	XForcing.Bathy[0].dx = 1.0;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
@@ -631,6 +632,7 @@ template <class T> bool Rivertest(T zsnit, int gpu)
 	XForcing.Bathy[0].ny = 3;
 
 	XForcing.Bathy[0].dx = 1.0;
+	XForcing.Bathy[0].dy = 1.0;
 
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
@@ -1495,6 +1497,7 @@ template <class T> bool ThackerLakeAtRest(Param XParam,T zsinit)
 	XForcing.Bathy[0].ny = 64;
 
 	XForcing.Bathy[0].dx = 126.0;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
@@ -2011,7 +2014,7 @@ template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound
 	XForcing.Bathy[0].ny = 32;
 
 	XForcing.Bathy[0].dx = 1.0;
-
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 	T x, y;
 	T center = T(31.0);
 
@@ -2668,6 +2671,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 	XForcing.Bathy[0].ny = 3;
 
 	XForcing.Bathy[0].dx = 1.0;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
@@ -2905,6 +2909,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 	XForcing.Bathy[0].xmax = 28.0;
 	XForcing.Bathy[0].ymax = 1.0;
 	XForcing.Bathy[0].dx = 0.1;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 	XForcing.Bathy[0].nx = ftoi((XForcing.Bathy[0].xmax - XForcing.Bathy[0].xo) / XForcing.Bathy[0].dx + 1);
 	XForcing.Bathy[0].ny = ftoi((XForcing.Bathy[0].ymax - XForcing.Bathy[0].yo) / XForcing.Bathy[0].dx + 1);
 
@@ -3307,6 +3312,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 	XForcing.Bathy[0].ny = 501;
 
 	XForcing.Bathy[0].dx = 0.1;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
@@ -3517,6 +3523,7 @@ template <class T> bool Rainlossestest(T zsinit, int gpu, float alpha)
 	XForcing.Bathy[0].ny = 3;
 
 	XForcing.Bathy[0].dx = 1.0;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
@@ -4296,6 +4303,7 @@ template <class T> Forcing<float> MakValleyBathy(Param XParam, T slope, bool bot
 	XForcing.Bathy[0].ny = 32;
 
 	XForcing.Bathy[0].dx = 1.0;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
 	T x, y;
 	T center = T(10.5);

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -3722,7 +3722,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 
 	// Record the start event
 	cudaEventRecord(startA, NULL);
-	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
+	gradient << < gridDim, blockDim, 0 >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.zb, XModel_g.grad.dzbdx, XModel_g.grad.dzbdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	// Record the stop event
@@ -3745,7 +3745,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 
 	// Record the start event
 	cudaEventRecord(startB, NULL);
-	gradientSM << < gridDim, blockDim >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.zb, XModel_g.grad.dzsdx, XModel_g.grad.dzsdy);
+	gradientSM << < gridDim, blockDim >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.zb, XModel_g.grad.dzsdx, XModel_g.grad.dzsdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	// Record the stop event
@@ -3768,7 +3768,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 
 	// Record the start event
 	cudaEventRecord(startC, NULL);
-	gradientSMC << < gridDim, blockDim >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.dx, XModel_g.zb, XModel_g.grad.dhdx, XModel_g.grad.dhdy);
+	gradientSMC << < gridDim, blockDim >> > (XParam.halowidth, XModel_g.blocks.active, XModel_g.blocks.level, (T)XParam.theta, (T)XParam.delta, XModel_g.zb, XModel_g.grad.dhdx, XModel_g.grad.dhdy);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
 	// Record the stop event

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -209,7 +209,7 @@ template <class T> __host__ void InjectRiverCPU(Param XParam, River XRiver, T qn
 
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 
-				T delta = calcres(T(XParam.dx), XBlock.level[ib]);
+				//T delta = calcres(T(XParam.dx), XBlock.level[ib]);
 
 				//T x = XParam.xo + XBlock.xo[ib] + ix * delta;
 				//T y = XParam.yo + XBlock.yo[ib] + iy * delta;

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -693,7 +693,7 @@ template <class T> __device__ T interp2BUQ(T x, T y, TexSetP Forcing)
 	T read;
 	
 	float ivw = float((x - T(Forcing.xo)) / T(Forcing.dx) + T(0.5));
-	float jvw = float((y - T(Forcing.yo)) / T(Forcing.dx) + T(0.5));
+	float jvw = float((y - T(Forcing.yo)) / T(Forcing.dy) + T(0.5));
 	read = tex2D<float>(Forcing.tex, ivw, jvw);
 	
 	return read;

--- a/src/Util_CPU.cu
+++ b/src/Util_CPU.cu
@@ -141,19 +141,11 @@ template float BarycentricInterpolation(float q1, float x1, float y1, float q2, 
 template double BarycentricInterpolation(double q1, double x1, double y1, double q2, double x2, double y2, double q3, double x3, double y3, double x, double y);
 
 
-template <class T>
-__host__ __device__ T calcresold(T dx, int level)
-{
-	return level < 0 ? dx * (1 << abs(level)) : dx / (1 << level);
-	//should be 1<< -level
-}
-template __host__ __device__ double calcresold<double>(double dx, int level);
-template __host__ __device__ float calcresold<float>(float dx, int level);
 
 template <class T>
 __host__ __device__ T calcres(T dx, int level)
 {
-	return  dx / (1 << level);
+	return  level < 0 ? dx * (1 << abs(level)) : dx / (1 << level);
 	//should be 1<< -level
 }
 template __host__ __device__ double calcres<double>(double dx, int level);
@@ -162,7 +154,7 @@ template __host__ __device__ float calcres<float>(float dx, int level);
 template <class T>
 __host__ __device__ T calcres(Param XParam, T dx, int level)
 {
-	T ddx = dx * (1 << level); // here use dx as the cue for the compiler to use the float or double version of this function
+	T ddx = calcres(dx, level); // here use dx as the cue for the compiler to use the float or double version of this function
 	
 	if (XParam.spherical)
 	{

--- a/src/Util_CPU.cu
+++ b/src/Util_CPU.cu
@@ -142,14 +142,38 @@ template double BarycentricInterpolation(double q1, double x1, double y1, double
 
 
 template <class T>
-__host__ __device__ T calcres(T dx, int level)
+__host__ __device__ T calcresold(T dx, int level)
 {
 	return level < 0 ? dx * (1 << abs(level)) : dx / (1 << level);
 	//should be 1<< -level
 }
+template __host__ __device__ double calcresold<double>(double dx, int level);
+template __host__ __device__ float calcresold<float>(float dx, int level);
 
+template <class T>
+__host__ __device__ T calcres(T dx, int level)
+{
+	return  dx / (1 << level);
+	//should be 1<< -level
+}
 template __host__ __device__ double calcres<double>(double dx, int level);
 template __host__ __device__ float calcres<float>(float dx, int level);
+
+template <class T>
+__host__ __device__ T calcres(Param XParam, T dx, int level)
+{
+	T ddx = dx * (1 << level); // here use dx as the cue for the compiler to use the float or double version of this function
+	
+	if (XParam.spherical)
+	{
+		ddx = ddx * XParam.Radius * pi / T(180.0);
+	}
+		
+	return ddx;
+	//should be 1<< -level
+}
+template __host__ __device__ double calcres<double>(Param XParam, double dx, int level);
+template __host__ __device__ float calcres<float>(Param XParam, float dx, int level);
 
 template <class T> __host__ __device__ T minmod2(T theta, T s0, T s1, T s2)
 {

--- a/src/Write_txtlog.cpp
+++ b/src/Write_txtlog.cpp
@@ -103,6 +103,7 @@ void SaveParamtolog(Param XParam)// need to bring in Xforcing info too!
 	//write_text_to_log_file("nx = " + std::to_string(XParam.nx) + ";");
 	//write_text_to_log_file("ny = " + std::to_string(XParam.ny) + ";");
 	write_text_to_log_file("dx = " + std::to_string(XParam.dx) + ";");
+	write_text_to_log_file("delta = " + std::to_string(XParam.delta) + ";");
 	write_text_to_log_file("grdalpha = " + std::to_string(XParam.grdalpha*180.0 / pi) + ";");
 	write_text_to_log_file("xo = " + std::to_string(XParam.xo) + ";");
 	write_text_to_log_file("yo = " + std::to_string(XParam.yo) + ";");


### PR DESCRIPTION
# Fix Spherical grid correction
Spherical grid capability has been shaky!. Added to a previous branch (#78) still had a serious bug. This may have been solved in the development branch. 
This branch tris to bring it all together and resolve any remaining bugs.

## Basework
 - [x] Modify Calcres for spherical grids
 - [x]  Add cm and fmv correction to Kurganov scheme
 - [x] Add cm and fmv correction to Buttinger scheme
 - [x]  Add spherical coordinate correction to the advance scheme
 - [x]  Add fix for adaptive BUQ
 - [x] Add delta reference to new gradient
 - [x] Make spherical/geo keyword a bool input
 - [x] Double check validity of Gradients
 - [x] Check which engine/forcing can/cannot use spherical grid
 - [x] Add limiter for latitude to stay between -90/90
 - [x] Hotstarting Pressure and adding inv. baro pressure to boundary water level forcing

## Test
 - [x] Lake-at-rest with spherical adaptive grid
 
## Demo
- [x] Tsunami Comparison of projected model and spherical model
- [x] storm surgeComparison of projected model and spherical model
- [x] rain Comparison of projected model and spherical model
- [x] rivers Comparison of projected model and spherical model