### PR TITLE
Netcdf a100

### DIFF
--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -59,6 +59,15 @@ struct AdvanceP
 };
 
 
+struct outP
+{
+	float* z;
+	short* z_s;
+	int level;
+	double xmin, xmax, ymin, ymax;
+};
+
+
 struct maskinfo 
 {
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -207,6 +207,9 @@ public:
 	std::string reftime = ""; // Reference time string as yyyy-mm-ddTHH:MM:SS
 	std::string crs_ref = "no_crs"; //"PROJCS[\"NZGD2000 / New Zealand Transverse Mercator 2000\",GEOGCS[\"NZGD2000\",DATUM[\"New_Zealand_Geodetic_Datum_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4167\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",173],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",1600000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1],AXIS[\"Northing\",NORTH],AXIS[\"Easting\",EAST],AUTHORITY[\"EPSG\",\"2193\"]]";
 
+
+	bool savebyblk=true;
+
 };
 
 

--- a/src/Poly.cu
+++ b/src/Poly.cu
@@ -212,7 +212,7 @@ Polygon CounterCWPoly(Polygon Poly)
 	if (sum > 0.0)
 	{
 		log(" Reversing Polygon handedness");
-		for (int i = Poly.vertices.size(); i > 0; i--)
+		for (int i = Poly.vertices.size()-1; i > 0; i--)
 		{
 			//
 			

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -736,7 +736,7 @@ Param readparamstr(std::string line, Param param)
 		param.crs_ref = parametervalue;
 	}
 
-	paramvec = { "savebyblk", "writebyblk","saveperblk", "writeperblk" };
+	paramvec = { "savebyblk", "writebyblk","saveperblk", "writeperblk","savebyblock", "writebyblock","saveperblock", "writeperblock" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -736,6 +736,13 @@ Param readparamstr(std::string line, Param param)
 		param.crs_ref = parametervalue;
 	}
 
+	paramvec = { "savebyblk", "writebyblk","saveperblk", "writeperblk" };
+	parametervalue = findparameter(paramvec, line);
+	if (!parametervalue.empty())
+	{
+		param.savebyblk = readparambool(parametervalue, param.savebyblk);
+	}
+
 	return param;
 }
 

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -746,11 +746,11 @@ template <class T> void deformstep(Param XParam, Loop<T> XLoop, std::vector<defo
 
 			if (XParam.GPUDEVICE < 0)
 			{
-				AddDeformCPU(XParam, XModel.blocks, deform[nd], scale, XModel.evolv.zs, XModel.zb);
+				AddDeformCPU(XParam, XModel.blocks, deform[nd], XModel.evolv, scale, XModel.zb);
 			}
 			else
 			{
-				AddDeformGPU <<<gridDim, blockDim, 0 >>> (XParam, XModel.blocks, deform[nd], scale, XModel.evolv.zs, XModel.zb);
+				AddDeformGPU <<<gridDim, blockDim, 0 >>> (XParam, XModel.blocks, deform[nd], XModel.evolv, scale, XModel.zb);
 				CUDA_CHECK(cudaDeviceSynchronize());
 			}
 
@@ -779,7 +779,7 @@ template <class T> void deformstep(Param XParam, Loop<T> XLoop, std::vector<defo
 }
 
 
-template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, T scale, T* zs, T* zb)
+template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, EvolvingP<T> XEv, T scale, T* zb)
 {
 	unsigned int ix = threadIdx.x;
 	unsigned int iy = threadIdx.y;
@@ -801,7 +801,7 @@ template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, 
 	//	printf("x=%f, y=%f, def=%f\n ", x, y, def);
 	//}
 
-	zss = zs[i] + def * scale;
+	zss = XEv.zs[i] + def * scale;
 	if (defmap.iscavity == true)
 	{
 		zbb = min(zss, zb[i]);
@@ -811,7 +811,8 @@ template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, 
 		zbb = zb[i] + def * scale;
 	}
 
-	zs[i] = zss;
+	XEv.h[i] = zss - zbb;
+	XEv.zs[i] = zss;
 	zb[i] = zbb;
 
 	//zs[i] = zs[i] + def * scale;
@@ -821,7 +822,7 @@ template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, 
 
 }
 
-template <class T> __host__ void AddDeformCPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, T scale, T* zs, T* zb)
+template <class T> __host__ void AddDeformCPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, EvolvingP<T> XEv, T scale, T* zb)
 {
 	int ib;
 	
@@ -846,7 +847,7 @@ template <class T> __host__ void AddDeformCPU(Param XParam, BlockP<T> XBlock, de
 
 				def = interp2BUQ(x, y, defmap);
 
-				zss = zs[i] + def * scale;
+				zss = XEv.zs[i] + def * scale;
 				if (defmap.iscavity == true)
 				{
 					zbb = min(zss, zb[i]);
@@ -856,7 +857,8 @@ template <class T> __host__ void AddDeformCPU(Param XParam, BlockP<T> XBlock, de
 					zbb = zb[i] + def * scale;
 				}
 
-				zs[i] = zss;
+				XEv.zs[i] = zss;
+				XEv.h[i] = zss - zbb;
 				zb[i] = zbb;
 			}
 		}

--- a/src/Updateforcing.h
+++ b/src/Updateforcing.h
@@ -36,7 +36,7 @@ template <class T> __host__ void AddRiverForcing(Param XParam, Loop<T> XLoop, st
 template <class T> void deformstep(Param XParam, Loop<T> XLoop, std::vector<deformmap<float>> deform, Model<T> XModel, Model<T> XModel_g);
 
 template <class T> __global__ void InjectRiverGPU(Param XParam, River XRiver, T qnow, int* Riverblks, BlockP<T> XBlock, AdvanceP<T> XAdv);
-template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, T scale, T* zs, T* zb);
+template <class T> __global__ void  AddDeformGPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, EvolvingP<T> XEv, T scale, T* zb);
 
 
 #endif

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -957,7 +957,7 @@ template <class T> void defncvarBUQlev(Param XParam, int* activeblk, int* level,
 	//for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	//{
 		bl = activeblkzone[ibl];
-		lev = level[bl];
+		int lev = level[bl];
 
 		double  xxmin, yymin;
 		int nxlev, nylev;

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -1480,7 +1480,16 @@ template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
 			{
 				std::string varstr = XParam.outvars[ivar];
-				defncvarBUQlev(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr,XModel.Outvarlongname[varstr],XModel.Outvarstdname[varstr],XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
+				if (XParam.savebyblk)
+				{
+					defncvarBUQ(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr, XModel.Outvarlongname[varstr], XModel.Outvarstdname[varstr], XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
+
+				}
+				else
+				{
+					defncvarBUQlev(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr, XModel.Outvarlongname[varstr], XModel.Outvarstdname[varstr], XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
+
+				}
 			}
 		}
 	}
@@ -1499,7 +1508,14 @@ template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T> XModel)
 			writenctimestep(XModel.blocks.outZone[o].outname, XLoop.totaltime);
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
 			{
-				writencvarstepBUQlev(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				if (XParam.savebyblk)
+				{
+					writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				}
+				else
+				{
+					writencvarstepBUQlev(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				}
 			}
 		}
 	}

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -616,7 +616,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 		int shuffle = 1;
 		int deflate = 1;        // This switches compression on (1) or off (0).
 		int deflate_level = 9;  // This is the compression level in range 1 (less) - 9 (more).
-		// nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
+		nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
 
 	}
 	// End definition
@@ -915,6 +915,203 @@ extern "C" void writenctimestep(std::string outfile, double totaltime)
 	if (status != NC_NOERR) handle_ncerror(status);
 }
 
+
+template <class T> void writencvarstepBUQlev(Param XParam, int vdim, int* activeblk, int* level, T* blockxo, T* blockyo, std::string varst, T* var, outzoneB Xzone)
+{
+	int status, ncid, recid, var_id;
+	static size_t nrec;
+	short* varblk_s;
+	float* varblk;
+	//int nx, ny;
+	//int dimids[NC_MAX_VAR_DIMS];
+	//size_t  *ddim, *start, *count;
+	//XParam.outfile.c_str()
+
+	static size_t start2D[] = { 0, 0 }; // start at first value 
+	//static size_t count2D[] = { ny, nx };
+	static size_t count2D[] = { (size_t)XParam.blkwidth, (size_t)XParam.blkwidth };
+
+	static size_t start3D[] = { 0, 0, 0 }; // start at first value // This is updated to nrec-1 further down
+	//static size_t count3D[] = { 1, ny, nx };
+	static size_t count3D[] = { 1, (size_t)XParam.blkwidth, (size_t)XParam.blkwidth };
+
+	int smallnc = XParam.smallnc;
+	float scalefactor = XParam.scalefactor;
+	float addoffset = XParam.addoffset;
+
+	status = nc_open(Xzone.outname.c_str(), NC_WRITE, &ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+	//read id from time dimension
+	status = nc_inq_unlimdim(ncid, &recid);
+	if (status != NC_NOERR) handle_ncerror(status);
+	status = nc_inq_dimlen(ncid, recid, &nrec);
+	if (status != NC_NOERR) handle_ncerror(status);
+
+	start3D[0] = nrec - 1;
+
+
+	// Create empty array for each levels
+	std::vector<outP> varlayers;
+	int nx, ny;
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		outP outlev;
+
+		Calcnxnyzone(XParam, levi, nx, ny, Xzone);
+		outlev.z = (float*)malloc(nx * ny * sizeof(float));
+		if (smallnc > 0)
+		{
+
+			outlev.z_s = (short*)malloc(nx * ny * sizeof(short));
+		}
+
+		varlayers.push_back(outlev);
+
+
+	}
+
+	std::string xxname, yyname, varname, sign;
+	std::vector<int> activeblkzone = Calcactiveblockzone(XParam, activeblk, Xzone);
+
+
+	int lev, bl;
+	for (int ibl = 0; ibl < Xzone.nblk; ibl++)
+	{
+		//bl = activeblk[Xzone.blk[ibl]];
+	//for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	//{
+		bl = activeblkzone[ibl];
+		lev = level[bl];
+		
+		double  xxmin, yymin;
+		int nxlev, nylev;
+		//double xxmax, yymax;
+		double initdx = calcres(XParam.dx, XParam.initlevel);
+
+		int io, jo;
+		//xxmax = Xzone.xmax - calcres(XParam.dx, lev) / 2.0;
+		//yymax = Xzone.ymax - calcres(XParam.dx, lev) / 2.0;
+
+		int levindex = (lev - Xzone.minlevel);
+
+		Calcnxnyzone(XParam, lev, nxlev, nylev, Xzone);
+		xxmin = Xzone.xo + calcres(XParam.dx, lev) / 2.0;
+		yymin = Xzone.yo + calcres(XParam.dx, lev) / 2.0;
+
+		
+
+		jo = round((XParam.yo + blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+		io = round((XParam.xo + blockxo[bl] - xxmin) / calcres(XParam.dx, lev));
+		
+
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			for (int i = 0; i < XParam.blkwidth; i++)
+			{
+				int n = (i + XParam.halowidth + XParam.outishift) + (j + XParam.halowidth + XParam.outjshift) * XParam.blkmemwidth + bl * XParam.blksize;
+				int r = (io + i) + (jo + j) * nxlev;
+				if (smallnc > 0)
+				{
+					// packed_data_value = nint((unpacked_data_value - add_offset) / scale_factor)
+					varlayers[levindex].z_s[r] = (short)round((var[n] - addoffset) / scalefactor);
+				}
+				else
+				{
+					varlayers[levindex].z[r] = (float)var[n];
+				}
+			}
+		}
+
+	}
+
+
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		int nxlev, nylev;
+		Calcnxnyzone(XParam, levi, nxlev, nylev, Xzone);
+		double  xxmin, yymin;
+		levi < 0 ? sign = "N" : sign = "P";
+		varname = varst + "_" + sign + std::to_string(abs(levi));
+
+		status = nc_inq_varid(ncid, varname.c_str(), &var_id);
+		if (status != NC_NOERR) handle_ncerror(status);
+
+		xxmin = Xzone.xo + calcres(XParam.dx, levi) / 2.0;
+		yymin = Xzone.yo + calcres(XParam.dx, levi) / 2.0;
+
+		int levindex = (lev - Xzone.minlevel);
+
+		if (vdim == 2)
+		{
+			
+
+			start2D[0] = (size_t)round((XParam.yo  - yymin) / calcres(XParam.dx, levi));
+			start2D[1] = (size_t)round((XParam.xo  - xxmin) / calcres(XParam.dx, levi));
+			
+			count2D[0] = (size_t)nylev;
+			count2D[1] = (size_t)nxlev;
+
+			if (smallnc > 0)
+			{
+
+				status = nc_put_vara_short(ncid, var_id, start2D, count2D, varlayers[levindex].z_s);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+			else
+			{
+				status = nc_put_vara_float(ncid, var_id, start2D, count2D, varlayers[levindex].z);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+		}
+		else if (vdim == 3)
+		{
+			start3D[1] = (size_t)round((XParam.yo - yymin) / calcres(XParam.dx, levi));
+			start3D[2] = (size_t)round((XParam.xo - xxmin) / calcres(XParam.dx, levi));
+
+			count3D[1] = (size_t)nylev;
+			count3D[2] = (size_t)nxlev;
+
+			if (smallnc > 0)
+			{
+				status = nc_put_vara_short(ncid, var_id, start3D, count3D, varlayers[levindex].z_s);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+			else
+			{
+				status = nc_put_vara_float(ncid, var_id, start3D, count3D, varlayers[levindex].z);
+				if (status != NC_NOERR) handle_ncerror(status);
+				//printf("\n ib=%d start=[%d,%d,%d]; initlevel=%d; initdx=%f; level=%d; xo=%f; yo=%f; blockxo[ib]=%f xxmin=%f blockyo[ib]=%f yymin=%f startfl=%f\n", bl, start3D[0], start3D[1], start3D[2], XParam.initlevel, initdx, lev, Xzone.xo, Xzone.yo, blockxo[bl], xxmin, blockyo[bl], yymin, (blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+				//printf("\n varblk[0]=%f varblk[255]=%f\n", varblk[0], varblk[255]);
+				//printf("\n ib=%d count3D=[%d,%d,%d]\n", count3D[0], count3D[1], count3D[2]);
+				//printf("\n ib=%d; level=%d; blockxo[ib]=%f blockyo[ib]=%f \n", bl, lev, blockxo[bl], blockyo[bl]);
+			}
+
+		}
+
+	}
+
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		int levindex = (lev - Xzone.minlevel);
+		if (smallnc > 0)
+		{
+
+			free(varlayers[levindex].z_s);
+		}
+		free(varlayers[levindex].z);
+	}
+	//close and save new file
+	status = nc_close(ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+}
+
+// Scope for compiler to know what function to compile
+
+template void writencvarstepBUQlev<float>(Param XParam, int vdim, int* activeblk, int* level, float* blockxo, float* blockyo, std::string varst, float* var, outzoneB Xzone);
+template void writencvarstepBUQlev<double>(Param XParam, int vdim, int* activeblk, int* level, double* blockxo, double* blockyo, std::string varst, double* var, outzoneB Xzone);
+
+
+
 template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 {
 	if (!XParam.outvars.empty())
@@ -947,7 +1144,7 @@ template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T> XModel)
 			writenctimestep(XModel.blocks.outZone[o].outname, XLoop.totaltime);
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
 			{
-				writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				writencvarstepBUQlev(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
 			}
 		}
 	}

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -616,7 +616,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 		int shuffle = 1;
 		int deflate = 1;        // This switches compression on (1) or off (0).
 		int deflate_level = 9;  // This is the compression level in range 1 (less) - 9 (more).
-		nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
+		// nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
 
 	}
 	// End definition

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -762,7 +762,7 @@ template <class T> void defncvarBUQlev(Param XParam, int* activeblk, int* level,
 	short* varblk_s;
 	float* varblk;
 	int recid, xid, yid;
-	int bl, ibl, lev;
+	int bl, ibl;
 	//size_t ntheta;// nx and ny are stored in XParam not yet for ntheta
 
 	float fillval = 9.9692e+36f;
@@ -821,7 +821,7 @@ template <class T> void defncvarBUQlev(Param XParam, int* activeblk, int* level,
 	std::string xxname, yyname, varname, sign;
 
 	//generate a different variable name for each level and add attribute as necessary
-	for (lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
+	for (int lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
 	{
 
 		//std::string xxname, yyname, sign;

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -1039,7 +1039,7 @@ template <class T> void writencvarstepBUQlev(Param XParam, int vdim, int* active
 		xxmin = Xzone.xo + calcres(XParam.dx, levi) / 2.0;
 		yymin = Xzone.yo + calcres(XParam.dx, levi) / 2.0;
 
-		int levindex = (lev - Xzone.minlevel);
+		int levindex = (levi - Xzone.minlevel);
 
 		if (vdim == 2)
 		{

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -615,7 +615,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 
 		int shuffle = 1;
 		int deflate = 1;        // This switches compression on (1) or off (0).
-		int deflate_level = 9;  // This is the compression level in range 1 (less) - 9 (more).
+		int deflate_level = 5;  // This is the compression level in range 1 (less) - 9 (more).
 		nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
 
 	}

--- a/src/Write_netcdf.h
+++ b/src/Write_netcdf.h
@@ -8,6 +8,7 @@
 #include "ReadInput.h"
 #include "MemManagement.h"
 #include "Util_CPU.h"
+#include "Arrays.h"
 
 void handle_ncerror(int status);
 template<class T> void creatncfileBUQ(Param &XParam, int* activeblk, int* level, T* blockxo, T* blockyo, outzoneB &Xzone);


### PR DESCRIPTION
# Save to file takes too long for many blocks

## The problem
The current dev branch save each block independantly to the netcdf file. The bottleneck is the netcdf write function overhead which make writing large model (20000 blocks and more) quite slow.
## The solution
 To alleviate this needs a new function that combines all blocks in a single array (for each level/variable) and write the whole array  at once to the netcdf file.
### Hold on
While this will be faster, it is likely inefficient when there are few arrays in a level. Typically when the highest level has only a few block we would still be writing a full array.
### Memory is cheap?
This will also be impossible if going to very high level where we won't be able to allocate memory to hold the highest level array.


## The real solution
Something that combine both option above and decide what is the best compromise.


### Collapse array
This may be a good time to introduce collapsing level to a single array and saving it to disk.

## Other things
This branch also includes:

-  fix on AOI polygon
- Fix for Tsunami initial condition (deform)
