### PR TITLE
New Bnd + New Save method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ development ]
+    branches: [ development Test_new_BND_A100]
   pull_request:
-    branches: [ development ]
+    branches: [ development Test_new_BND_A100]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ development Test_new_BND_A100]
+    branches: [ development, Test_new_BND_A100]
   pull_request:
-    branches: [ development Test_new_BND_A100]
+    branches: [ development, Test_new_BND_A100]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -67,6 +67,10 @@ struct maskinfo
 	int* blks; // array of block where bnd applies 
 	// 8 digit binary where 1 is a mask and 0 is not a mask with the first digit represent the left bottom side the rest is clockwise (i.e.left-bot left-top, top-left, top-right, right-top, right-bot, bot-right, bot-left)
 	int* side; // e.g. 11000000 for the entire left side being a mask
+
+	int type = 0;
+
+
 };
 
 // outzone info used to actually write the nc files (one nc file by zone, the default zone is the full domain)

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -73,6 +73,7 @@ struct maskinfo
 
 };
 
+
 // outzone info used to actually write the nc files (one nc file by zone, the default zone is the full domain)
 struct outzoneB 
 {

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -59,6 +59,15 @@ struct AdvanceP
 };
 
 
+struct outP
+{
+	float* z;
+	short* z_s;
+	int level;
+	double xmin, xmax, ymin, ymax;
+};
+
+
 struct maskinfo 
 {
 

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -844,14 +844,22 @@ template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XB
 				T qmean = T(0.0);
 				T factime = min(T(XParam.dt / 60.0), T(1.0));
 				T facrel = T(1.0) - min(T(XParam.dt / 3600.0), T(1.0));
-
-				//noslipbndQ(Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
-
-				//ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T & qmean, T & q, T & G, T & S)
-				//ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T & qmean, T & q, T & G, T & S)
-				if (hinside > XParam.eps)
+				if (XParam.aoibnd == 0)
 				{
-					ABS1DQ(T(XParam.g), T(-1.0), factime, facrel, zsi, zsbnd, zsinside, hinside, qmean, Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]);
+					noslipbndQ(Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
+				}
+				//ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T & qmean, T & q, T & G, T & S)
+				//ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T & qmean, T & q, T & G, T & S)
+				if (XParam.aoibnd == 3)
+				{
+					if (hinside > XParam.eps)
+					{
+						ABS1DQ(T(XParam.g), T(-1.0), factime, facrel, zsi, zsbnd, zsinside, hinside, qmean, Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]);
+					}
+					else
+					{
+						noslipbndQ(Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]);
+					}
 				}
 
 

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -1056,7 +1056,7 @@ template <class T> __device__ __host__ void ABS1D(T g, T sign, T zsbnd, T zsinsi
 	h = hinside;
 }
 
-template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T factime, T zsbnd, T zsinside, T hinside, T utbnd, T& qmean, T& q)
+template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T factime, T zsbnd, T zsinside, T hinside, T utbnd, T& zs, T&h, T& qmean, T& q)
 {
 	//Absorbing 1D boundary
 	//When nesting unbnd is read from file. when unbnd is not known assume 0. or the mean of un over a certain time 
@@ -1065,14 +1065,16 @@ template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T factime, T zsb
 	qmean = factime * q + T(0.99) * (T(1.0) - factime) * qmean;
 
 	T un;
-	T q=0.0;
+	
 
+	// Below should be hinside ? or h at Flux bnd?
+	// What if h is 0? then q and qmean should be 0
 	un = sign * sqrt(g / h) * (T(2.0)*(zs - zsbnd) - (zsinside - zsbnd));
 	//zs = zsinside;
 	//ut = T(utbnd);//ut[inside];
-	h = hinside;
+	//h = hinside;
 
-	q = un*h+qmean
+	q = un * h + qmean;
 
 
 }

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -1056,19 +1056,25 @@ template <class T> __device__ __host__ void ABS1D(T g, T sign, T zsbnd, T zsinsi
 	h = hinside;
 }
 
-template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T zsbnd, T zsinside, T hinside, T utbnd, T unbnd, T& un, T& ut, T& zs, T& h)
+template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T factime, T zsbnd, T zsinside, T hinside, T utbnd, T& qmean, T& q)
 {
 	//Absorbing 1D boundary
 	//When nesting unbnd is read from file. when unbnd is not known assume 0. or the mean of un over a certain time 
 	// For utbnd use utinside if no utbnd are known 
+
+	qmean = factime * q + T(0.99) * (T(1.0) - factime) * qmean;
+
+	T un;
 	T q=0.0;
 
 	un = sign * sqrt(g / h) * (T(2.0)*(zs - zsbnd) - (zsinside - zsbnd));
-	zs = zsinside;
-	ut = T(utbnd);//ut[inside];
+	//zs = zsinside;
+	//ut = T(utbnd);//ut[inside];
 	h = hinside;
 
 	q = un*h+qmean
+
+
 }
 
 template <class T> __device__ __host__ void Dirichlet1D(T g, T sign, T zsbnd, T zsinside, T hinside,  T uninside, T& un, T& ut, T& zs, T& h)

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -394,13 +394,13 @@ template <class T> void bndFluxGPUSideCPU(Param XParam, bndsegmentside side, Blo
 			if (side.isright == 0)
 			{
 				ix = tx;
-				iy = side.istop < 0 ? 0 : (XParam.blkwidth - 1);
+				iy = side.istop < 0 ? 0 : (XParam.blkwidth);
 				//itx = (xx - XParam.xo) / (XParam.xmax - XParam.xo) * side.nbnd;
 			}
 			else
 			{
 				iy = tx;
-				ix = side.isright < 0 ? 0 : (XParam.blkwidth - 1);
+				ix = side.isright < 0 ? 0 : (XParam.blkwidth);
 				//itx = (yy - XParam.yo) / (XParam.ymax - XParam.yo) * side.nbnd;
 			}
 			xx = XBlock.xo[ib] + ix * delta;

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -332,7 +332,7 @@ template <class T> __global__ void bndFluxGPUSide(Param XParam, bndsegmentside s
 		if (h[i] > XParam.eps || zsX > zsi )
 		{
 			ABS1DQ(T(XParam.g), sign, factime, facrel, zsi, zsX, zsinside, h[i], qmean, F, G, S);
-			
+			//qmean = T(0.0);
 		}
 		else
 		{
@@ -1370,7 +1370,8 @@ template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T factime,T facr
 
 	
 	
-	qmean = h < T(0.1) ? T(0.0) : factime* q + facrel * (T(1.0) - factime) * qmean;
+	qmean = h < T(0.01) ? T(0.0) : factime* q + facrel * (T(1.0) - factime) * qmean;
+	//qmean = factime * q + facrel * (T(1.0) - factime) * qmean;
 
 	T un;
 	T zn = max(zsbnd, (zs - h));

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -1061,12 +1061,14 @@ template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T zsbnd, T zsins
 	//Absorbing 1D boundary
 	//When nesting unbnd is read from file. when unbnd is not known assume 0. or the mean of un over a certain time 
 	// For utbnd use utinside if no utbnd are known 
+	T q=0.0;
 
-
-	un = sign * sqrt(g / h) * (T(2.0)*(zs - zsbnd) - (zsinside - zsbnd)) + T(unbnd);
+	un = sign * sqrt(g / h) * (T(2.0)*(zs - zsbnd) - (zsinside - zsbnd));
 	zs = zsinside;
 	ut = T(utbnd);//ut[inside];
 	h = hinside;
+
+	q = un*h+qmean
 }
 
 template <class T> __device__ __host__ void Dirichlet1D(T g, T sign, T zsbnd, T zsinside, T hinside,  T uninside, T& un, T& ut, T& zs, T& h)

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -843,11 +843,11 @@ template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XB
 				T factime = min(T(XParam.dt / 60.0), T(1.0));
 				T facrel = T(1.0) - min(T(XParam.dt / 3600.0), T(1.0));
 
-				//noslipbndQ(Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
+				noslipbndQ(Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
 
 				//ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T & qmean, T & q, T & G, T & S)
 				//ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T & qmean, T & q, T & G, T & S)
-				ABS1DQ(T(XParam.g), T(1.0), factime, facrel, zsi, zsbnd, zsinside, hinside, qmean, Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]);
+				//ABS1DQ(T(XParam.g), T(1.0), factime, facrel, zsi, zsbnd, zsinside, hinside, qmean, Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]);
 
 
 

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -86,7 +86,12 @@ template <class T> void FlowbndFlux(Param XParam, double totaltime, BlockP<T> XB
 	dim3 gridDimBBNDTop(bndseg.top.nblk, 1, 1);
 	dim3 gridDimBBNDBot(bndseg.bot.nblk, 1, 1);
 
-	double zsbnd=0.0;
+	double zsbnd = 0.0;
+	if (!std::isnan(XParam.zsinit)) // apply specified zsinit
+	{
+		zsbnd = XParam.zsinit;
+	}
+	// Warning this above is not ideal but sufficient for fail safe of testing if someone specifies initial conditions and no boundary for a type 3 they should be in trouble
 	T taper=T(1.0);
 	if (bndseg.on)
 	{

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -301,8 +301,8 @@ template <class T> __global__ void bndFluxGPUSide(Param XParam, bndsegmentside s
 		S = Fq[inside];
 	}
 	
-	T factime = min(T(XParam.dt / XParam.bndfiltertime), T(1.0));
-	T facrel = T(1.0) - min(T(XParam.dt / XParam.bndrelaxtime), T(1.0));
+	T factime = T(0.0001);//min(T(XParam.dt / XParam.bndfiltertime), T(1.0));
+	T facrel = T(0.999);// T(1.0) - min(T(XParam.dt / XParam.bndrelaxtime), T(1.0));
 
 
 

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -95,23 +95,29 @@ template <class T> void FlowbndFlux(Param XParam, double totaltime, BlockP<T> XB
 	T taper=T(1.0);
 	if (bndseg.on)
 	{
-
-		int SLstepinbnd = 1;
-
-		double difft = bndseg.data[SLstepinbnd].time - totaltime;
-		while (difft < 0.0)
+		if (bndseg.uniform)
 		{
-			SLstepinbnd++;
-			difft = bndseg.data[SLstepinbnd].time - totaltime;
+			int SLstepinbnd = 1;
+
+			double difft = bndseg.data[SLstepinbnd].time - totaltime;
+			while (difft < 0.0)
+			{
+				SLstepinbnd++;
+				difft = bndseg.data[SLstepinbnd].time - totaltime;
+			}
+
+			//itime = SLstepinbnd - 1.0 + (totaltime - bndseg.data[SLstepinbnd - 1].time) / (bndseg.data[SLstepinbnd].time - bndseg.data[SLstepinbnd - 1].time);
+			zsbnd = interptime(bndseg.data[SLstepinbnd].wspeed, bndseg.data[SLstepinbnd - 1].wspeed, bndseg.data[SLstepinbnd].time - bndseg.data[SLstepinbnd - 1].time, totaltime - bndseg.data[SLstepinbnd - 1].time);
+
+
+			if (XParam.bndtaper > 0.0)
+			{
+				taper = min(totaltime / XParam.bndtaper, 1.0);
+			}
 		}
-
-		//itime = SLstepinbnd - 1.0 + (totaltime - bndseg.data[SLstepinbnd - 1].time) / (bndseg.data[SLstepinbnd].time - bndseg.data[SLstepinbnd - 1].time);
-		zsbnd = interptime(bndseg.data[SLstepinbnd].wspeed, bndseg.data[SLstepinbnd - 1].wspeed, bndseg.data[SLstepinbnd].time - bndseg.data[SLstepinbnd - 1].time, totaltime - bndseg.data[SLstepinbnd - 1].time);
-		
-
-		if (XParam.bndtaper > 0.0)
+		else
 		{
-			taper = min(totaltime / XParam.bndtaper, 1.0);
+			// Nothing. it is already done in update forcing
 		}
 		
 	}

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -796,7 +796,7 @@ template <class T> __global__ void maskbndGPUleft(Param XParam, BlockP<T> XBlock
 template __global__ void maskbndGPUleft<float>(Param XParam, BlockP<float> XBlock, EvolvingP<float> Xev, float* zb);
 template __global__ void maskbndGPUleft<double>(Param XParam, BlockP<double> XBlock, EvolvingP<double> Xev, double* zb);
 
-//For the GPU version we apply 4 separate global function in the hope to increase occupancy
+
 template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XBlock, FluxP<T> Flux)
 {
 	unsigned int halowidth = XParam.halowidth;
@@ -834,14 +834,11 @@ template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XB
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int inside = Inside(halowidth, blkmemwidth, isright, istop, ix, iy, ib);
 
-				Flux.Su[inside] = Flux.Fqux[i];
-				//Flux.Fqux[i] = T(0.0);
 
-				Flux.Fhu[inside] = T(0.0);
-
-				//Flux.Fhu[i] = T(0.0);
-
+				noslipbndQ(Flux.Fhu[inside], Flux.Fqux[i], Flux.Su[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
 				
+
+
 
 
 			}
@@ -952,10 +949,8 @@ template <class T> __global__ void maskbndGPUFluxtop(Param XParam, BlockP<T> XBl
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int inside = Inside(halowidth, blkmemwidth, isright, istop, ix, iy, ib);
 
-				Flux.Fqvy[inside] = Flux.Sv[i];
-				//Flux.Fqux[i] = T(0.0);
-
-				Flux.Fhv[i] = T(0.0);
+				
+				noslipbndQ(Flux.Fhv[i], Flux.Sv[i], Flux.Fqvy[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
 				
 
 
@@ -1067,10 +1062,8 @@ template <class T> __global__ void maskbndGPUFluxright(Param XParam, BlockP<T> X
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int inside = Inside(halowidth, blkmemwidth, isright, istop, ix, iy, ib);
 
-				Flux.Fqux[inside] = Flux.Su[i];
-				//Flux.Fqux[i] = T(0.0);
-				//Flux.Fquy[i] = T(0.0);
-				Flux.Fhu[i] = T(0.0);
+				
+				noslipbndQ(Flux.Fhu[i], Flux.Su[i], Flux.Fqux[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
 
 				
 
@@ -1182,14 +1175,7 @@ template <class T> __global__ void maskbndGPUFluxbot(Param XParam, BlockP<T> XBl
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int inside = Inside(halowidth, blkmemwidth, isright, istop, ix, iy, ib);
 
-
-
-				Flux.Sv[inside] = Flux.Fqvy[i];
-				//Flux.Fqux[i] = T(0.0);
-
-				Flux.Fhv[inside] = T(0.0);
-
-				//Flux.Fhu[i] = T(0.0);
+				noslipbndQ(Flux.Fhv[inside], Flux.Fqvy[i], Flux.Sv[inside]); //noslipbndQ(T & F, T & G, T & S) F = T(0.0); S = G;
 
 			}
 

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -748,10 +748,10 @@ template <class T> __global__ void maskbndGPUFluxtop(Param XParam, BlockP<T> XBl
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int inside = Inside(halowidth, blkmemwidth, isright, istop, ix, iy, ib);
 
-				Flux.Fqvy[inside] = T(0.0);
+				Flux.Fqvy[i] = T(0.0);
 				//Flux.Fqux[i] = T(0.0);
 
-				Flux.Fhv[inside] = T(0.0);
+				Flux.Fhv[i] = T(0.0);
 				
 
 
@@ -863,10 +863,10 @@ template <class T> __global__ void maskbndGPUFluxright(Param XParam, BlockP<T> X
 				int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
 				int inside = Inside(halowidth, blkmemwidth, isright, istop, ix, iy, ib);
 
-				Flux.Fqux[inside] = T(0.0);
+				Flux.Fqux[i] = T(0.0);
 				//Flux.Fqux[i] = T(0.0);
 
-				Flux.Fhu[inside] = T(0.0);
+				Flux.Fhu[i] = T(0.0);
 
 				
 

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -217,7 +217,7 @@ template <class T> __global__ void bndFluxGPU(Param XParam, bndparam side, Block
 	
 	if (side.isright < 0 || side.istop < 0) // top or bottom
 	{
-		F = Fh[inside];
+		F = Fh[i];
 		G = Fq[i];
 		S = Ss[inside];
 	}
@@ -264,7 +264,7 @@ template <class T> __global__ void bndFluxGPU(Param XParam, bndparam side, Block
 
 	if (side.isright < 0 || side.istop < 0) // left or bottom
 	{
-		Fh[inside] = T(0.0);
+		Fh[i] = T(0.0);
 		//Fh[i] = 0.0;
 		//Fq[i] = G;
 		Ss[inside]=G;

--- a/src/Boundary.cu
+++ b/src/Boundary.cu
@@ -29,14 +29,14 @@ template <class T> void Flowbnd(Param XParam, Loop<T> &XLoop, BlockP<T> XBlock, 
 	if (side.on)
 	{
 		int SLstepinbnd = 1;
-
+		
 		double difft = side.data[SLstepinbnd].time - XLoop.totaltime;
 		while (difft < 0.0)
 		{
 			SLstepinbnd++;
 			difft = side.data[SLstepinbnd].time - XLoop.totaltime;
 		}
-
+		
 		itime = SLstepinbnd - 1.0 + (XLoop.totaltime - side.data[SLstepinbnd - 1].time) / (side.data[SLstepinbnd].time - side.data[SLstepinbnd - 1].time);
 
 		
@@ -238,8 +238,8 @@ template <class T> __global__ void bndFluxGPU(Param XParam, bndparam side, Block
 		if (side.type == 4)
 		{
 			//un is V (top or bot bnd) or U (left or right bnd) depending on which side it's dealing with (same for ut)
-			unbnd = side.isright == 0 ? tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f);
-			utbnd = side.isright == 0 ? tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f);
+			unbnd = side.isright == 0 ? tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f);
+			utbnd = side.isright == 0 ? tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f);
 
 		}
 
@@ -367,8 +367,8 @@ template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T>
 		if (side.type == 4)
 		{
 			//un is V (top or bot bnd) or U (left or right bnd) depending on which side it's dealing with (same for ut)
-			unbnd = side.isright == 0 ? tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f);
-			utbnd = side.isright == 0 ? tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f);
+			unbnd = side.isright == 0 ? tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f);
+			utbnd = side.isright == 0 ? tex2D<float>(side.GPU.Uvel.tex, itime + 0.5f, itx + 0.5f) : tex2D<float>(side.GPU.Vvel.tex, itime + 0.5f, itx + 0.5f);
 
 		}
 		

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -25,6 +25,9 @@ template <class T> __global__ void maskbndGPUFluxtop(Param XParam, BlockP<T> XBl
 template <class T> __global__ void maskbndGPUFluxright(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
 template <class T> __global__ void maskbndGPUFluxbot(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
 
+template <class T> void FlowbndFlux(Param XParam,double totaltime, BlockP<T> XBlock, bndparam side, DynForcingP<float> Atmp, EvolvingP<T> XEv, FluxP<T> XFlux);
+template <class T> __global__ void bndFluxGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut, T* Fh, T* Fq, T* Ss);
+
 template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut);
 template <class T> __host__ void bndCPU(Param XParam, bndparam side, BlockP<T> XBlock, std::vector<double> zsbndvec, std::vector<double> uubndvec, std::vector<double> vvbndvec, DynForcingP<float> Atmp, T* zs, T* h, T* un, T* ut);
 

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -20,6 +20,11 @@ template <class T> __global__ void maskbndGPUtop(Param XParam, BlockP<T> XBlock,
 template <class T> __global__ void maskbndGPUright(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 template <class T> __global__ void maskbndGPUbot(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 
+template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
+template <class T> __global__ void maskbndGPUFluxtop(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
+template <class T> __global__ void maskbndGPUFluxright(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
+template <class T> __global__ void maskbndGPUFluxbot(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
+
 template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut);
 template <class T> __host__ void bndCPU(Param XParam, bndparam side, BlockP<T> XBlock, std::vector<double> zsbndvec, std::vector<double> uubndvec, std::vector<double> vvbndvec, DynForcingP<float> Atmp, T* zs, T* h, T* un, T* ut);
 

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -35,6 +35,7 @@ template <class T> __host__ void bndCPU(Param XParam, bndparam side, BlockP<T> X
 __device__ __host__ void findmaskside(int side, bool &isleftbot, bool& islefttop, bool& istopleft, bool& istopright, bool& isrighttop, bool& isrightbot, bool& isbotright, bool& isbotleft);
 template <class T> __device__ __host__ void halowall(T zsinside, T& un, T& ut, T& zs, T& h,T&zb);
 template <class T> __device__ __host__ void noslipbnd(T zsinside,T hinside,T &un, T &ut,T &zs, T &h);
+template <class T> __device__ __host__ void noslipbndQ(T& F, T& G, T& S);
 template <class T> __device__ __host__ void ABS1D(T g, T sign, T zsbnd, T zsinside, T hinside, T utbnd,T unbnd, T& un, T& ut, T& zs, T& h);
 template <class T> __device__ __host__ void Dirichlet1D(T g, T sign, T zsbnd, T zsinside, T hinside,  T uninside, T& un, T& ut, T& zs, T& h);
 

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -20,7 +20,7 @@ template <class T> __global__ void maskbndGPUtop(Param XParam, BlockP<T> XBlock,
 template <class T> __global__ void maskbndGPUright(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 template <class T> __global__ void maskbndGPUbot(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, T* zb);
 
-template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
+template <class T> __global__ void maskbndGPUFluxleft(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, FluxP<T> Flux);
 template <class T> __global__ void maskbndGPUFluxtop(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
 template <class T> __global__ void maskbndGPUFluxright(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
 template <class T> __global__ void maskbndGPUFluxbot(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
@@ -37,6 +37,7 @@ template <class T> __device__ __host__ void halowall(T zsinside, T& un, T& ut, T
 template <class T> __device__ __host__ void noslipbnd(T zsinside,T hinside,T &un, T &ut,T &zs, T &h);
 template <class T> __device__ __host__ void noslipbndQ(T& F, T& G, T& S);
 template <class T> __device__ __host__ void ABS1D(T g, T sign, T zsbnd, T zsinside, T hinside, T utbnd,T unbnd, T& un, T& ut, T& zs, T& h);
+template <class T> __device__ __host__ void ABS1DQ(T g, T sign, T factime, T facrel, T zs, T zsbnd, T zsinside, T h, T& qmean, T& q, T& G, T& S);
 template <class T> __device__ __host__ void Dirichlet1D(T g, T sign, T zsbnd, T zsinside, T hinside,  T uninside, T& un, T& ut, T& zs, T& h);
 
 // End of global definition

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -29,7 +29,7 @@ template <class T> void FlowbndFlux(Param XParam, double totaltime, BlockP<T> XB
 template <class T> void FlowbndFlux(Param XParam,double totaltime, BlockP<T> XBlock, bndparam side, DynForcingP<float> Atmp, EvolvingP<T> XEv, FluxP<T> XFlux);
 
 
-template <class T> __global__ void bndFluxGPUSide(Param XParam, bndsegmentside side, BlockP<T> XBlock, DynForcingP<float> Atmp, DynForcingP<float> Zsmap, bool uniform, int type, float zsbnd, T* zs, T* h, T* un, T* ut, T* Fh, T* Fq, T* Ss);
+template <class T> __global__ void bndFluxGPUSide(Param XParam, bndsegmentside side, BlockP<T> XBlock, DynForcingP<float> Atmp, DynForcingP<float> Zsmap, bool uniform, int type, float zsbnd, T taper, T* zs, T* h, T* un, T* ut, T* Fh, T* Fq, T* Ss);
 
 template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut);
 template <class T> __host__ void bndCPU(Param XParam, bndparam side, BlockP<T> XBlock, std::vector<double> zsbndvec, std::vector<double> uubndvec, std::vector<double> vvbndvec, DynForcingP<float> Atmp, T* zs, T* h, T* un, T* ut);

--- a/src/Boundary.h
+++ b/src/Boundary.h
@@ -25,8 +25,11 @@ template <class T> __global__ void maskbndGPUFluxtop(Param XParam, BlockP<T> XBl
 template <class T> __global__ void maskbndGPUFluxright(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
 template <class T> __global__ void maskbndGPUFluxbot(Param XParam, BlockP<T> XBlock, FluxP<T> Flux);
 
+template <class T> void FlowbndFlux(Param XParam, double totaltime, BlockP<T> XBlock, bndsegment bndseg, DynForcingP<float> Atmp, EvolvingP<T> XEv, FluxP<T> XFlux);
 template <class T> void FlowbndFlux(Param XParam,double totaltime, BlockP<T> XBlock, bndparam side, DynForcingP<float> Atmp, EvolvingP<T> XEv, FluxP<T> XFlux);
-template <class T> __global__ void bndFluxGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut, T* Fh, T* Fq, T* Ss);
+
+
+template <class T> __global__ void bndFluxGPUSide(Param XParam, bndsegmentside side, BlockP<T> XBlock, DynForcingP<float> Atmp, DynForcingP<float> Zsmap, bool uniform, int type, float zsbnd, T* zs, T* h, T* un, T* ut, T* Fh, T* Fq, T* Ss);
 
 template <class T> __global__ void bndGPU(Param XParam, bndparam side, BlockP<T> XBlock, DynForcingP<float> Atmp, float itime, T* zs, T* h, T* un, T* ut);
 template <class T> __host__ void bndCPU(Param XParam, bndparam side, BlockP<T> XBlock, std::vector<double> zsbndvec, std::vector<double> uubndvec, std::vector<double> vvbndvec, DynForcingP<float> Atmp, T* zs, T* h, T* un, T* ut);

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -78,6 +78,13 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	//============================================
 	// Fill Halo for flux from fine to coarse
 	fillHalo(XParam, XModel.blocks, XModel.flux);
+
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
+
+	bndmaskCPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 	
 	//============================================
 	// Reduce minimum timestep

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -78,11 +78,11 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	//============================================
 	// Fill Halo for flux from fine to coarse
 	fillHalo(XParam, XModel.blocks, XModel.flux);
-
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
+	}
+	
 
 	//bndmaskCPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 	
@@ -170,6 +170,12 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	//============================================
 	// Fill Halo for flux from fine to coarse
 	fillHalo(XParam, XModel.blocks, XModel.flux);
+
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
+	}
+
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -84,7 +84,7 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
 	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
 
-	bndmaskCPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
+	//bndmaskCPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 	
 	//============================================
 	// Reduce minimum timestep

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -173,7 +173,7 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 
 	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
 	{
-		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
+		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt , XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
 	}
 
 

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -135,7 +135,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
 	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
 
-
+	bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 	
 
 	XModel.time.dt = T(XLoop.dt);

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -129,6 +129,13 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	// Reduce minimum timestep
 	XLoop.dt = double(CalctimestepGPU(XParam, XLoop, XModel.blocks, XModel.time));
 	XLoop.dtmax = XLoop.dt;
+
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
+
+
 	
 
 	XModel.time.dt = T(XLoop.dt);
@@ -213,6 +220,11 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	//============================================
 	// Fill Halo for flux from fine to coarse
 	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
+
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
+	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -226,6 +226,8 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
 	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
 
+	bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
+
 	//============================================
 	// Update advection terms (dh dhu dhv) 
 	updateEVGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.flux, XModel.adv);

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -130,10 +130,10 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	XLoop.dt = double(CalctimestepGPU(XParam, XLoop, XModel.blocks, XModel.time));
 	XLoop.dtmax = XLoop.dt;
 
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
+	}
 
 	bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 	
@@ -221,11 +221,11 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	// Fill Halo for flux from fine to coarse
 	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
 
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv, XModel.flux);
-	FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv, XModel.flux);
-
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt , XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
+	}
+	
 	bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 
 	//============================================

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -504,16 +504,15 @@ template void HalfStepGPU<float>(Param XParam, Loop<float>& XLoop, Forcing<float
 template void HalfStepGPU<double>(Param XParam, Loop<double>& XLoop, Forcing<float> XForcing, Model<double> XModel);
 
 
-
 template <class T> __global__ void reset_var(int halowidth, int* active, T resetval, T* Var)
 {
 
-	unsigned int blkmemwidth = blockDim.x + halowidth * 2;
+	int blkmemwidth = blockDim.x + halowidth * 2;
 	//unsigned int blksize = blkmemwidth * blkmemwidth;
-	unsigned int ix = threadIdx.x;
-	unsigned int iy = threadIdx.y;
-	unsigned int ibl = blockIdx.x;
-	unsigned int ib = active[ibl];
+	int ix = threadIdx.x;
+	int iy = threadIdx.y;
+	int ibl = blockIdx.x;
+	int ib = active[ibl];
 
 	int n = memloc(halowidth, blkmemwidth, ix, iy, ib);
 	//int n= (ix + halowidth) + (iy + halowidth) * blkmemwidth + ib * blksize;

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -135,7 +135,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt * 0.5, XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
 	}
 
-	bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
+	//bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 	
 
 	XModel.time.dt = T(XLoop.dt);
@@ -226,7 +226,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 		FlowbndFlux(XParam, XLoop.totaltime + XLoop.dt , XModel.blocks, XForcing.bndseg[iseg], XForcing.Atmp, XModel.evolv, XModel.flux);
 	}
 	
-	bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
+	//bndmaskGPU(XParam, XModel.blocks, XModel.evolv, XModel.flux);
 
 	//============================================
 	// Update advection terms (dh dhu dhv) 

--- a/src/FlowGPU.h
+++ b/src/FlowGPU.h
@@ -13,6 +13,7 @@
 #include "Friction.h"
 #include "Updateforcing.h"
 #include "Reimann.h"
+#include "boundary.h"
 
 template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel);
 

--- a/src/FlowGPU.h
+++ b/src/FlowGPU.h
@@ -13,7 +13,7 @@
 #include "Friction.h"
 #include "Updateforcing.h"
 #include "Reimann.h"
-#include "boundary.h"
+#include "Boundary.h"
 
 template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XForcing, Model<T> XModel);
 

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -119,7 +119,7 @@ public:
 
 class bndsegment {
 public:
-	std::vector<SLTS> data;
+	std::vector<Windin> data;
 	std::string inputfile;
 	Polygon poly;
 	std::string polyfile;

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -116,6 +116,9 @@ public:
 class bndsegment {
 public:
 	std::vector<SLTS> data;
+	std::string inputfile;
+	Polygon poly;
+	std::string polyfile;
 	bool on = false;
 	//If changing this default value, please change documentation later on the file
 	int type = 1; // 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -110,6 +110,8 @@ public:
 	int* blk_g;
 	float* qmean;
 	float* qmean_g;
+	// 8 digit binary where 1 is a mask and 0 is not a mask with the first digit represent the left bottom side the rest is clockwise (i.e.left-bot left-top, top-left, top-right, right-top, right-bot, bot-right, bot-left)
+	//int* side; // e.g. 11000000 for the entire left side being a mask
 };
 
 
@@ -126,8 +128,7 @@ public:
 	int nbnd; // number of forcing bnds along the side (>=1 is side is on) 
 	int nblk = 0; //number of blocks where this bnd applies
 
-	// 8 digit binary where 1 is a mask and 0 is not a mask with the first digit represent the left bottom side the rest is clockwise (i.e.left-bot left-top, top-left, top-right, right-top, right-bot, bot-right, bot-left)
-	int* side; // e.g. 11000000 for the entire left side being a mask
+	
 
 	
 	bndTexP GPU;

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -105,7 +105,7 @@ public:
 
 class bndsegmentside {
 public:
-	int nblk;
+	int nblk=0;
 	int* blk;
 	int* blk_g;
 	float* qmean;

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -99,6 +99,41 @@ public:
 	bndTexP GPU;
 	int* blks; // array of block where bnd applies 
 	int* blks_g; // Also needed for GPU (because it should be a gpu allocated pointer) This is not pretty at all! In the future maybe using pagelocked memory or other new type may be beneficial 
+	float* qmean;
+	float* qmean_g;
+};
+
+class bndsegmentside {
+public:
+	int nblk;
+	int* blk;
+	int* blk_g;
+	float* qmean;
+	float* qmean_g;
+};
+
+
+class bndsegment {
+public:
+	std::vector<SLTS> data;
+	bool on = false;
+	//If changing this default value, please change documentation later on the file
+	int type = 1; // 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)
+	std::string inputfile;
+	int nbnd; // number of forcing bnds along the side (>=1 is side is on) 
+	int nblk = 0; //number of blocks where this bnd applies
+
+	// 8 digit binary where 1 is a mask and 0 is not a mask with the first digit represent the left bottom side the rest is clockwise (i.e.left-bot left-top, top-left, top-right, right-top, right-bot, bot-right, bot-left)
+	int* side; // e.g. 11000000 for the entire left side being a mask
+
+	
+	bndTexP GPU;
+
+	bndsegmentside left;
+	bndsegmentside right;
+	bndsegmentside top;
+	bndsegmentside bot;
+		
 };
 
 
@@ -220,6 +255,13 @@ struct Forcing
 	Ex: bot = 0;
 	Ex: bot = botBnd.txt,2;
 	Default: 1
+	*/
+
+
+	std::vector<bndsegment> bndseg;
+	/* boundary segment; Only applies to AOI bnds
+	Ex: bndseg=area.txt,waterlevelforcing,1;
+	Default: none
 	*/
 
 	AOIinfo AOI;

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -122,7 +122,7 @@ public:
 	bool on = false;
 	//If changing this default value, please change documentation later on the file
 	int type = 1; // 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)
-	std::string inputfile;
+	
 	int nbnd; // number of forcing bnds along the side (>=1 is side is on) 
 	int nblk = 0; //number of blocks where this bnd applies
 

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -110,6 +110,8 @@ public:
 	int* blk_g;
 	float* qmean;
 	float* qmean_g;
+	int isright = 0;
+	int istop = 0;
 	// 8 digit binary where 1 is a mask and 0 is not a mask with the first digit represent the left bottom side the rest is clockwise (i.e.left-bot left-top, top-left, top-right, right-top, right-bot, bot-right, bot-left)
 	//int* side; // e.g. 11000000 for the entire left side being a mask
 };
@@ -122,6 +124,7 @@ public:
 	Polygon poly;
 	std::string polyfile;
 	bool on = false;
+	bool uniform = true;
 	//If changing this default value, please change documentation later on the file
 	int type = 1; // 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)
 	
@@ -131,7 +134,7 @@ public:
 	
 
 	
-	bndTexP GPU;
+	DynForcingP<float> WLmap;
 
 	bndsegmentside left;
 	bndsegmentside right;

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -735,6 +735,8 @@ template void fillHaloGPU<float>(Param XParam, BlockP<float> XBlock, FluxP<float
 template void fillHaloGPU<double>(Param XParam, BlockP<double> XBlock, FluxP<double> Flux);
 
 
+
+
 //template <class T> void refine_linearCPU(Param XParam, int ib, bool isLR, bool isoposit, BlockP<T> XBlock, T* z, T* dzdx, T* dzdy)
 //{
 //	int Neighblock, Mirrorblock;

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -719,7 +719,7 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 		maskbndGPUFluxleft << <gridDim, blockDimHalo, 0, streams[0] >> > (XParam, XBlock, Flux);
 		maskbndGPUFluxtop << <gridDim, blockDimHalo, 0, streams[1] >> > (XParam, XBlock, Flux);
 		maskbndGPUFluxright << <gridDim, blockDimHalo, 0, streams[2] >> > (XParam, XBlock, Flux);
-		maskbndGPUFluxtop << <gridDim, blockDimHalo, 0, streams[3] >> > (XParam, XBlock, Flux);
+		maskbndGPUFluxbot << <gridDim, blockDimHalo, 0, streams[3] >> > (XParam, XBlock, Flux);
 
 		//CUDA_CHECK(cudaDeviceSynchronize());
 	}

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -519,9 +519,9 @@ template void fillHaloGPU<double>(Param XParam, BlockP<double> XBlock, EvolvingP
 template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev,T * zb)
 {
 	const int num_streams = 4;
-	dim3 blockDimHalo(XParam.blkwidth, 2, 1);
+	dim3 blockDimHalo(XParam.blkwidth,1, 1);
 
-	dim3 gridDim(ceil(XBlock.mask.nblk/2), 1, 1);
+	dim3 gridDim(XBlock.mask.nblk, 1, 1);
 	
 	dim3 blockDimfull(XParam.blkmemwidth, XParam.blkmemwidth, 1);
 	dim3 gridDimfull(XParam.nblk, 1, 1);
@@ -691,6 +691,10 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 		CUDA_CHECK(cudaStreamCreate(&streams[i]));
 	}
 
+	dim3 blockDimHalo(XParam.blkwidth, 1, 1);
+
+	dim3 gridDim(XBlock.mask.nblk, 1, 1);
+
 
 	fillHaloLeftRightGPUnew(XParam, XBlock, streams[0], Flux.Fhu);
 	fillHaloLeftRightGPUnew(XParam, XBlock, streams[1], Flux.Su);
@@ -704,10 +708,27 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 	fillHaloBotTopGPUnew(XParam, XBlock, streams[6], Flux.Fhv);
 	fillHaloBotTopGPUnew(XParam, XBlock, streams[7], Flux.Sv);
 
+	/*
+	for (int i = 0; i < num_streams; i++)
+	{
+		cudaStreamSynchronize(streams[i]);
+	}
+
+	if (XBlock.mask.nblk > 0)
+	{
+		maskbndGPUFluxleft << <gridDim, blockDimHalo, 0, streams[0] >> > (XParam, XBlock, Flux);
+		maskbndGPUFluxtop << <gridDim, blockDimHalo, 0, streams[1] >> > (XParam, XBlock, Flux);
+		maskbndGPUFluxright << <gridDim, blockDimHalo, 0, streams[2] >> > (XParam, XBlock, Flux);
+		maskbndGPUFluxtop << <gridDim, blockDimHalo, 0, streams[3] >> > (XParam, XBlock, Flux);
+
+		//CUDA_CHECK(cudaDeviceSynchronize());
+	}
+	*/
 	for (int i = 0; i < num_streams; i++)
 	{
 		cudaStreamDestroy(streams[i]);
 	}
+
 	
 }
 template void fillHaloGPU<float>(Param XParam, BlockP<float> XBlock, FluxP<float> Flux);

--- a/src/Halo.cu
+++ b/src/Halo.cu
@@ -708,7 +708,7 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 	fillHaloBotTopGPUnew(XParam, XBlock, streams[6], Flux.Fhv);
 	fillHaloBotTopGPUnew(XParam, XBlock, streams[7], Flux.Sv);
 
-	/*
+	
 	for (int i = 0; i < num_streams; i++)
 	{
 		cudaStreamSynchronize(streams[i]);
@@ -723,7 +723,7 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 
 		//CUDA_CHECK(cudaDeviceSynchronize());
 	}
-	*/
+	
 	for (int i = 0; i < num_streams; i++)
 	{
 		cudaStreamDestroy(streams[i]);

--- a/src/Halo.h
+++ b/src/Halo.h
@@ -31,6 +31,8 @@ template <class T> void fillHaloGPU(Param XParam, BlockP<T> XBlock, FluxP<T> Flu
 template <class T> void fillHaloTopRightC(Param XParam, BlockP<T> XBlock, T* z);
 template <class T> void fillHaloTopRightGPU(Param XParam, bool doprolong, BlockP<T> XBlock, cudaStream_t stream, T* z);
 
+template <class T> void bndmaskGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> Xev, FluxP<T> Flux);
+
 template <class T> void fillLeft(Param XParam, int ib, BlockP<T> XBlock, T*& z);
 template <class T> void fillRight(Param XParam, int ib, BlockP<T> XBlock, T*& z);
 template <class T> void fillBot(Param XParam, int ib, BlockP<T> XBlock, T*& z);

--- a/src/InitEvolv.cu
+++ b/src/InitEvolv.cu
@@ -163,7 +163,7 @@ void warmstart(Param XParam, Forcing<float> XForcing, BlockP<T> XBlock, T* zb, E
 				}
 
 				//itime = SLstepinbnd - 1.0 + (totaltime - bndseg.data[SLstepinbnd - 1].time) / (bndseg.data[SLstepinbnd].time - bndseg.data[SLstepinbnd - 1].time);
-				zsbnduni = zsbnduni + interptime(XForcing.bndseg[iseg].data[SLstepinbnd].wlevs[0], XForcing.bndseg[iseg].data[SLstepinbnd - 1].wlevs[0], XForcing.bndseg[iseg].data[SLstepinbnd].time - XForcing.bndseg[iseg].data[SLstepinbnd - 1].time, XParam.totaltime - XForcing.bndseg[iseg].data[SLstepinbnd - 1].time);
+				zsbnduni = zsbnduni + interptime(XForcing.bndseg[iseg].data[SLstepinbnd].wspeed, XForcing.bndseg[iseg].data[SLstepinbnd - 1].wspeed, XForcing.bndseg[iseg].data[SLstepinbnd].time - XForcing.bndseg[iseg].data[SLstepinbnd - 1].time, XParam.totaltime - XForcing.bndseg[iseg].data[SLstepinbnd - 1].time);
 
 			}
 			else

--- a/src/InitEvolv.cu
+++ b/src/InitEvolv.cu
@@ -61,8 +61,18 @@ template <class T> void initevolv(Param XParam, BlockP<T> XBlock,Forcing<float> 
 		//!leftWLbnd.empty()
 
 		//case 0 (i.e. zsinint not specified by user and no boundaries were specified)
+		bool bndison = false;
+		for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+		{
+			if (XForcing.bndseg[iseg].on)
+			{
+				bndison = true;
+			}
+		}
+
+
 		
-		if (std::isnan(XParam.zsinit) && (!XForcing.left.on && !XForcing.right.on && !XForcing.top.on && !XForcing.bot.on)) //zsinit is default
+		if (std::isnan(XParam.zsinit) && (!bndison)) //zsinit is default
 		{
 			XParam.zsinit = 0.0; // better default value than nan
 		}
@@ -127,9 +137,108 @@ int coldstart(Param XParam, BlockP<T> XBlock, T* zb, EvolvingP<T> & XEv)
 	return coldstartsucess;
 }
 
+template <class T>
+void warmstart(Param XParam, Forcing<float> XForcing, BlockP<T> XBlock, T* zb, EvolvingP<T>& XEv)
+{
+	int nuni=0;
+	int ndyn=0;
+
+	T zsbnduni=T(0.0);
+	T zsbnd;
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		if (XForcing.bndseg[iseg].on)
+		{
+			if (XForcing.bndseg[iseg].uniform)
+			{
+				nuni++;
+
+				int SLstepinbnd = 1;
+
+				double difft = XForcing.bndseg[iseg].data[SLstepinbnd].time - XParam.totaltime;
+				while (difft < 0.0)
+				{
+					SLstepinbnd++;
+					difft = XForcing.bndseg[iseg].data[SLstepinbnd].time - XParam.totaltime;
+				}
+
+				//itime = SLstepinbnd - 1.0 + (totaltime - bndseg.data[SLstepinbnd - 1].time) / (bndseg.data[SLstepinbnd].time - bndseg.data[SLstepinbnd - 1].time);
+				zsbnduni = zsbnduni + interptime(XForcing.bndseg[iseg].data[SLstepinbnd].wlevs[0], XForcing.bndseg[iseg].data[SLstepinbnd - 1].wlevs[0], XForcing.bndseg[iseg].data[SLstepinbnd].time - XForcing.bndseg[iseg].data[SLstepinbnd - 1].time, XParam.totaltime - XForcing.bndseg[iseg].data[SLstepinbnd - 1].time);
+
+			}
+			else
+			{
+				ndyn++;
+				Forcingthisstep(XParam, XParam.totaltime, XForcing.bndseg[iseg].WLmap);
+			}
+		}
+	}
+	if (nuni > 0)
+	{
+		zsbnduni = zsbnduni / nuni;
+	}
+
+	int ib;
+	double xi, yi;
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+		ib = XBlock.active[ibl];
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			for (int i = 0; i < XParam.blkwidth; i++)
+			{
+				int n = (i + XParam.halowidth) + (j + XParam.halowidth) * XParam.blkmemwidth + ib * XParam.blksize;
+
+				double levdx = calcres(XParam.dx, XBlock.level[ib]);
+				xi = XParam.xo + XBlock.xo[ib] + i * levdx;
+				yi = XParam.yo + XBlock.yo[ib] + j * levdx;
+
+				zsbnd = zsbnduni;
+
+				if (ndyn > 0)
+				{
+					zsbnd = zsbnduni * nuni;
+					
+					for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+					{
+						if (XForcing.bndseg[iseg].on && !XForcing.bndseg[iseg].uniform)
+						{
+							//
+							zsbnd = zsbnd + float(interp2BUQ(xi, yi, XForcing.bndseg[iseg].WLmap));
+						}
+					}
+
+					zsbnd = zsbnd / (nuni + ndyn);
+				}
+
+				if (XParam.atmpforcing)
+				{
+					float atmpi;
+
+					if (XForcing.Atmp.uniform)
+					{
+						atmpi = float(XForcing.Atmp.nowvalue);
+					}
+					else
+					{
+						atmpi = float(interp2BUQ(xi, yi, XForcing.Atmp));
+					}
+					zsbnd = zsbnd - (atmpi - (T)XParam.Paref) * (T)XParam.Pa2m;
+				}
+
+				XEv.zs[n] = utils::max(zsbnd, zb[n]);
+				XEv.h[n] = utils::max(XEv.zs[n] - zb[n], T(0.0));
+				XEv.u[n] = T(0.0);
+				XEv.v[n] = T(0.0);
+			}
+		}
+	}
+
+}
+
 
 template <class T>
-void warmstart(Param XParam,Forcing<float> XForcing, BlockP<T> XBlock, T* zb, EvolvingP<T>& XEv)
+void warmstartold(Param XParam,Forcing<float> XForcing, BlockP<T> XBlock, T* zb, EvolvingP<T>& XEv)
 {
 	// This function read water level boundary if they have been setup and calculate the distance to the boundary 
 	// toward the end the water level value is calculated as an inverse distance to the available boundaries.

--- a/src/InitEvolv.h
+++ b/src/InitEvolv.h
@@ -12,7 +12,7 @@
 #include "GridManip.h"
 #include "Read_netcdf.h"
 #include "ReadForcing.h"
-
+#include "Updateforcing.h"
 
 
 template <class T> void initevolv(Param XParam, BlockP<T> XBlock, Forcing<float> XForcing, EvolvingP<T>& XEv, T*& zb);

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -951,6 +951,10 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 		AllocateCPU(topcount, XParam.blkwidth, XForcing.bndseg[s].top.qmean);
 		AllocateCPU(botcount, XParam.blkwidth, XForcing.bndseg[s].bot.qmean);
 
+		FillCPU(leftcount, XParam.blkwidth, 0.0f, XForcing.bndseg[s].left.qmean);
+		FillCPU(rightcount, XParam.blkwidth, 0.0f, XForcing.bndseg[s].right.qmean);
+		FillCPU(topcount, XParam.blkwidth, 0.0f, XForcing.bndseg[s].top.qmean);
+		FillCPU(botcount, XParam.blkwidth, 0.0f, XForcing.bndseg[s].bot.qmean);
 
 		leftcount = 0;
 		rightcount = 0;

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -879,11 +879,11 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 			T dxlev = calcres(XParam.dx, XBlock.level[ib]);
 
 			bndblks.push_back(ib);
-			bndsegment.push_back(-1); // i.e. by default the block doesn't belong to a segment
-
-			for (int s = 0; s < XForcing.bndseg.size(); s++)
+			bndsegment.push_back(XForcing.bndseg.size()-1); // i.e. by default the block doesn't belong to a segment so it belongs to collector (last) segemnt
+			//loop through all but the last bnd seg which is meant for block that are not in any segments
+			for (int s = 0; s < XForcing.bndseg.size()-1; s++)
 			{
-				bool inpoly=blockinpoly(XBlock.xo[ib], XBlock.yo[ib], dxlev, XParam.blkwidth, XForcing.bndseg[s].poly);
+				bool inpoly=blockinpoly(T(XParam.xo + XBlock.xo[ib]), T(XParam.yo + XBlock.yo[ib]), dxlev, XParam.blkwidth, XForcing.bndseg[s].poly);
 
 				if (inpoly)
 				{
@@ -941,15 +941,16 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 		XForcing.bndseg[s].bot.nblk = botcount;
 
 		//allocate array
-		AllocateCPU(leftcount, 1, XForcing.bndseg[s].left.blk);
-		AllocateCPU(rightcount, 1, XForcing.bndseg[s].right.blk);
-		AllocateCPU(topcount, 1, XForcing.bndseg[s].top.blk);
-		AllocateCPU(botcount, 1, XForcing.bndseg[s].bot.blk);
+		//ReallocArray(int nblk, int blksize, T * &zb)
+		ReallocArray(leftcount, 1, XForcing.bndseg[s].left.blk);
+		ReallocArray(rightcount, 1, XForcing.bndseg[s].right.blk);
+		ReallocArray(topcount, 1, XForcing.bndseg[s].top.blk);
+		ReallocArray(botcount, 1, XForcing.bndseg[s].bot.blk);
 
-		AllocateCPU(leftcount, XParam.blkwidth, XForcing.bndseg[s].left.qmean);
-		AllocateCPU(rightcount, XParam.blkwidth, XForcing.bndseg[s].right.qmean);
-		AllocateCPU(topcount, XParam.blkwidth, XForcing.bndseg[s].top.qmean);
-		AllocateCPU(botcount, XParam.blkwidth, XForcing.bndseg[s].bot.qmean);
+		ReallocArray(leftcount, XParam.blkwidth, XForcing.bndseg[s].left.qmean);
+		ReallocArray(rightcount, XParam.blkwidth, XForcing.bndseg[s].right.qmean);
+		ReallocArray(topcount, XParam.blkwidth, XForcing.bndseg[s].top.qmean);
+		ReallocArray(botcount, XParam.blkwidth, XForcing.bndseg[s].bot.qmean);
 
 		FillCPU(leftcount, XParam.blkwidth, 0.0f, XForcing.bndseg[s].left.qmean);
 		FillCPU(rightcount, XParam.blkwidth, 0.0f, XForcing.bndseg[s].right.qmean);

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -871,10 +871,10 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 	{
 		int ib = XBlock.active[ibl];
 
-		testbot = (XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib) || (XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib) || (XBlock.LeftTop[ib] == ib) || (XBlock.LeftBot[ib] == ib) (XBlock.RightTop[ib] == ib) || (XBlock.RightBot[ib] == ib);
+		bool testbot = (XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib) || (XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib) || (XBlock.LeftTop[ib] == ib) || (XBlock.LeftBot[ib] == ib) (XBlock.RightTop[ib] == ib) || (XBlock.RightBot[ib] == ib);
 		if (testbot)
 		{
-			T dxlev=calcres(Xparam.dx,Xblock.level[ib])
+			T dxlev = calcres(XParam.dx, XBlock.level[ib]);
 
 			bndblks.push_back(ib);
 			bndsegment.push_back(-1); // i.e. by default the block doesn't belong to a segment
@@ -908,7 +908,7 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 		
 		for (int ibl = 0; ibl < bndblks.size(); ibl++)
 		{
-			ib = bndblks[ibl];
+			int ib = bndblks[ibl];
 			if (bndsegment[ibl] == s)
 			{
 				segcount++;
@@ -952,7 +952,7 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 
 		for (int ibl = 0; ibl < bndblks.size(); ibl++)
 		{
-			ib = bndblks[ibl];
+			int ib = bndblks[ibl];
 
 			if (bndsegment[ibl] == s)
 			{
@@ -973,7 +973,7 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 				}
 				if ((XBlock.RightBot[ib] == ib) || (XBlock.RightTop[ib] == ib))
 				{
-					Forcing.bndseg[s].right.blk[rightcount] = ib;
+					XForcing.bndseg[s].right.blk[rightcount] = ib;
 					rightcount++;
 				}
 

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -906,12 +906,17 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 		int topcount = 0;
 		int botcount = 0;
 		
-		for (int ib = 0; ib < bndblks.size(); ib++)
+		for (int ibl = 0; ibl < bndblks.size(); ibl++)
 		{
-			if (bndsegment[ib] == s)
+			ib = bndblks[ibl];
+			if (bndsegment[ibl] == s)
 			{
 				segcount++;
 
+				if ((XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib))
+				{
+					botcount++;
+				}
 
 			}
 		}

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -897,7 +897,7 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 
 	}
 
-	// 2. make an array to store which segemnt they belong to 
+	
 	for (int s = 0; s < XForcing.bndseg.size(); s++)
 	{
 		int segcount = 0;
@@ -917,27 +917,73 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 				{
 					botcount++;
 				}
-
+				if ((XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib))
+				{
+					topcount++;
+				}
+				if ((XBlock.LeftBot[ib] == ib) || (XBlock.LeftTop[ib] == ib))
+				{
+					leftcount++;
+				}
+				if ((XBlock.RightBot[ib] == ib) || (XBlock.RightTop[ib] == ib))
+				{
+					rightcount++;
+				}
 			}
 		}
 		XForcing.bndseg[s].nblk = segcount;
 
 		//allocate array
-		XForcing.bndseg[s].left.blk
+		AllocateCPU(leftcount, 1, XForcing.bndseg[s].left.blk);
+		AllocateCPU(rightcount, 1, XForcing.bndseg[s].right.blk);
+		AllocateCPU(topcount, 1, XForcing.bndseg[s].top.blk);
+		AllocateCPU(botcount, 1, XForcing.bndseg[s].bot.blk);
+
+		AllocateCPU(leftcount, XParam.blkwidth, XForcing.bndseg[s].left.qmean);
+		AllocateCPU(rightcount, XParam.blkwidth, XForcing.bndseg[s].right.qmean);
+		AllocateCPU(topcount, XParam.blkwidth, XForcing.bndseg[s].top.qmean);
+		AllocateCPU(botcount, XParam.blkwidth, XForcing.bndseg[s].bot.qmean);
+
+
+		leftcount = 0;
+		rightcount = 0;
+		topcount = 0;
+		botcount = 0;
+
+		for (int ibl = 0; ibl < bndblks.size(); ibl++)
+		{
+			ib = bndblks[ibl];
+
+			if (bndsegment[ibl] == s)
+			{
+				if ((XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib))
+				{
+					XForcing.bndseg[s].bot.blk[botcount] = ib;
+					botcount++;
+				}
+				if ((XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib))
+				{
+					XForcing.bndseg[s].top.blk[topcount] = ib;
+					topcount++;
+				}
+				if ((XBlock.LeftBot[ib] == ib) || (XBlock.LeftTop[ib] == ib))
+				{
+					XForcing.bndseg[s].left.blk[leftcount] = ib;
+					leftcount++;
+				}
+				if ((XBlock.RightBot[ib] == ib) || (XBlock.RightTop[ib] == ib))
+				{
+					Forcing.bndseg[s].right.blk[rightcount] = ib;
+					rightcount++;
+				}
+
+			}
+
+		}
+
+
 
 	}
-
-	// If any bnd segment was specified
-	// 3. scan each block and find which (if any) segment they belong to
-		// For each segment
-			// Calculate bbox
-			// if inbbox calc inpoly
-			//if inpoly overwrite assingned segment with new one
-
-	 
-	// 4. Calculate nblk per segment & allocate (do for each segment)
-	
-	// 5. fill segmnent and side arrays for each segments
 
 
 }

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -63,8 +63,10 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 
 	//=====================================
 	// Initial bndinfo
-	Calcbndblks(XParam, XForcing, XModel.blocks);
-	Findbndblks(XParam, XModel, XForcing);
+	//Calcbndblks(XParam, XForcing, XModel.blocks);
+	//Findbndblks(XParam, XModel, XForcing);
+	Initbndblks(XParam, XForcing, XModel.blocks);
+
 
 	//=====================================
 	// Calculate Active cells
@@ -871,7 +873,7 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 	{
 		int ib = XBlock.active[ibl];
 
-		bool testbot = (XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib) || (XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib) || (XBlock.LeftTop[ib] == ib) || (XBlock.LeftBot[ib] == ib) (XBlock.RightTop[ib] == ib) || (XBlock.RightBot[ib] == ib);
+		bool testbot = (XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib) || (XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib) || (XBlock.LeftTop[ib] == ib) || (XBlock.LeftBot[ib] == ib) || (XBlock.RightTop[ib] == ib) || (XBlock.RightBot[ib] == ib);
 		if (testbot)
 		{
 			T dxlev = calcres(XParam.dx, XBlock.level[ib]);
@@ -932,6 +934,11 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 			}
 		}
 		XForcing.bndseg[s].nblk = segcount;
+
+		XForcing.bndseg[s].left.nblk = leftcount;
+		XForcing.bndseg[s].right.nblk = rightcount;
+		XForcing.bndseg[s].top.nblk = topcount;
+		XForcing.bndseg[s].bot.nblk = botcount;
 
 		//allocate array
 		AllocateCPU(leftcount, 1, XForcing.bndseg[s].left.blk);

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -860,7 +860,7 @@ template void Initoutzone<double>(Param& XParam, BlockP<double>& XBlock);
 */
 template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, BlockP<T> XBlock)
 {
-	//To do
+	//if(XForcing.bndseg.size()>0)
 
 	std::vector<int> bndblks;
 	std::vector<int> bndsegment;
@@ -874,7 +874,21 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 		testbot = (XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib) || (XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib) || (XBlock.LeftTop[ib] == ib) || (XBlock.LeftBot[ib] == ib) (XBlock.RightTop[ib] == ib) || (XBlock.RightBot[ib] == ib);
 		if (testbot)
 		{
+			T dxlev=calcres(Xparam.dx,Xblock.level[ib])
+
 			bndblks.push_back(ib);
+			bndsegment.push_back(-1); // i.e. by default the block doesn't belong to a segment
+
+			for (int s = 0; s < XForcing.bndseg.size(); s++)
+			{
+				bool inpoly=blockinpoly(XBlock.xo[ib], XBlock.yo[ib], dxlev, XParam.blkwidth, XForcing.bndseg[s].poly);
+
+				if (inpoly)
+				{
+					bndsegment.back() = s;
+				}
+
+			}
 
 
 
@@ -884,7 +898,29 @@ template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 	}
 
 	// 2. make an array to store which segemnt they belong to 
+	for (int s = 0; s < XForcing.bndseg.size(); s++)
+	{
+		int segcount = 0;
+		int leftcount = 0;
+		int rightcount = 0;
+		int topcount = 0;
+		int botcount = 0;
+		
+		for (int ib = 0; ib < bndblks.size(); ib++)
+		{
+			if (bndsegment[ib] == s)
+			{
+				segcount++;
 
+
+			}
+		}
+		XForcing.bndseg[s].nblk = segcount;
+
+		//allocate array
+		XForcing.bndseg[s].left.blk
+
+	}
 
 	// If any bnd segment was specified
 	// 3. scan each block and find which (if any) segment they belong to

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -840,6 +840,32 @@ template <class T> void Initoutzone(Param& XParam, BlockP<T>& XBlock)
 template void Initoutzone<float>(Param& XParam, BlockP<float>& XBlock);
 template void Initoutzone<double>(Param& XParam, BlockP<double>& XBlock);
 
+/*
+*  Initialise bnd blk assign block to their relevant segment allocate memory...
+*
+*/
+template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, BlockP<T> XBlock)
+{
+	//To do
+
+	// 1. Find all the boundary blocks (block with themselves as neighbours)
+
+	// 2. make an array to store which segemnt they belown to 
+
+	// If any bnd segment was specified
+	// 3. scan each block and find which (if any) segment they belong to
+		// For each segment
+			// Calculate bbox
+			// if inbbox calc inpoly
+			//if inpoly overwrite assingned segment with new one
+
+	 
+	// 4. Calculate nblk per segment & allocate (do for each segment)
+	
+	// 5. fill segmnent and side arrays for each segments
+
+
+}
 
 template <class T> void Calcbndblks(Param& XParam, Forcing<float>& XForcing, BlockP<T> XBlock)
 {
@@ -915,9 +941,10 @@ template <class T> void Calcbndblks(Param& XParam, Forcing<float>& XForcing, Blo
 }
 
 
-
-
-
+/*! \fn Findbndblks(Param XParam, Model<T> XModel,Forcing<float> &XForcing)
+* Find which block on the model edge belongs to a "side boundary"
+* 
+*/
 template <class T> void Findbndblks(Param XParam, Model<T> XModel,Forcing<float> &XForcing)
 {
 	//=====================================

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -842,15 +842,49 @@ template void Initoutzone<double>(Param& XParam, BlockP<double>& XBlock);
 
 /*
 *  Initialise bnd blk assign block to their relevant segment allocate memory...
+* 1. Find all the boundary blocks(block with themselves as neighbours)
 *
+* 2. make an array to store which segemnt they belong to
+*
+* If any bnd segment was specified
+* 3. scan each block and find which (if any) segment they belong to
+*	 For each segment
+*		 Calculate bbox
+*		 if inbbox calc inpoly
+*		if inpoly overwrite assingned segment with new one
+*
+*
+* 4. Calculate nblk per segment & allocate (do for each segment)
+*
+* 5. fill segmnent and side arrays for each segments
 */
 template <class T> void Initbndblks(Param& XParam, Forcing<float>& XForcing, BlockP<T> XBlock)
 {
 	//To do
 
+	std::vector<int> bndblks;
+	std::vector<int> bndsegment;
 	// 1. Find all the boundary blocks (block with themselves as neighbours)
+	
+	
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+		int ib = XBlock.active[ibl];
 
-	// 2. make an array to store which segemnt they belown to 
+		testbot = (XBlock.BotLeft[ib] == ib) || (XBlock.BotRight[ib] == ib) || (XBlock.TopLeft[ib] == ib) || (XBlock.TopRight[ib] == ib) || (XBlock.LeftTop[ib] == ib) || (XBlock.LeftBot[ib] == ib) (XBlock.RightTop[ib] == ib) || (XBlock.RightBot[ib] == ib);
+		if (testbot)
+		{
+			bndblks.push_back(ib);
+
+
+
+		}
+		
+
+	}
+
+	// 2. make an array to store which segemnt they belong to 
+
 
 	// If any bnd segment was specified
 	// 3. scan each block and find which (if any) segment they belong to

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -205,19 +205,25 @@ template <class T> Loop<T> InitLoop(Param &XParam, Model<T> &XModel)
 
 template <class T> void updateBnd(Param XParam, Loop<T> XLoop, Forcing<float> XForcing, Model<T> XModel, Model<T> XModel_g)
 {
-	if (XParam.GPUDEVICE >= 0)
+	for (int ibndseg = 0; ibndseg < XForcing.bndseg.size(); ibndseg++)
 	{
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.left, XForcing.Atmp, XModel_g.evolv);
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.right, XForcing.Atmp, XModel_g.evolv);
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.top, XForcing.Atmp, XModel_g.evolv);
-		Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.bot, XForcing.Atmp, XModel_g.evolv);
-	}
-	else
-	{
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv);
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv);
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv);
-		Flowbnd(XParam, XLoop, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv);
+		if (XParam.GPUDEVICE >= 0)
+		{
+
+
+			Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.left, XForcing.Atmp, XModel_g.evolv);
+			Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.right, XForcing.Atmp, XModel_g.evolv);
+			Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.top, XForcing.Atmp, XModel_g.evolv);
+			Flowbnd(XParam, XLoop, XModel_g.blocks, XForcing.bot, XForcing.Atmp, XModel_g.evolv);
+
+		}
+		else
+		{
+			Flowbnd(XParam, XLoop, XModel.blocks, XForcing.left, XForcing.Atmp, XModel.evolv);
+			Flowbnd(XParam, XLoop, XModel.blocks, XForcing.right, XForcing.Atmp, XModel.evolv);
+			Flowbnd(XParam, XLoop, XModel.blocks, XForcing.top, XForcing.Atmp, XModel.evolv);
+			Flowbnd(XParam, XLoop, XModel.blocks, XForcing.bot, XForcing.Atmp, XModel.evolv);
+		}
 	}
 }
 

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -20,7 +20,7 @@ template <class T> void MainLoop(Param &XParam, Forcing<float> XForcing, Model<T
 	while (XLoop.totaltime < XParam.endtime)
 	{
 		// Bnd stuff here
-		updateBnd(XParam, XLoop, XForcing, XModel, XModel_g);
+		//updateBnd(XParam, XLoop, XForcing, XModel, XModel_g);
 
 
 		// Calculate dynamic forcing at this step

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -23,6 +23,19 @@ template <class T> __host__ void AllocateCPU(int nx, int ny, T *&zb)
 	}
 }
 
+template <class T> __host__ void FillCPU(int nx, int ny,T fillval, T*& zb)
+{
+	for (int ix = 0; ix < nx; ix++)
+	{
+		for (int iy = 0; iy < ny; iy++)
+		{
+			zb[iy * nx + ix] = fillval;
+		}
+	}
+}
+template void FillCPU<double>(int nx, int ny, double fillval, double*& zb);
+template void FillCPU<float>(int nx, int ny, float fillval, float*& zb);
+template void FillCPU<int>(int nx, int ny, int fillval, int*& zb);
 
 template <class T> __host__ void AllocateCPU(int nx, int ny, T *&zs, T *&h, T *&u, T *&v)
 {

--- a/src/MemManagement.h
+++ b/src/MemManagement.h
@@ -25,6 +25,8 @@ template <class T> void ReallocArray(int nblk, int blksize, EvolvingP<T>& Ev);
 template <class T> void ReallocArray(int nblk, int blksize, EvolvingP_M<T>& Ev);
 template <class T> void ReallocArray(int nblk, int blksize, Param XParam, Model<T>& XModel);
 
+template <class T> __host__ void FillCPU(int nx, int ny, T fillval, T*& zb);
+
 int memloc(Param XParam, int i, int j, int ib);
 //__device__ int memloc(int halowidth, int blkmemwidth, int  blksize, int i, int j, int ib);
 __host__ __device__ int memloc(int halowidth, int blkmemwidth, int i, int j, int ib);

--- a/src/Param.h
+++ b/src/Param.h
@@ -56,6 +56,7 @@ public:
 	int blkmemwidth = 0; // Calculated in sanity check as blkwidth+2*halowidth
 	int blksize = 0; // Calculated in sanity check as blkmemwidth*blkmemwidth
 	int halowidth = 1; // Use a halo around the blocks default is 1 cell: the memory for each blk is 18x18 when blkwidth is 16
+	
 
 	double xo = nan(""); // Grid x origin (if not alter by the user, will be defined based on the topography/bathymetry input map)
 	double yo = nan(""); // Grid y origin (if not alter by the user, will be defined based on the topography/bathymetry input map)
@@ -98,6 +99,9 @@ public:
 	*/
 	//std::string deformfile;
 	int hotstep = 0; //Step to read if hotstart file has multiple steps (step and not (computation) time)
+
+
+	double bndtaper = 0.0; // number of second to taper boundary values to smooth transition with initial conditions default is no tapering but 600s is good practice
 	//other
 	clock_t startcputime, endcputime, setupcputime;
 	size_t GPU_initmem_byte, GPU_totalmem_byte;

--- a/src/Param.h
+++ b/src/Param.h
@@ -35,6 +35,8 @@ public:
 	bool topbnd = false; // bnd is forced (i.e. not a wall or neuman)
 	bool botbnd = false; // bnd is forced (i.e. not a wall or neuman)
 
+	int aoibnd = 0; // Boundary type for AOI: 0=wall; 1 neumann; 3 absorbing
+
 	double Pa2m = 0.00009916; // Conversion between atmospheric pressure changes to water level changes in Pa (if unit is hPa then user should use 0.009916)
 	double Paref = 101300.0; // Reference pressure in Pa (if unit is hPa then user should use 1013.0)
 	double lat = 0.0; // Model latitude. This is ignored in spherical case

--- a/src/Param.h
+++ b/src/Param.h
@@ -83,6 +83,9 @@ public:
 	double totaltime = 0.0; // Total simulation time in s
 	double dtinit = -1; // Maximum initial time steps in s (should be positive, advice 0.1 if dry domain initialement) 
 	double dtmin = 0.0005; //Minimum accepted time steps in s (a lower value will be concidered a crash of the code, and stop the run)
+	double bndrelaxtime = 3600.0; // Realxation time for absorbing boundary
+	double bndfiltertime = 60.0; // Filtering time for absorbing boundary
+
 
 	//* Initialisation
 	double zsinit = nan(""); //Init zs for cold start in m. If not specified by user and no bnd file = 1 then sanity check will set it to 0.0

--- a/src/Param.h
+++ b/src/Param.h
@@ -216,6 +216,9 @@ public:
 	std::string reftime = ""; // Reference time string as yyyy-mm-ddTHH:MM:SS
 	std::string crs_ref = "no_crs"; //"PROJCS[\"NZGD2000 / New Zealand Transverse Mercator 2000\",GEOGCS[\"NZGD2000\",DATUM[\"New_Zealand_Geodetic_Datum_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4167\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",173],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",1600000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1],AXIS[\"Northing\",NORTH],AXIS[\"Easting\",EAST],AUTHORITY[\"EPSG\",\"2193\"]]";
 
+
+	bool savebyblk=true;
+
 };
 
 

--- a/src/Poly.cu
+++ b/src/Poly.cu
@@ -395,6 +395,7 @@ bool PolygonIntersect(Polygon P, Polygon Q)
 * ## Description
 * Check whether a block is inside or intersectin a polygon
 * 
+* ## Usage blockinpoly( blockxo,  blockyo,  blockdx, blkwidth, Polygon)
 *
 */
 template <class T> bool blockinpoly(T xo, T yo, T dx, int blkwidth, Polygon Poly)

--- a/src/Poly.cu
+++ b/src/Poly.cu
@@ -212,7 +212,7 @@ Polygon CounterCWPoly(Polygon Poly)
 	if (sum > 0.0)
 	{
 		log(" Reversing Polygon handedness");
-		for (int i = Poly.vertices.size(); i > 0; i--)
+		for (int i = Poly.vertices.size()-1; i > 0; i--)
 		{
 			//
 			

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -622,19 +622,92 @@ std::string readCRSfrombathy(std::string crs_ref, StaticForcingP<float>& Sforcin
 	return crs_wkt;
 }
 
-Polygon readbndsegment(bndsegment bnd)
+Polygon readbndpolysegment(bndsegment bnd, Param XParam)
 {
 	Polygon bndpoly;
+	Vertex va,vb,vc,vd;
+	double epsbnd = XParam.dx*2.0;
+	double xo = XParam.xo;
+	double xmax = XParam.xmax;
+	double yo = XParam.yo;
+	double ymax = XParam.ymax;
 
-	if (bnd.polyfile == "left")
+	if (case_insensitive_compare(bnd.polyfile,"left")==0)
+	{
+		va.x = xo - epsbnd; va.y = yo;
+		vb.x = xo + epsbnd; vb.y = yo;
+		vc.x = xo + epsbnd; vc.y = ymax;
+		vd.x = xo - epsbnd; vd.y = ymax;
+
+		bndpoly.vertices.push_back(va);
+		bndpoly.vertices.push_back(vb);
+		bndpoly.vertices.push_back(vc);
+		bndpoly.vertices.push_back(vd);
+		bndpoly.vertices.push_back(va);
+		bndpoly.xmin = xo - epsbnd;
+		bndpoly.xmax = xo + epsbnd;
+		bndpoly.ymin = yo;
+		bndpoly.ymax = ymax;
+
+	}
+	else if (case_insensitive_compare(bnd.polyfile, "bot") == 0)
+	{
+		va.x = xo ; va.y = yo - epsbnd;
+		vb.x = xmax; vb.y = yo - epsbnd;
+		vc.x = xmax; vc.y = yo + epsbnd;
+		vd.x = xo; vd.y = yo + epsbnd;
+
+		bndpoly.vertices.push_back(va);
+		bndpoly.vertices.push_back(vb);
+		bndpoly.vertices.push_back(vc);
+		bndpoly.vertices.push_back(vd);
+		bndpoly.vertices.push_back(va);
+		bndpoly.xmin = xo ;
+		bndpoly.xmax = xmax;
+		bndpoly.ymin = yo - epsbnd;
+		bndpoly.ymax = yo + epsbnd;
+	}
+	else if (case_insensitive_compare(bnd.polyfile, "right") == 0)
+	{
+		va.x = xmax - epsbnd; va.y = yo;
+		vb.x = xmax + epsbnd; vb.y = yo;
+		vc.x = xmax + epsbnd; vc.y = ymax;
+		vd.x = xmax - epsbnd; vd.y = ymax;
+
+		bndpoly.vertices.push_back(va);
+		bndpoly.vertices.push_back(vb);
+		bndpoly.vertices.push_back(vc);
+		bndpoly.vertices.push_back(vd);
+		bndpoly.vertices.push_back(va);
+		bndpoly.xmin = xmax - epsbnd;
+		bndpoly.xmax = xmax + epsbnd;
+		bndpoly.ymin = yo;
+		bndpoly.ymax = ymax;
+
+	}
+	else if (case_insensitive_compare(bnd.polyfile, "top") == 0)
 	{
 
+		va.x = xo; va.y = ymax - epsbnd;
+		vb.x = xmax; vb.y = ymax - epsbnd;
+		vc.x = xmax; vc.y = ymax + epsbnd;
+		vd.x = xo; vd.y = ymax + epsbnd;
+
+		bndpoly.vertices.push_back(va);
+		bndpoly.vertices.push_back(vb);
+		bndpoly.vertices.push_back(vc);
+		bndpoly.vertices.push_back(vd);
+		bndpoly.vertices.push_back(va);
+		bndpoly.xmin = xo;
+		bndpoly.xmax = xmax;
+		bndpoly.ymin = ymax - epsbnd;
+		bndpoly.ymax = ymax + epsbnd;
 	}
 	else
 	{
 		bndpoly = readPolygon(bnd.polyfile);
 	}
-	
+
 	return bndpoly;
 }
 

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -73,7 +73,7 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 		{
 			//XForcing.bndseg[iseg].data = readbndfile(XForcing.bndseg[iseg].inputfile, XParam);
 
-			if (XForcing.Rain.uniform == 1)
+			if (XForcing.bndseg[iseg].uniform == 1)
 			{
 				// grid uniform time varying rain input
 				XForcing.bndseg[iseg].data = readINfileUNI(XForcing.bndseg[iseg].inputfile, XParam.reftime);

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -71,7 +71,19 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	{
 		if (XForcing.bndseg[iseg].on)
 		{
-			XForcing.bndseg[iseg].data = readbndfile(XForcing.bndseg[iseg].inputfile, XParam);
+			//XForcing.bndseg[iseg].data = readbndfile(XForcing.bndseg[iseg].inputfile, XParam);
+
+			if (XForcing.Rain.uniform == 1)
+			{
+				// grid uniform time varying rain input
+				XForcing.bndseg[iseg].data = readINfileUNI(XForcing.bndseg[iseg].inputfile, XParam.reftime);
+			}
+			else
+			{
+				XForcing.bndseg[iseg].WLmap.denanval = 0.0;
+				InitDynforcing(gpgpu, XParam, XForcing.bndseg[iseg].WLmap);
+				//readDynforcing(gpgpu, XParam.totaltime, XForcing.Rain);
+			}
 		}
 	}
 
@@ -1189,7 +1201,7 @@ std::vector<Windin> readINfileUNI(std::string filename, std::string &refdate)
 
 	if (fs.fail()) {
 		//std::cerr << filename << "ERROR: Atm presssure / Rainfall file could not be opened" << std::endl;
-		log("ERROR: Atm presssure / Rainfall file could not be opened : " + filename);
+		log("ERROR: Bnd file / Atm presssure / Rainfall file could not be opened : " + filename);
 		exit(1);
 	}
 

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -622,6 +622,22 @@ std::string readCRSfrombathy(std::string crs_ref, StaticForcingP<float>& Sforcin
 	return crs_wkt;
 }
 
+Polygon readbndsegment(bndsegment bnd)
+{
+	Polygon bndpoly;
+
+	if (bnd.polyfile == "left")
+	{
+
+	}
+	else
+	{
+		bndpoly = readPolygon(bnd.polyfile);
+	}
+	
+	return bndpoly;
+}
+
 /*! \fn std::vector<SLTS> readbndfile(std::string filename,Param XParam, int side)
 * Read boundary forcing files
 * 

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -67,6 +67,15 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	// Read bnd files
 	log("\nReading boundary data...");
 
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		if (XForcing.bndseg[iseg].on)
+		{
+			XForcing.bndseg[iseg].data = readbndfile(XForcing.bndseg[iseg].inputfile, XParam);
+		}
+	}
+
+	/*
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 	
 
@@ -115,6 +124,9 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 			AllocateBndTEX(XForcing.bot);
 		}
 	}
+	*/
+
+
 
 	//Check that endtime is no longer than boundaries (if specified to other than wall or neumann)
 	// Removed. This is better done in the sanity check!
@@ -626,7 +638,7 @@ Polygon readbndpolysegment(bndsegment bnd, Param XParam)
 {
 	Polygon bndpoly;
 	Vertex va,vb,vc,vd;
-	double epsbnd = XParam.dx*2.0;
+	double epsbnd = calcres(XParam.dx,XParam.initlevel);
 	double xo = XParam.xo;
 	double xmax = XParam.xmax;
 	double yo = XParam.yo;
@@ -715,7 +727,7 @@ Polygon readbndpolysegment(bndsegment bnd, Param XParam)
 * Read boundary forcing files
 * 
 */
-std::vector<SLTS> readbndfile(std::string filename,Param & XParam, int side)
+std::vector<SLTS> readbndfile(std::string filename,Param & XParam)
 {
 	// read bnd or nest file
 	// side is for deciding whether we are talking about a left(side=0) bot (side =1) right (side=2) or top (side=3)

--- a/src/ReadForcing.h
+++ b/src/ReadForcing.h
@@ -14,7 +14,7 @@
 
 template<class T> void readforcing(Param& XParam, Forcing<T> & XForcing);
 
-std::vector<SLTS> readbndfile(std::string filename, Param & XParam, int side);
+std::vector<SLTS> readbndfile(std::string filename, Param & XParam);
 std::vector<SLTS> readWLfile(std::string WLfilename,  std::string& refdate);
 
 std::vector<SLTS> readNestfile(std::string ncfile, std::string varname, int hor, double eps, double bndxo, double bndxmax, double bndy);

--- a/src/ReadForcing.h
+++ b/src/ReadForcing.h
@@ -56,6 +56,7 @@ template <class T> void clampedges(int nx, int ny, T clamp, T* z);
 std::vector<std::string> DelimLine(std::string line, int n, char delim);
 std::vector<std::string> DelimLine(std::string line, int n);
 Polygon readPolygon(std::string filename);
+Polygon readbndpolysegment(bndsegment bnd, Param XParam);
 
 
 // End of global definition

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1195,6 +1195,36 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 		XForcing.bndseg[iseg].bot.istop = -1;
 	}
 
+	bndsegment remainderblk;
+
+	remainderblk.left.isright = -1;
+	remainderblk.left.istop = 0;
+
+	remainderblk.right.isright = 1;
+	remainderblk.right.istop = 0;
+
+	remainderblk.top.isright = 0;
+	remainderblk.top.istop = 1;
+
+	remainderblk.bot.isright = 0;
+	remainderblk.bot.istop = -1;
+	remainderblk.type = XParam.aoibnd;
+
+	XForcing.bndseg.push_back(remainderblk);
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].left.blk);
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].right.blk);
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].top.blk);
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].bot.blk);
+
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].left.qmean);
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].right.qmean);
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].top.qmean);
+		AllocateCPU(1, 1, XForcing.bndseg[iseg].bot.qmean);
+	}
+
 	
 	
 	
@@ -1594,16 +1624,15 @@ bndsegment readbndlineside(std::string parametervalue, std::string side)
 	else if (items.size() >= 2)
 	{
 		const char* cstr = items[1].c_str();
-		if (items[1].length() < 2)
+		
+		if (isdigit(cstr[0]))
 		{
-			if (!isdigit(cstr[0]))
-			{
-				// Error
-				//exit?
-			}
+			//?
 			bnd.type = std::stoi(items[1]);
 			bnd.inputfile = items[0];
 			bnd.on = true;
+			
+			
 			
 		}
 		else
@@ -1612,8 +1641,9 @@ bndsegment readbndlineside(std::string parametervalue, std::string side)
 			bnd.inputfile = items[1];
 			bnd.on = true;
 		}
-		bnd.polyfile = side;
+		
 	}
+	bnd.polyfile = side;
 	return bnd;
 }
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1661,9 +1661,9 @@ bool readparambool(std::string paramstr,bool defaultval)
 
 
 
-inline bool fileexists(const std::string& name) {
-	struct stat buffer;
-	return (stat(name.c_str(), &buffer) == 0);
-}
+//inline bool fileexists(const std::string& name) {
+//	struct stat buffer;
+//	return (stat(name.c_str(), &buffer) == 0);
+//}
 
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1540,6 +1540,23 @@ std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> ve
 	return found;
 }
 
+
+bndparam readbndlineNew(std::string parametervalue)
+{
+	bndparam bnd;
+
+	std::vector<std::string> items = split(parametervalue, ',');
+
+	if (items.size() == 1)
+	{
+		bnd.type = std::stoi(items[0]);
+
+	}
+	
+	return bnd;
+}
+
+
 bndparam readbndline(std::string parametervalue)
 {
 	bndparam bnd;

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1182,6 +1182,17 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	{
 		XForcing.bndseg[iseg].poly= readbndpolysegment(XForcing.bndseg[iseg], XParam);
 
+		XForcing.bndseg[iseg].left.isright = -1;
+		XForcing.bndseg[iseg].left.istop = 0;
+
+		XForcing.bndseg[iseg].right.isright = 1;
+		XForcing.bndseg[iseg].right.istop = 0;
+
+		XForcing.bndseg[iseg].top.isright = 0;
+		XForcing.bndseg[iseg].top.istop = 1;
+
+		XForcing.bndseg[iseg].bot.isright = 0;
+		XForcing.bndseg[iseg].bot.istop = -1;
 	}
 
 	
@@ -1189,7 +1200,7 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	
 	
 	//setup extra infor about boundaries
-	// This is not needed anymore?
+	// This is not needed anymore
 	XForcing.left.side = 3;
 	XForcing.left.isright = -1;
 	XForcing.left.istop = 0;

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -216,7 +216,7 @@ Param readparamstr(std::string line, Param param)
 		param.conserveElevation = readparambool(parametervalue, param.conserveElevation);
 	}
 
-	paramvec = { "wetdryfix","reminstab" };
+	paramvec = { "wetdryfix","reminstab","fixinstab" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -304,6 +304,13 @@ Param readparamstr(std::string line, Param param)
 	if (!parametervalue.empty())
 	{
 		param.dtmin = std::stod(parametervalue);
+
+	}
+	parameterstr = "bndtaper";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		param.bndtaper = std::stod(parametervalue);
 
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -818,6 +818,8 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 	{
 		//forcing.left = readbndline(parametervalue);
 		forcing.bndseg.push_back(readbndlineside(parametervalue, "left"));
+
+		
 			
 	}
 	
@@ -1651,6 +1653,23 @@ bndsegment readbndlineside(std::string parametervalue, std::string side)
 		
 	}
 	bnd.polyfile = side;
+	if (bnd.on)
+	{
+		bnd.WLmap = readfileinfo(bnd.inputfile, bnd.WLmap);
+
+		//set the expected type of input
+
+		if (bnd.WLmap.extension.compare("nc") == 0)
+		{
+			bnd.WLmap.uniform = 0;
+			bnd.uniform = 0;
+		}
+		else
+		{
+			bnd.WLmap.uniform = 1;
+			bnd.uniform = 1;
+		}
+	}
 	return bnd;
 }
 
@@ -1681,6 +1700,27 @@ bndsegment readbndline(std::string parametervalue)
 			bnd.polyfile = items[0];
 			bnd.type = std::max(std::stoi(items[1]),1); // only 2 param implies that it is either a wall or Neumann bnd
 	
+		}
+	}
+	
+
+	//set the expected type of input
+
+	if (bnd.on)
+	{
+		bnd.WLmap = readfileinfo(bnd.inputfile, bnd.WLmap);
+
+		//set the expected type of input
+
+		if (bnd.WLmap.extension.compare("nc") == 0)
+		{
+			bnd.WLmap.uniform = 0;
+			bnd.uniform = 0;
+		}
+		else
+		{
+			bnd.WLmap.uniform = 1;
+			bnd.uniform = 1;
 		}
 	}
 	return bnd;

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1541,9 +1541,9 @@ std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> ve
 }
 
 
-bndparam readbndlineNew(std::string parametervalue)
+bndsegment readbndlineside(std::string parametervalue)
 {
-	bndparam bnd;
+	bndsegment bnd;
 
 	std::vector<std::string> items = split(parametervalue, ',');
 
@@ -1552,7 +1552,27 @@ bndparam readbndlineNew(std::string parametervalue)
 		bnd.type = std::stoi(items[0]);
 
 	}
-	
+	else if (items.size() >= 2)
+	{
+		const char* cstr = items[1].c_str();
+		if (items[1].length() < 2)
+		{
+			if (!isdigit(cstr[0]))
+			{
+				// Error
+				//exit?
+			}
+			bnd.type = std::stoi(items[1]);
+			bnd.inputfile = items[0];
+			bnd.on = true;
+		}
+		else
+		{
+			bnd.type = std::stoi(items[0]);
+			bnd.inputfile = items[1];
+			bnd.on = true;
+		}
+	}
 	return bnd;
 }
 
@@ -1608,3 +1628,7 @@ bool readparambool(std::string paramstr,bool defaultval)
 	return out;
 }
 
+inline bool fileexists(const std::string& name) {
+	struct stat buffer;
+	return (stat(name.c_str(), &buffer) == 0);
+}

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -809,7 +809,8 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		forcing.left = readbndline(parametervalue);
+		//forcing.left = readbndline(parametervalue);
+		forcing.bndseg.push_back(readbndlineside(parametervalue, "left"));
 			
 	}
 	
@@ -817,7 +818,8 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		forcing.right = readbndline(parametervalue);
+		//forcing.right = readbndline(parametervalue);
+		forcing.bndseg.push_back(readbndlineside(parametervalue, "right"));
 
 	}
 
@@ -825,14 +827,16 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		forcing.top = readbndline(parametervalue);
+		//forcing.top = readbndline(parametervalue);
+		forcing.bndseg.push_back(readbndlineside(parametervalue, "top"));
 	}
 
 	paramvec = { "bot","botbndfile","botbnd","bottom" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		forcing.bot = readbndline(parametervalue);
+		//forcing.bot = readbndline(parametervalue);
+		forcing.bndseg.push_back(readbndlineside(parametervalue, "bot"));
 	}
 
 
@@ -1541,9 +1545,10 @@ std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> ve
 }
 
 
-bndsegment readbndlineside(std::string parametervalue)
+bndsegment readbndlineside(std::string parametervalue, std::string side)
 {
 	bndsegment bnd;
+
 
 	std::vector<std::string> items = split(parametervalue, ',');
 
@@ -1565,6 +1570,7 @@ bndsegment readbndlineside(std::string parametervalue)
 			bnd.type = std::stoi(items[1]);
 			bnd.inputfile = items[0];
 			bnd.on = true;
+			
 		}
 		else
 		{
@@ -1572,6 +1578,7 @@ bndsegment readbndlineside(std::string parametervalue)
 			bnd.inputfile = items[1];
 			bnd.on = true;
 		}
+		bnd.polyfile = side;
 	}
 	return bnd;
 }

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -743,6 +743,13 @@ Param readparamstr(std::string line, Param param)
 		param.crs_ref = parametervalue;
 	}
 
+	paramvec = { "savebyblk", "writebyblk","saveperblk", "writeperblk","savebyblock", "writebyblock","saveperblock", "writeperblock" };
+	parametervalue = findparameter(paramvec, line);
+	if (!parametervalue.empty())
+	{
+		param.savebyblk = readparambool(parametervalue, param.savebyblk);
+	}
+
 	return param;
 }
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -839,6 +839,14 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		forcing.bndseg.push_back(readbndlineside(parametervalue, "bot"));
 	}
 
+	paramvec = { "bnd","bndseg" };
+	parametervalue = findparameter(paramvec, line);
+	if (!parametervalue.empty())
+	{
+		//forcing.bot = readbndline(parametervalue);
+		forcing.bndseg.push_back(readbndline(parametervalue));
+	}
+
 
 	//Tsunami deformation input files
 	parameterstr = "deform";
@@ -1584,9 +1592,10 @@ bndsegment readbndlineside(std::string parametervalue, std::string side)
 }
 
 
-bndparam readbndline(std::string parametervalue)
+bndsegment readbndline(std::string parametervalue)
 {
-	bndparam bnd;
+	//bndseg = area.txt, waterlevelforcing, 1;
+	bndsegment bnd;
 	std::vector<std::string> items = split(parametervalue, ',');
 	if (items.size() == 1)
 	{
@@ -1596,26 +1605,25 @@ bndparam readbndline(std::string parametervalue)
 	else if (items.size() >= 2)
 	{
 		const char* cstr = items[1].c_str();
-		if (items[1].length()<2)
+		if (items[1].length()>2)
 		{
-			if (!isdigit(cstr[0]))
-			{
-				// Error
-				//exit?
-			}
-			bnd.type = std::stoi(items[1]);
-			bnd.inputfile = items[0];
+			bnd.polyfile = items[0];
+			bnd.type = std::stoi(items[2]);
+			bnd.inputfile = items[1];
 			bnd.on = true;
+			
 		}
 		else
 		{
-			bnd.type = std::stoi(items[0]);
-			bnd.inputfile = items[1];
-			bnd.on = true;
+			bnd.polyfile = items[0];
+			bnd.type = std::max(std::stoi(items[1]),1); // only 2 param implies that it is either a wall or Neumann bnd
+	
 		}
 	}
 	return bnd;
 }
+
+
 
 bool readparambool(std::string paramstr,bool defaultval)
 {

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1177,7 +1177,19 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 		}
 	}
 
+	// Read/setup bdn segment polygon. Note this can't be part of the "readforcing" step because xmin, xmax ymin ymax are not known then
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		XForcing.bndseg[iseg].poly= readbndpolysegment(XForcing.bndseg[iseg], XParam);
+
+	}
+
+	
+	
+	
+	
 	//setup extra infor about boundaries
+	// This is not needed anymore?
 	XForcing.left.side = 3;
 	XForcing.left.isright = -1;
 	XForcing.left.istop = 0;
@@ -1193,6 +1205,9 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	XForcing.bot.side = 2;
 	XForcing.bot.isright = 0;
 	XForcing.bot.istop = -1;
+
+
+	//
 
 	XForcing.Atmp.clampedge = float(XParam.Paref);
 
@@ -1643,7 +1658,12 @@ bool readparambool(std::string paramstr,bool defaultval)
 	return out;
 }
 
+
+
+
 inline bool fileexists(const std::string& name) {
 	struct stat buffer;
 	return (stat(name.c_str(), &buffer) == 0);
 }
+
+

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1197,6 +1197,11 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
 	{
 		XForcing.bndseg[iseg].poly= readbndpolysegment(XForcing.bndseg[iseg], XParam);
+		if (XForcing.bndseg[iseg].type == 2)
+		{
+			XForcing.bndseg[iseg].type = 3;
+		}
+
 
 		XForcing.bndseg[iseg].left.isright = -1;
 		XForcing.bndseg[iseg].left.istop = 0;

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -30,9 +30,9 @@ std::string trim(const std::string& str, const std::string& whitespace);
 std::size_t case_insensitive_compare(std::string s1, std::string s2);
 std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> vecstr);
 bool readparambool(std::string paramstr, bool defaultval);
-bndparam readbndline(std::string parametervalue);
+bndsegment readbndline(std::string parametervalue);
 
-inline bool fileexists(const std::string& name)
+inline bool fileexists(const std::string& name);
 
 // End of global definition
 #endif

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -32,5 +32,7 @@ std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> ve
 bool readparambool(std::string paramstr, bool defaultval);
 bndparam readbndline(std::string parametervalue);
 
+inline bool fileexists(const std::string& name)
+
 // End of global definition
 #endif

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -33,7 +33,9 @@ std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> ve
 bool readparambool(std::string paramstr, bool defaultval);
 bndsegment readbndline(std::string parametervalue);
 
-inline bool fileexists(const std::string& name);
+bndsegment readbndlineside(std::string parametervalue, std::string side);
+
+//inline bool fileexists(const std::string& name);
 
 // End of global definition
 #endif

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -8,6 +8,7 @@
 #include "Forcing.h"
 #include "Util_CPU.h"
 #include "utctime.h"
+#include "ReadForcing.h"
 
 
 template <class T> T readfileinfo(std::string input, T outinfo);

--- a/src/Read_netcdf.cu
+++ b/src/Read_netcdf.cu
@@ -487,16 +487,22 @@ int readnctime2(int ncid,std::string refdate,size_t nt, double*& time)
 		// convert to string
 		tunitstr = std::string(tunit);
 
-		// Try to make sense of the unit
-		// The word "since" should be in the center
-		// e.g. hour since 2000-01-01 00:00:00 
-		std::vector<std::string> nodeitems = split(tunitstr, "since");
-		std::string ncstepunit = trim(nodeitems[0]," ");
-		std::string ncrefdatestr = trim(nodeitems[1], " ");
+		std::string ncstepunit= tunitstr;
 
-		//time_t ncrefdate = date_string_to_time(ncrefdatestr);
-		offset = date_string_to_s(ncrefdatestr, refdate);
+		if (tunitstr.find("since") != std::string::npos)
+		{
 
+			// Try to make sense of the unit
+			// The word "since" should be in the center
+			// e.g. hour since 2000-01-01 00:00:00 
+			std::vector<std::string> nodeitems = split(tunitstr, "since");
+			ncstepunit = trim(nodeitems[0], " ");
+			std::string ncrefdatestr = trim(nodeitems[1], " ");
+
+			//time_t ncrefdate = date_string_to_time(ncrefdatestr);
+			offset = date_string_to_s(ncrefdatestr, refdate);
+		}
+	
 		std::vector<std::string> secondvec = { "seconds","second","sec","s" };
 		std::vector<std::string> minutevec = { "minutes","minute","min","m" };
 		std::vector<std::string> hourvec = { "hours","hour","hrs","hr","h" };
@@ -529,7 +535,7 @@ int readnctime2(int ncid,std::string refdate,size_t nt, double*& time)
 		found = case_insensitive_compare(ncstepunit, yearvec);
 		if (found == 0)
 			fac = 3600.0 * 24.0 * 365.25;
-
+		
 
 	}
 

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -47,6 +47,35 @@ template <class T> void SetupGPU(Param &XParam, Model<T> XModel,Forcing<float> &
 		AllocateGPU(XForcing.bot.nblk, 1, XForcing.bot.blks_g);
 		CopytoGPU(XForcing.bot.nblk, 1, XForcing.bot.blks, XForcing.bot.blks_g);
 
+
+		for (int s = 0; s < XForcing.bndseg.size(); s++)
+		{
+			AllocateGPU(XForcing.bndseg[s].left.nblk, 1, XForcing.bndseg[s].left.blk_g);
+			CopytoGPU(XForcing.bndseg[s].left.nblk, 1, XForcing.bndseg[s].left.blk, XForcing.bndseg[s].left.blk_g);
+
+			AllocateGPU(XForcing.bndseg[s].right.nblk, 1, XForcing.bndseg[s].right.blk_g);
+			CopytoGPU(XForcing.bndseg[s].right.nblk, 1, XForcing.bndseg[s].right.blk, XForcing.bndseg[s].right.blk_g);
+
+			AllocateGPU(XForcing.bndseg[s].top.nblk, 1, XForcing.bndseg[s].top.blk_g);
+			CopytoGPU(XForcing.bndseg[s].top.nblk, 1, XForcing.bndseg[s].top.blk, XForcing.bndseg[s].top.blk_g);
+
+			AllocateGPU(XForcing.bndseg[s].bot.nblk, 1, XForcing.bndseg[s].bot.blk_g);
+			CopytoGPU(XForcing.bndseg[s].bot.nblk, 1, XForcing.bndseg[s].bot.blk, XForcing.bndseg[s].bot.blk_g);
+
+			AllocateGPU(XForcing.bndseg[s].left.nblk, XParam.blkwidth, XForcing.bndseg[s].left.qmean_g);
+			CopytoGPU(XForcing.bndseg[s].left.nblk, XParam.blkwidth, XForcing.bndseg[s].left.qmean, XForcing.bndseg[s].left.qmean_g);
+
+			AllocateGPU(XForcing.bndseg[s].right.nblk, XParam.blkwidth, XForcing.bndseg[s].right.qmean_g);
+			CopytoGPU(XForcing.bndseg[s].right.nblk, XParam.blkwidth, XForcing.bndseg[s].right.qmean, XForcing.bndseg[s].right.qmean_g);
+
+			AllocateGPU(XForcing.bndseg[s].top.nblk, XParam.blkwidth, XForcing.bndseg[s].top.qmean_g);
+			CopytoGPU(XForcing.bndseg[s].top.nblk, XParam.blkwidth, XForcing.bndseg[s].top.qmean, XForcing.bndseg[s].top.qmean_g);
+
+			AllocateGPU(XForcing.bndseg[s].bot.nblk, XParam.blkwidth, XForcing.bndseg[s].bot.qmean_g);
+			CopytoGPU(XForcing.bndseg[s].bot.nblk, XParam.blkwidth, XForcing.bndseg[s].bot.qmean, XForcing.bndseg[s].bot.qmean_g);
+		}
+
+
 		// Also for mask
 		XModel_g.blocks.mask.nblk = XModel.blocks.mask.nblk;
 		AllocateGPU(XModel_g.blocks.mask.nblk, 1, XModel_g.blocks.mask.side);

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -583,6 +583,8 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 
 					printf("ib=%d, ix=%d, iy=%d; simulated=%f; expected=%f; diff=%e\n", ib, ix, iy, XModel.evolv.zs[n], ZsVerifButtinger[iv], diff);
 					modelgood = false;
+					creatncfileBUQ(XParam, XModel.blocks);
+					defncvarBUQ(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, "zs", 3, XModel.evolv.zs, XModel.blocks.outZone[0]);
 				}
 
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -264,10 +264,16 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		*/
 		bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
 		log("\t###AOI bnd wall test ###");
-		wallbndleft=TestAIObnd(XParam, XModel, XModel_g,false,false);
-		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true);
-		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false);
-		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true);
+		wallbndleft=TestAIObnd(XParam, XModel, XModel_g,false,false, false);
+		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, false);
+		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, false);
+		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, false);
+		result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
+		log("\t\tBBox bnd wall test : " + result);
+		wallbndleft = TestAIObnd(XParam, XModel, XModel_g, false, false, true);
+		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, true);
+		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, true);
+		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, true);
 		result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
 		log("\t\tAOI bnd wall test : " + result);
 	}
@@ -4312,7 +4318,7 @@ template <class T> void Testzbinit(Param XParam, Forcing<float> XForcing, Model<
 }
 
 
-template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel_g, bool bottop,bool flip)
+template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel_g, bool bottop,bool flip, bool withaoi)
 {
 	Forcing<float> XForcing;
 
@@ -4366,10 +4372,12 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	aoi_file << "-5.0 -3.0" << std::endl;
 	aoi_file.close(); //destructor implicitly does it
 	*/
-	XForcing.AOI.file = "testaoi.tmp";
-	XForcing.AOI.active = true;
-	XForcing.AOI.poly = readPolygon(XForcing.AOI.file);
-
+	if (withaoi)
+	{	
+		XForcing.AOI.file = "testaoi.tmp";
+		XForcing.AOI.active = true;
+		XForcing.AOI.poly = readPolygon(XForcing.AOI.file);
+	}
 	
 	XParam.minlevel = 3;
 	XParam.maxlevel = 3;

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4310,7 +4310,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 {
 	Forcing<float> XForcing;
 
-	XForcing = MakValleyBathy(XParam, T(0.4), true, true);
+	XForcing = MakValleyBathy(XParam, T(0.4), false, true);
 
 	XParam.conserveElevation = true;
 
@@ -4334,7 +4334,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 
 	XParam.dx = XForcing.Bathy[0].dx;
 
-	XParam.zsinit = mintopo + 6.9;// Had a water level so that the wet and dry affects the 
+	XParam.zsinit = mintopo - 6.9;// Had a water level so that the wet and dry affects the 
 	XParam.endtime = 20.0;
 
 	XParam.dtmin = 0.00000001;

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -259,10 +259,13 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 
 		if (mytest == 13)
 		{
-			bool wallbnd;
+			bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
 			log("\t###AOI bnd wall test ###");
-			wallbnd=TestAIObnd(XParam, XModel, XModel_g);
-			result = wallbnd ? "successful" : "failed";
+			wallbndleft=TestAIObnd(XParam, XModel, XModel_g,false,false);
+			wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true);
+			wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false);
+			wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true);
+			result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
 			log("\t\tAOI bnd wall test : " + result);
 		}
 		if (mytest == 994)
@@ -4306,11 +4309,11 @@ template <class T> void Testzbinit(Param XParam, Forcing<float> XForcing, Model<
 }
 
 
-template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel_g)
+template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel_g, bool bottop,bool flip)
 {
 	Forcing<float> XForcing;
 
-	XForcing = MakValleyBathy(XParam, T(0.4), false, true);
+	XForcing = MakValleyBathy(XParam, T(0.4), bottop, flip);
 
 	XParam.conserveElevation = true;
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -373,6 +373,8 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 	XParam.zsinit = zsnit;
 	XParam.zsoffset = 0.0;
 
+	XParam.aoibnd = 3;
+
 	//Output times for comparisons
 	XParam.endtime = 1.0;
 	XParam.outputtimestep = 0.1;
@@ -416,7 +418,7 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 	XForcing.Bathy[0].dx = 1.0;
 	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
 
-	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
+	//AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
 	AllocateCPU(XForcing.Bathy[0].nx, XForcing.Bathy[0].ny, XForcing.Bathy[0].val);
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -257,17 +257,20 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		log("\t\tCalendar time test : " + result);
 	}
 
-		if (mytest == 13)
-		{
-			bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
-			log("\t###AOI bnd wall test ###");
-			wallbndleft=TestAIObnd(XParam, XModel, XModel_g,false,false);
-			wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true);
-			wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false);
-			wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true);
-			result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
-			log("\t\tAOI bnd wall test : " + result);
-		}
+	if (mytest == 13)
+	{
+		/* Test 13  This test AOI bnds aswall to start with
+
+		*/
+		bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
+		log("\t###AOI bnd wall test ###");
+		wallbndleft=TestAIObnd(XParam, XModel, XModel_g,false,false);
+		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true);
+		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false);
+		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true);
+		result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
+		log("\t\tAOI bnd wall test : " + result);
+	}
 		if (mytest == 994)
 		{
 			Testzbinit(XParam, XForcing, XModel, XModel_g);

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -519,7 +519,10 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 		}
 		if (XParam.GPUDEVICE >= 0 && compare)
 		{
+			int GPUdev = XParam.GPUDEVICE;
+			XParam.GPUDEVICE = -1;
 			FlowCPU(XParam, XLoop, XForcing, XModel);
+			XParam.GPUDEVICE = GPUdev;
 
 			T diffdt = T(XLoop_g.dt - XLoop.dt);
 			if (abs(diffdt) > T(100.0) * (XLoop.epsilon))

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -257,9 +257,13 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		log("\t\tCalendar time test : " + result);
 	}
 
-		if (mytest == 993)
+		if (mytest == 13)
 		{
-			TestAIObnd(XParam, XModel, XModel_g);
+			bool wallbnd;
+			log("\t###AOI bnd wall test ###");
+			wallbnd=TestAIObnd(XParam, XModel, XModel_g);
+			result = wallbnd ? "successful" : "failed";
+			log("\t\tAOI bnd wall test : " + result);
 		}
 		if (mytest == 994)
 		{

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4489,7 +4489,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 
 	T error = abs(SimulatedVolume - TheoryInput);
 
-	int modelgood = error / TheoryInput < 0.05;
+	int modelgood = error / TheoryInput < 0.001;
 
 	printf("\nSim Vol = %f, theory=%f, Error = %f, (%f %%) \n", SimulatedVolume, TheoryInput, error, (error / TheoryInput)*100);
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -268,7 +268,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		*/
 		bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
 		log("\t###AOI bnd wall test ###");
-		wallbndleft=TestAIObnd(XParam, XModel, XModel_g,false,false, false);
+		wallbndleft = TestAIObnd(XParam, XModel, XModel_g, false, false, false);
 		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, false);
 		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, false);
 		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, false);
@@ -280,7 +280,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, true);
 		result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
 		log("\t\tAOI bnd wall test : " + result);
-
+	}
 	if (mytest == 13)
 	{
 		/* Test 13 is to test the input of different roughness maps (and different bathymetry at the same time)

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4358,6 +4358,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	XParam.endtime = 20.0;
 
 	XParam.dtmin = 0.00000001;
+	XParam.aoibnd = 0;
 
 	XParam.outputtimestep = XParam.endtime;
 	

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4346,7 +4346,8 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 
 	XParam.dx = XForcing.Bathy[0].dx;
 
-	XParam.zsinit = mintopo - 6.9;// Had a water level so that the wet and dry affects the 
+	//XParam.zsinit = mintopo - 6.9;// Had a water level so that the wet and dry affects the 
+	XParam.zsinit = mintopo - 9.9;// Had a water level so that the wet and dry affects the 
 	XParam.endtime = 20.0;
 
 	XParam.dtmin = 0.00000001;
@@ -4377,6 +4378,23 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 		XForcing.AOI.file = "testaoi.tmp";
 		XForcing.AOI.active = true;
 		XForcing.AOI.poly = readPolygon(XForcing.AOI.file);
+	}
+
+	if (bottop==false && flip==false)
+	{
+		XForcing.left.type = 0;
+	}
+	if (bottop == false && flip == true)
+	{
+		XForcing.right.type = 0;
+	}
+	if (bottop == true && flip == false)
+	{
+		XForcing.bot.type = 0;
+	}
+	if (bottop == true && flip == true)
+	{
+		XForcing.top.type = 0;
 	}
 	
 	XParam.minlevel = 3;

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4379,7 +4379,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 		XForcing.AOI.active = true;
 		XForcing.AOI.poly = readPolygon(XForcing.AOI.file);
 	}
-
+	/*
 	if (bottop==false && flip==false)
 	{
 		XForcing.left.type = 0;
@@ -4396,7 +4396,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	{
 		XForcing.top.type = 0;
 	}
-	
+	*/
 	XParam.minlevel = 3;
 	XParam.maxlevel = 3;
 	XParam.initlevel = 3;

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -19,6 +19,13 @@ template <class T> void updateforcing(Param XParam, Loop<T> XLoop, Forcing<float
 		Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.UWind);
 		Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.VWind);
 	}
+	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
+	{
+		if (XForcing.bndseg[iseg].on && !XForcing.bndseg[iseg].uniform)
+		{
+			Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.bndseg[iseg].WLmap);
+		}
+	}
 
 	
 }

--- a/src/Updateforcing.cu
+++ b/src/Updateforcing.cu
@@ -8,16 +8,16 @@ template <class T> void updateforcing(Param XParam, Loop<T> XLoop, Forcing<float
 	//if a file is declared that implies that the dynamic forcing is applicable
 	if (!XForcing.Rain.inputfile.empty())
 	{
-		Forcingthisstep(XParam, XLoop, XForcing.Rain);
+		Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.Rain);
 	}
 	if (!XForcing.Atmp.inputfile.empty())
 	{
-		Forcingthisstep(XParam, XLoop, XForcing.Atmp);
+		Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.Atmp);
 	}
 	if (!XForcing.UWind.inputfile.empty())//&& !XForcing.UWind.inputfile.empty()
 	{
-		Forcingthisstep(XParam, XLoop, XForcing.UWind);
-		Forcingthisstep(XParam, XLoop, XForcing.VWind);
+		Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.UWind);
+		Forcingthisstep(XParam, double(XLoop.totaltime), XForcing.VWind);
 	}
 
 	
@@ -28,7 +28,7 @@ template void updateforcing<double>(Param XParam, Loop<double> XLoop, Forcing<fl
 
 
 
-template <class T> void Forcingthisstep(Param XParam, Loop<T> XLoop, DynForcingP<float> &XDynForcing)
+void Forcingthisstep(Param XParam, double totaltime, DynForcingP<float> &XDynForcing)
 {
 	dim3 blockDimDF(16, 16, 1);
 	dim3 gridDimDF((int)ceil((float)XDynForcing.nx / (float)blockDimDF.x), (int)ceil((float)XDynForcing.ny / (float)blockDimDF.y), 1);
@@ -42,22 +42,22 @@ template <class T> void Forcingthisstep(Param XParam, Loop<T> XLoop, DynForcingP
 
 		// Do this for all the corners
 		//Needs limiter in case WLbnd is empty
-		double difft = XDynForcing.unidata[Rstepinbnd].time - XLoop.totaltime;
+		double difft = XDynForcing.unidata[Rstepinbnd].time - totaltime;
 
 		while (difft < 0.0)
 		{
 			Rstepinbnd++;
-			difft = XDynForcing.unidata[Rstepinbnd].time - XLoop.totaltime;
+			difft = XDynForcing.unidata[Rstepinbnd].time - totaltime;
 		}
 
-		XDynForcing.nowvalue = T(interptime(XDynForcing.unidata[Rstepinbnd].wspeed, XDynForcing.unidata[Rstepinbnd - 1].wspeed, XDynForcing.unidata[Rstepinbnd].time - XDynForcing.unidata[Rstepinbnd - 1].time, XLoop.totaltime - XDynForcing.unidata[Rstepinbnd - 1].time));
+		XDynForcing.nowvalue =interptime(XDynForcing.unidata[Rstepinbnd].wspeed, XDynForcing.unidata[Rstepinbnd - 1].wspeed, XDynForcing.unidata[Rstepinbnd].time - XDynForcing.unidata[Rstepinbnd - 1].time, totaltime - XDynForcing.unidata[Rstepinbnd - 1].time);
 
 
 
 	}
 	else
 	{
-		int readfirststep = min(max((int)floor((XLoop.totaltime - XDynForcing.to) / XDynForcing.dt), 0), XDynForcing.nt - 2);
+		int readfirststep = std::min(std::max((int)floor((totaltime - XDynForcing.to) / XDynForcing.dt), 0), XDynForcing.nt - 2);
 
 		if (readfirststep + 1 > XDynForcing.instep)
 		{
@@ -91,14 +91,14 @@ template <class T> void Forcingthisstep(Param XParam, Loop<T> XLoop, DynForcingP
 		// Interpolate the forcing array to this time 
 		if (XParam.GPUDEVICE >= 0)
 		{
-			InterpstepGPU << <gridDimDF, blockDimDF, 0 >> > (XDynForcing.nx, XDynForcing.ny, XDynForcing.instep - 1, float(XLoop.totaltime), float(XDynForcing.dt), XDynForcing.now_g, XDynForcing.before_g, XDynForcing.after_g);
+			InterpstepGPU << <gridDimDF, blockDimDF, 0 >> > (XDynForcing.nx, XDynForcing.ny, XDynForcing.instep - 1, float(totaltime), float(XDynForcing.dt), XDynForcing.now_g, XDynForcing.before_g, XDynForcing.after_g);
 			CUDA_CHECK(cudaDeviceSynchronize());
 
 			CUDA_CHECK(cudaMemcpyToArray(XDynForcing.GPU.CudArr, 0, 0, XDynForcing.now_g, XDynForcing.nx * XDynForcing.ny * sizeof(float), cudaMemcpyDeviceToDevice));
 		}
 		else
 		{
-			InterpstepCPU(XDynForcing.nx, XDynForcing.ny, XDynForcing.instep - 1, XLoop.totaltime, XDynForcing.dt, XDynForcing.val, XDynForcing.before, XDynForcing.after);
+			InterpstepCPU(XDynForcing.nx, XDynForcing.ny, XDynForcing.instep - 1, totaltime, XDynForcing.dt, XDynForcing.val, XDynForcing.before, XDynForcing.after);
 		}
 		//InterpstepCPU(XParam.windU.nx, XParam.windU.ny, readfirststep, XParam.totaltime, XParam.windU.dt, Uwind, Uwbef, Uwaft);
 		//InterpstepCPU(XParam.windV.nx, XParam.windV.ny, readfirststep, XParam.totaltime, XParam.windV.dt, Vwind, Vwbef, Vwaft);

--- a/src/Updateforcing.h
+++ b/src/Updateforcing.h
@@ -14,6 +14,7 @@
 
 template <class T> void updateforcing(Param XParam, Loop<T> XLoop, Forcing<float>& XForcing);
 
+void Forcingthisstep(Param XParam, double totaltime, DynForcingP<float>& XDynForcing);
 
 template <class T> __device__ T interpDyn2BUQ(T x, T y, TexSetP Forcing);
 

--- a/src/Updateforcing.h
+++ b/src/Updateforcing.h
@@ -37,7 +37,7 @@ template <class T> __host__ void AddRiverForcing(Param XParam, Loop<T> XLoop, st
 template <class T> void deformstep(Param XParam, Loop<T> XLoop, std::vector<deformmap<float>> deform, Model<T> XModel, Model<T> XModel_g);
 
 template <class T> __global__ void InjectRiverGPU(Param XParam, River XRiver, T qnow, int* Riverblks, BlockP<T> XBlock, AdvanceP<T> XAdv);
-template <class T> __global__ void AddDeformGPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, T scale, T* zs, T* zb);
+template <class T> __global__ void  AddDeformGPU(Param XParam, BlockP<T> XBlock, deformmap<float> defmap, EvolvingP<T> XEv, T scale, T* zb);
 
 
 #endif

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -615,7 +615,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 
 		int shuffle = 1;
 		int deflate = 1;        // This switches compression on (1) or off (0).
-		int deflate_level = 9;  // This is the compression level in range 1 (less) - 9 (more).
+		int deflate_level = 5;  // This is the compression level in range 1 (less) - 9 (more).
 		nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
 
 	}
@@ -743,6 +743,345 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 
 template void defncvarBUQ<float>(Param XParam, int* activeblk, int* level, float* blockxo, float* blockyo, std::string varst, int vdim, float* var, outzoneB Xzone);
 template void defncvarBUQ<double>(Param XParam, int* activeblk, int* level, double* blockxo, double* blockyo, std::string varst, int vdim, double* var, outzoneB Xzone);
+
+
+template <class T> void defncvarBUQlev(Param XParam, int* activeblk, int* level, T* blockxo, T* blockyo, std::string varst, std::string longname, std::string stdname, std::string unit, int vdim, T* var, outzoneB Xzone)
+{
+
+	int smallnc = XParam.smallnc;
+	float scalefactor = XParam.scalefactor;
+	float addoffset = XParam.addoffset;
+	//int nx = ceil(XParam.nx / 16.0) * 16.0;
+	//int ny = ceil(XParam.ny / 16.0) * 16.0;
+	int status;
+	int ncid, var_id;
+	int  var_dimid2D[2];
+	int  var_dimid3D[3];
+	//int  var_dimid4D[4];
+
+	short* varblk_s;
+	float* varblk;
+	int recid, xid, yid;
+	int bl, ibl;
+	//size_t ntheta;// nx and ny are stored in XParam not yet for ntheta
+
+	float fillval = 9.9692e+36f;
+	short fillval_s = (short)round((9.9692e+36f - addoffset) / scalefactor);
+	//short Sfillval = 32767;
+	//short fillval = 32767
+	static size_t start2D[] = { 0, 0 }; // start at first value 
+	//static size_t count2D[] = { ny, nx };
+	static size_t count2D[] = { (size_t)XParam.blkwidth, (size_t)XParam.blkwidth };
+
+	static size_t start3D[] = { 0, 0, 0 }; // start at first value 
+	//static size_t count3D[] = { 1, ny, nx };
+	static size_t count3D[] = { 1, (size_t)XParam.blkwidth, (size_t)XParam.blkwidth };
+	//size_t count3D[3];
+	//count3D[0] = 1;
+	//count3D[1] = XParam.blkwidth;
+	//count3D[2] = XParam.blkwidth;
+
+	//int minlevzone, maxlevzone;
+
+	std::string outfile = Xzone.outname;
+	std::vector<int> activeblkzone = Calcactiveblockzone(XParam, activeblk, Xzone);
+	//Calclevelzone(XParam, minlevzone, maxlevzone, Xzone, level);
+
+
+	nc_type VarTYPE;
+
+	if (smallnc > 0)
+	{
+		VarTYPE = NC_SHORT;
+	}
+	else
+	{
+		VarTYPE = NC_FLOAT;
+	}
+
+	//printf("\n ib=%d count3D=[%d,%d,%d]\n", count3D[0], count3D[1], count3D[2]);
+
+
+	status = nc_open(outfile.c_str(), NC_WRITE, &ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+	status = nc_redef(ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+	//Inquire dimensions ids
+	status = nc_inq_unlimdim(ncid, &recid);//time
+	if (status != NC_NOERR) handle_ncerror(status);
+
+	varblk = (float*)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(float));
+	if (smallnc > 0)
+	{
+
+		varblk_s = (short*)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(short));
+	}
+
+
+	std::string xxname, yyname, varname, sign;
+
+	//generate a different variable name for each level and add attribute as necessary
+	for (int lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
+	{
+
+		//std::string xxname, yyname, sign;
+
+		lev < 0 ? sign = "N" : sign = "P";
+
+
+		xxname = "xx_" + sign + std::to_string(abs(lev));
+		yyname = "yy_" + sign + std::to_string(abs(lev));
+
+		varname = varst + "_" + sign + std::to_string(abs(lev));
+
+
+		//printf("lev=%d; xxname=%s; yyname=%s;\n", lev, xxname.c_str(), yyname.c_str());
+		status = nc_inq_dimid(ncid, xxname.c_str(), &xid);
+		if (status != NC_NOERR) handle_ncerror(status);
+		status = nc_inq_dimid(ncid, yyname.c_str(), &yid);
+		if (status != NC_NOERR) handle_ncerror(status);
+
+
+		var_dimid2D[0] = yid;
+		var_dimid2D[1] = xid;
+
+		var_dimid3D[0] = recid;
+		var_dimid3D[1] = yid;
+		var_dimid3D[2] = xid;
+
+		if (vdim == 2)
+		{
+			status = nc_def_var(ncid, varname.c_str(), VarTYPE, vdim, var_dimid2D, &var_id);
+			if (status != NC_NOERR) handle_ncerror(status);
+		}
+		else if (vdim == 3)
+		{
+			status = nc_def_var(ncid, varname.c_str(), VarTYPE, vdim, var_dimid3D, &var_id);
+			if (status != NC_NOERR) handle_ncerror(status);
+		}
+
+		if (smallnc > 0)
+		{
+
+			status = nc_put_att_short(ncid, var_id, "_FillValue", NC_SHORT, 1, &fillval_s);
+			if (status != NC_NOERR) handle_ncerror(status);
+			status = nc_put_att_short(ncid, var_id, "missingvalue", NC_SHORT, 1, &fillval_s);
+
+			if (status != NC_NOERR) handle_ncerror(status);
+		}
+		else
+		{
+			status = nc_put_att_float(ncid, var_id, "_FillValue", NC_FLOAT, 1, &fillval);
+			if (status != NC_NOERR) handle_ncerror(status);
+			status = nc_put_att_float(ncid, var_id, "missingvalue", NC_FLOAT, 1, &fillval);
+
+			if (status != NC_NOERR) handle_ncerror(status);
+		}
+
+
+		if (smallnc > 0)
+		{
+
+			status = nc_put_att_float(ncid, var_id, "scale_factor", NC_FLOAT, 1, &scalefactor);
+			if (status != NC_NOERR) handle_ncerror(status);
+			status = nc_put_att_float(ncid, var_id, "add_offset", NC_FLOAT, 1, &addoffset);
+			if (status != NC_NOERR) handle_ncerror(status);
+		}
+
+
+		status = nc_put_att_text(ncid, var_id, "standard_name", stdname.size(), stdname.c_str());
+		status = nc_put_att_text(ncid, var_id, "long_name", longname.size(), longname.c_str());
+		status = nc_put_att_text(ncid, var_id, "units", unit.size(), unit.c_str());
+
+		std::string crsstrname = "crs";
+		status = nc_put_att_text(ncid, var_id, "grid_mapping", crsstrname.size(), crsstrname.c_str());
+
+
+		int shuffle = 1;
+		int deflate = 1;        // This switches compression on (1) or off (0).
+		int deflate_level = 5;  // This is the compression level in range 1 (less) - 9 (more).
+		nc_def_var_deflate(ncid, var_id, shuffle, deflate, deflate_level);
+
+	}
+	// End definition
+	status = nc_enddef(ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+
+	//printf("\n ib=%d count3D=[%d,%d,%d]\n", count3D[0], count3D[1], count3D[2]);
+
+	// Now write the initial value of the Variable out
+
+	//std::vector<int> activeblkzone = Calcactiveblockzone(XParam, activeblk, Xzone);
+
+	//####################
+	// Create empty array for each levels
+	std::vector<outP> varlayers;
+	int nx, ny;
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		varlayers.push_back(outP());
+		int levindex = (levi - Xzone.minlevel);
+
+		Calcnxnyzone(XParam, levi, nx, ny, Xzone);
+		varlayers[levindex].z = (float*)malloc(nx * ny * sizeof(float));
+		if (smallnc > 0)
+		{
+
+			varlayers[levindex].z_s = (short*)malloc(nx * ny * sizeof(short));
+		}
+		varlayers[levindex].level = levi;
+
+		for (int j = 0; j < ny; j++)
+		{
+			for (int i = 0; i < nx; i++)
+			{
+				int n = i + j * nx;
+
+				varlayers[levindex].z[n] = fillval;
+				if (smallnc > 0)
+				{
+					varlayers[levindex].z_s[n] = fillval_s;
+				}
+			}
+		}
+	}
+
+	//std::string xxname, yyname, varname, sign;
+	//std::vector<int> activeblkzone = Calcactiveblockzone(XParam, activeblk, Xzone);
+
+
+	//int lev, bl;
+	for (int ibl = 0; ibl < Xzone.nblk; ibl++)
+	{
+		//bl = activeblk[Xzone.blk[ibl]];
+	//for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	//{
+		bl = activeblkzone[ibl];
+		int lev = level[bl];
+
+		double  xxmin, yymin;
+		int nxlev, nylev;
+		//double xxmax, yymax;
+		double initdx = calcres(XParam.dx, XParam.initlevel);
+
+		int io, jo;
+		//xxmax = Xzone.xmax - calcres(XParam.dx, lev) / 2.0;
+		//yymax = Xzone.ymax - calcres(XParam.dx, lev) / 2.0;
+
+		int levindex = (lev - Xzone.minlevel);
+
+		Calcnxnyzone(XParam, lev, nxlev, nylev, Xzone);
+		xxmin = Xzone.xo + calcres(XParam.dx, lev) / 2.0;
+		yymin = Xzone.yo + calcres(XParam.dx, lev) / 2.0;
+
+
+
+		jo = round((XParam.yo + blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+		io = round((XParam.xo + blockxo[bl] - xxmin) / calcres(XParam.dx, lev));
+
+
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			for (int i = 0; i < XParam.blkwidth; i++)
+			{
+				int n = (i + XParam.halowidth + XParam.outishift) + (j + XParam.halowidth + XParam.outjshift) * XParam.blkmemwidth + bl * XParam.blksize;
+				int r = (io + i) + (jo + j) * nxlev;
+				if (smallnc > 0)
+				{
+					// packed_data_value = nint((unpacked_data_value - add_offset) / scale_factor)
+					varlayers[levindex].z_s[r] = (short)round((var[n] - addoffset) / scalefactor);
+				}
+				else
+				{
+					varlayers[levindex].z[r] = (float)var[n];
+				}
+			}
+		}
+
+	}
+
+
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		int nxlev, nylev;
+		Calcnxnyzone(XParam, levi, nxlev, nylev, Xzone);
+		//double  xxmin, yymin;
+		levi < 0 ? sign = "N" : sign = "P";
+		varname = varst + "_" + sign + std::to_string(abs(levi));
+
+		status = nc_inq_varid(ncid, varname.c_str(), &var_id);
+		if (status != NC_NOERR) handle_ncerror(status);
+
+		//xxmin = Xzone.xo + calcres(XParam.dx, levi) / 2.0;
+		//yymin = Xzone.yo + calcres(XParam.dx, levi) / 2.0;
+
+		int levindex = (levi - Xzone.minlevel);
+
+		if (vdim == 2)
+		{
+
+
+			start2D[0] = 0; // (size_t)round((XParam.yo - yymin) / calcres(XParam.dx, levi));
+			start2D[1] = 0; // (size_t)round((XParam.xo - xxmin) / calcres(XParam.dx, levi));
+
+			count2D[0] = (size_t)nylev;
+			count2D[1] = (size_t)nxlev;
+
+			if (smallnc > 0)
+			{
+
+				status = nc_put_vara_short(ncid, var_id, start2D, count2D, varlayers[levindex].z_s);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+			else
+			{
+				status = nc_put_vara_float(ncid, var_id, start2D, count2D, varlayers[levindex].z);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+		}
+		else if (vdim == 3)
+		{
+			start3D[1] = 0;// (size_t)round((XParam.yo - yymin) / calcres(XParam.dx, levi));
+			start3D[2] = 0;// (size_t)round((XParam.xo - xxmin) / calcres(XParam.dx, levi));
+
+			count3D[1] = (size_t)nylev;
+			count3D[2] = (size_t)nxlev;
+
+			if (smallnc > 0)
+			{
+				status = nc_put_vara_short(ncid, var_id, start3D, count3D, varlayers[levindex].z_s);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+			else
+			{
+				status = nc_put_vara_float(ncid, var_id, start3D, count3D, varlayers[levindex].z);
+				if (status != NC_NOERR) handle_ncerror(status);
+				//printf("\n ib=%d start=[%d,%d,%d]; initlevel=%d; initdx=%f; level=%d; xo=%f; yo=%f; blockxo[ib]=%f xxmin=%f blockyo[ib]=%f yymin=%f startfl=%f\n", bl, start3D[0], start3D[1], start3D[2], XParam.initlevel, initdx, lev, Xzone.xo, Xzone.yo, blockxo[bl], xxmin, blockyo[bl], yymin, (blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+				//printf("\n varblk[0]=%f varblk[255]=%f\n", varblk[0], varblk[255]);
+				//printf("\n ib=%d count3D=[%d,%d,%d]\n", count3D[0], count3D[1], count3D[2]);
+				//printf("\n ib=%d; level=%d; blockxo[ib]=%f blockyo[ib]=%f \n", bl, lev, blockxo[bl], blockyo[bl]);
+			}
+
+		}
+
+	}
+
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		int levindex = (levi - Xzone.minlevel);
+		if (smallnc > 0)
+		{
+
+			free(varlayers[levindex].z_s);
+		}
+		free(varlayers[levindex].z);
+	}
+	//close and save new file
+	status = nc_close(ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+
+}
+
 
 
 
@@ -915,6 +1254,219 @@ extern "C" void writenctimestep(std::string outfile, double totaltime)
 	if (status != NC_NOERR) handle_ncerror(status);
 }
 
+
+template <class T> void writencvarstepBUQlev(Param XParam, int vdim, int* activeblk, int* level, T* blockxo, T* blockyo, std::string varst, T* var, outzoneB Xzone)
+{
+	int status, ncid, recid, var_id;
+	static size_t nrec;
+	short* varblk_s;
+	float* varblk;
+	//int nx, ny;
+	//int dimids[NC_MAX_VAR_DIMS];
+	//size_t  *ddim, *start, *count;
+	//XParam.outfile.c_str()
+
+
+	float fillval = 9.9692e+36f;
+	short fillval_s = (short)round((9.9692e+36f - XParam.addoffset) / XParam.scalefactor);
+
+	static size_t start2D[] = { 0, 0 }; // start at first value 
+	//static size_t count2D[] = { ny, nx };
+	static size_t count2D[] = { (size_t)XParam.blkwidth, (size_t)XParam.blkwidth };
+
+	static size_t start3D[] = { 0, 0, 0 }; // start at first value // This is updated to nrec-1 further down
+	//static size_t count3D[] = { 1, ny, nx };
+	static size_t count3D[] = { 1, (size_t)XParam.blkwidth, (size_t)XParam.blkwidth };
+
+	int smallnc = XParam.smallnc;
+	float scalefactor = XParam.scalefactor;
+	float addoffset = XParam.addoffset;
+
+	status = nc_open(Xzone.outname.c_str(), NC_WRITE, &ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+	//read id from time dimension
+	status = nc_inq_unlimdim(ncid, &recid);
+	if (status != NC_NOERR) handle_ncerror(status);
+	status = nc_inq_dimlen(ncid, recid, &nrec);
+	if (status != NC_NOERR) handle_ncerror(status);
+
+	start3D[0] = nrec - 1;
+
+
+	// Create empty array for each levels
+	std::vector<outP> varlayers;
+	int nx, ny;
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		varlayers.push_back(outP());
+		int levindex = (levi - Xzone.minlevel);
+
+		Calcnxnyzone(XParam, levi, nx, ny, Xzone);
+		varlayers[levindex].z = (float*)malloc(nx * ny * sizeof(float));
+		if (smallnc > 0)
+		{
+
+			varlayers[levindex].z_s = (short*)malloc(nx * ny * sizeof(short));
+		}
+		varlayers[levindex].level = levi;
+
+		for (int j = 0; j < ny; j++)
+		{
+			for (int i = 0; i < nx; i++)
+			{
+				int n = i + j * nx;
+
+				varlayers[levindex].z[n] = fillval;
+				if (smallnc > 0)
+				{
+					varlayers[levindex].z_s[n] = fillval_s;
+				}
+			}
+		}
+	}
+
+	std::string xxname, yyname, varname, sign;
+	std::vector<int> activeblkzone = Calcactiveblockzone(XParam, activeblk, Xzone);
+
+
+	int lev, bl;
+	for (int ibl = 0; ibl < Xzone.nblk; ibl++)
+	{
+		//bl = activeblk[Xzone.blk[ibl]];
+	//for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	//{
+		bl = activeblkzone[ibl];
+		lev = level[bl];
+		
+		double  xxmin, yymin;
+		int nxlev, nylev;
+		//double xxmax, yymax;
+		double initdx = calcres(XParam.dx, XParam.initlevel);
+
+		int io, jo;
+		//xxmax = Xzone.xmax - calcres(XParam.dx, lev) / 2.0;
+		//yymax = Xzone.ymax - calcres(XParam.dx, lev) / 2.0;
+
+		int levindex = (lev - Xzone.minlevel);
+
+		Calcnxnyzone(XParam, lev, nxlev, nylev, Xzone);
+		xxmin = Xzone.xo + calcres(XParam.dx, lev) / 2.0;
+		yymin = Xzone.yo + calcres(XParam.dx, lev) / 2.0;
+
+		
+
+		jo = round((XParam.yo + blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+		io = round((XParam.xo + blockxo[bl] - xxmin) / calcres(XParam.dx, lev));
+		
+
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			for (int i = 0; i < XParam.blkwidth; i++)
+			{
+				int n = (i + XParam.halowidth + XParam.outishift) + (j + XParam.halowidth + XParam.outjshift) * XParam.blkmemwidth + bl * XParam.blksize;
+				int r = (io + i) + (jo + j) * nxlev;
+				if (smallnc > 0)
+				{
+					// packed_data_value = nint((unpacked_data_value - add_offset) / scale_factor)
+					varlayers[levindex].z_s[r] = (short)round((var[n] - addoffset) / scalefactor);
+				}
+				else
+				{
+					varlayers[levindex].z[r] = (float)var[n];
+				}
+			}
+		}
+
+	}
+
+
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		int nxlev, nylev;
+		Calcnxnyzone(XParam, levi, nxlev, nylev, Xzone);
+		//double  xxmin, yymin;
+		levi < 0 ? sign = "N" : sign = "P";
+		varname = varst + "_" + sign + std::to_string(abs(levi));
+
+		status = nc_inq_varid(ncid, varname.c_str(), &var_id);
+		if (status != NC_NOERR) handle_ncerror(status);
+
+		//xxmin = Xzone.xo + calcres(XParam.dx, levi) / 2.0;
+		//yymin = Xzone.yo + calcres(XParam.dx, levi) / 2.0;
+
+		int levindex = (levi - Xzone.minlevel);
+
+		if (vdim == 2)
+		{
+			
+
+			start2D[0] = 0; // (size_t)round((XParam.yo - yymin) / calcres(XParam.dx, levi));
+			start2D[1] = 0; // (size_t)round((XParam.xo - xxmin) / calcres(XParam.dx, levi));
+			
+			count2D[0] = (size_t)nylev;
+			count2D[1] = (size_t)nxlev;
+
+			if (smallnc > 0)
+			{
+
+				status = nc_put_vara_short(ncid, var_id, start2D, count2D, varlayers[levindex].z_s);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+			else
+			{
+				status = nc_put_vara_float(ncid, var_id, start2D, count2D, varlayers[levindex].z);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+		}
+		else if (vdim == 3)
+		{
+			start3D[1] = 0;// (size_t)round((XParam.yo - yymin) / calcres(XParam.dx, levi));
+			start3D[2] = 0;// (size_t)round((XParam.xo - xxmin) / calcres(XParam.dx, levi));
+
+			count3D[1] = (size_t)nylev;
+			count3D[2] = (size_t)nxlev;
+
+			if (smallnc > 0)
+			{
+				status = nc_put_vara_short(ncid, var_id, start3D, count3D, varlayers[levindex].z_s);
+				if (status != NC_NOERR) handle_ncerror(status);
+			}
+			else
+			{
+				status = nc_put_vara_float(ncid, var_id, start3D, count3D, varlayers[levindex].z);
+				if (status != NC_NOERR) handle_ncerror(status);
+				//printf("\n ib=%d start=[%d,%d,%d]; initlevel=%d; initdx=%f; level=%d; xo=%f; yo=%f; blockxo[ib]=%f xxmin=%f blockyo[ib]=%f yymin=%f startfl=%f\n", bl, start3D[0], start3D[1], start3D[2], XParam.initlevel, initdx, lev, Xzone.xo, Xzone.yo, blockxo[bl], xxmin, blockyo[bl], yymin, (blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+				//printf("\n varblk[0]=%f varblk[255]=%f\n", varblk[0], varblk[255]);
+				//printf("\n ib=%d count3D=[%d,%d,%d]\n", count3D[0], count3D[1], count3D[2]);
+				//printf("\n ib=%d; level=%d; blockxo[ib]=%f blockyo[ib]=%f \n", bl, lev, blockxo[bl], blockyo[bl]);
+			}
+
+		}
+
+	}
+
+	for (int levi = Xzone.minlevel; levi <= Xzone.maxlevel; levi++)
+	{
+		int levindex = (levi - Xzone.minlevel);
+		if (smallnc > 0)
+		{
+
+			free(varlayers[levindex].z_s);
+		}
+		free(varlayers[levindex].z);
+	}
+	//close and save new file
+	status = nc_close(ncid);
+	if (status != NC_NOERR) handle_ncerror(status);
+}
+
+// Scope for compiler to know what function to compile
+
+template void writencvarstepBUQlev<float>(Param XParam, int vdim, int* activeblk, int* level, float* blockxo, float* blockyo, std::string varst, float* var, outzoneB Xzone);
+template void writencvarstepBUQlev<double>(Param XParam, int vdim, int* activeblk, int* level, double* blockxo, double* blockyo, std::string varst, double* var, outzoneB Xzone);
+
+
+
 template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 {
 	if (!XParam.outvars.empty())
@@ -928,7 +1480,16 @@ template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
 			{
 				std::string varstr = XParam.outvars[ivar];
-				defncvarBUQ(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr,XModel.Outvarlongname[varstr],XModel.Outvarstdname[varstr],XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
+				if (XParam.savebyblk)
+				{
+					defncvarBUQ(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr, XModel.Outvarlongname[varstr], XModel.Outvarstdname[varstr], XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
+
+				}
+				else
+				{
+					defncvarBUQlev(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr, XModel.Outvarlongname[varstr], XModel.Outvarstdname[varstr], XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
+
+				}
 			}
 		}
 	}
@@ -947,7 +1508,14 @@ template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T> XModel)
 			writenctimestep(XModel.blocks.outZone[o].outname, XLoop.totaltime);
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
 			{
-				writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				if (XParam.savebyblk)
+				{
+					writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				}
+				else
+				{
+					writencvarstepBUQlev(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				}
 			}
 		}
 	}

--- a/src/Write_netcdf.h
+++ b/src/Write_netcdf.h
@@ -8,6 +8,7 @@
 #include "ReadInput.h"
 #include "MemManagement.h"
 #include "Util_CPU.h"
+#include "Arrays.h"
 
 void handle_ncerror(int status);
 template<class T> void creatncfileBUQ(Param &XParam, int* activeblk, int* level, T* blockxo, T* blockyo, outzoneB &Xzone);

--- a/src/Write_txtlog.cpp
+++ b/src/Write_txtlog.cpp
@@ -74,7 +74,7 @@ void create_logfile()
 
 
 	log("#################################");
-	log("BG_Flood v0.8");
+	log("BG_Flood v0.9");
 	log("#################################");
 	//log("model started at " + ss.str());
 	log("#################################");


### PR DESCRIPTION
# New Bnd and New save method
This PR superseeds 2 PR: #101 and #98 .
They have been pre-merged to facilitate testing.

# Save to file takes too long for many blocks

## The problem
The current dev branch save each block independantly to the netcdf file. The bottleneck is the netcdf write function overhead which make writing large model (20000 blocks and more) quite slow.
## The solution
 To alleviate this needs a new function that combines all blocks in a single array (for each level/variable) and write the whole array  at once to the netcdf file.
### Hold on
While this will be faster, it is likely inefficient when there are few arrays in a level. Typically when the highest level has only a few block we would still be writing a full array.
### Memory is cheap?
This will also be impossible if going to very high level where we won't be able to allocate memory to hold the highest level array.


## The real solution
Something that combine both option above and decide what is the best compromise.


### Collapse array
This may be a good time to introduce collapsing level to a single array and saving it to disk.

## Other things
This branch also includes:

-  fix on AOI polygon
- Fix for Tsunami initial condition (deform)


# Using flux term for new boundary treatment


## Proof of concept
- [x] New wall bnd for halo flux on GPU
- [x] Same for CPU

## Implementation
- [x] apply wall boundary metafunction designed for AOI wall to model BBox
- [x] Implement new segment based bnd
- [x] New abs flux for model BBox 
- [x] Fix Warmstart

## Testing
- [x] New CI test for wall bnd of AOI
- [ ] New CI test for wall of BBox
- [x] Test new spatially varying forcing for water level

## Docs
- [ ] Full documentation page with example 
- [x] Demo of stability/instability and if it solves the problem