### PR TITLE
Implement flexible output Times

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
           sed -i 's/test = 14/test = 15/' BG_param.txt
           ./BG_Flood
           ./BG_Flood BG_param_test15.txt
-          var=$(ncdump -v h_P0 Test15_zoom2.nc)
-        if: echo ${{ ${#var} == 7 }}
+       ##   var=$(ncdump -v h_P0 Test15_zoom2.nc)
+       ## if: echo ${{ ${#var} == 7 }}
 
      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
           ./BG_Flood BG_param_test15.txt
           var=$(ncdump -v h_P0 Test15_zoom2.nc)
           var_length=${#var}
-        if: ${{ var_length == 7}}
+        if: echo ${{ var_length == 7}}
 
 
      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,16 @@ jobs:
       - name: running test 13, Test on multi-Bathy / Multi-Roughness input
         run: |
           sed -i 's/test = 12/test = 13/' BG_param.txt
-          ./BG_Flood          
+          ./BG_Flood    
+
+      - name: running test 15, Test on flexible time input
+        run: |
+          sed -i 's/test = 14/test = 15/' BG_param.txt
+          ./BG_Flood
+          ./BG_Flood BG_param_test15.txt
+          var=$(ncdump -v h_P0 Test15_zoom2.nc)
+          var_length=${#var}
+        if: ${{ var_length == 7}}
+
 
      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,6 @@ jobs:
           ./BG_Flood
           ./BG_Flood BG_param_test15.txt
           var=$(ncdump -v h_P0 Test15_zoom2.nc)
-          var_length=${#var}
-        if: echo ${{ var_length == 7}}
+        if: echo ${{ ${#var} == 7 }}
 
      

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -78,6 +78,7 @@ struct outzoneB
 	std::string outname; // name for the output file (one for each zone)
 	int maxlevel; // maximum level in the zone
 	int minlevel; //minimum level in the zone
+	//double Next_OutputT; //Next time for the output of this zone
 };
 
 
@@ -178,7 +179,7 @@ struct Model
 	std::map<std::string, std::string> Outvarlongname;
 	std::map<std::string, std::string> Outvarstdname;
 	std::map<std::string, std::string> Outvarunits;
-
+	std::vector<double> OutputT;
 
 	//other output
 	//std::vector< std::vector< Pointout > > TSallout;

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -78,7 +78,8 @@ struct outzoneB
 	std::string outname; // name for the output file (one for each zone)
 	int maxlevel; // maximum level in the zone
 	int minlevel; //minimum level in the zone
-	//double Next_OutputT; //Next time for the output of this zone
+	std::vector<double> OutputT; //Next time for the output of this zone
+	int index_next_OutputT = 0; //Index of next time output
 };
 
 
@@ -216,6 +217,8 @@ struct Loop
 	int nstep = 0;
 	//useful for calculating avg timestep
 	int nstepout = 0;
+	// Needed to identify next output time
+	int indNextoutputtime = 0;
 
 	// usefull for Time series output
 	int nTSsteps = 0;

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -1393,12 +1393,12 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 	std::vector<double> times_partial;
 
 	times_partial = GetTimeOutput(XParam.Toutput);
-	printf("Time partial:\n");
-	for (int k = 0; k < times_partial.size(); k++)
-	{
-		printf("%f, ", times_partial[k]);
-	}
-	printf("\n");
+	//printf("Time partial:\n");
+	//for (int k = 0; k < times_partial.size(); k++)
+	//{
+	//	printf("%f, ", times_partial[k]);
+	//}
+	//printf("\n");
 
 	times.insert(times.end(), times_partial.begin(), times_partial.end());
 
@@ -1430,7 +1430,7 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 	std::sort(times.begin(), times.end());
 	times.erase(unique(times.begin(), times.end()), times.end());
 	
-	printf("Times:\n");
+	printf("Output Times:\n");
 	for (int k = 0; k < times.size(); k++)
 	{
 		printf("%e, ", times[k]);

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -1359,27 +1359,27 @@ template <class T> void initinfiltration(Param XParam, BlockP<T> XBlock, T* h, T
 // Create a vector of times steps from the input structure Toutput
 std::vector<double> GetTimeOutput(T_output time_info)
 {
-	std::vector<double> time_vect;
-	double time;
+	//std::vector<double> time_vect;
+	//double time;
 	
 	//Add independant values
-	if (!time_info.val.empty())
-	{
-		time_vect = time_info.val;
-	}
+	//if (!time_info.val.empty())
+	//{
+	//	time_vect = time_info.val;
+	//}
 	
 	//Add timesteps from the vector 
-	time = time_info.init;
-	while (time < time_info.end)
-	{
-		time_vect.push_back(time);
-		time += time_info.tstep;
-	}
+	//time = time_info.init;
+	//while (time < time_info.end)
+	//{
+	//	time_vect.push_back(time);
+	//	time += time_info.tstep;
+	//}
 
 	//Add last timesteps from the vector definition
-	time_vect.push_back(time_info.end);
+	//time_vect.push_back(time_info.end);
 
-	return(time_vect);
+	return(time_info.val);
 }
 
 
@@ -1412,7 +1412,7 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 			//Add to main vector
 			times.insert(times.end(), times_partial.begin(), times_partial.end());
 			//Sort and remove duplicate before saving in outZone struct
-			std::sort(times_partial.begin(), times_partial.end());
+			
 			times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
 			std::sort(times_partial.begin(), times_partial.end());
 			XBlock.outZone[ii].OutputT = times_partial;
@@ -1420,11 +1420,13 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 	}
 	else //If not zoneoutput, output zone saved in zoneoutput structure
 	{
+		times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
 		std::sort(times_partial.begin(), times_partial.end());
 		XBlock.outZone[0].OutputT = times_partial;
 	}
 
 	// Sort the times for output
+	times.erase(unique(times.begin(), times.end()), times.end());
 	std::sort(times.begin(), times.end());
 	printf("Times:\n");
 	for (int k = 0; k < times.size(); k++)
@@ -1433,8 +1435,7 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 	}
 	printf("\n");
 	
-	// remove duplicate
-	times.erase( unique ( times.begin(), times.end()), times.end());
+	
 
 	OutputT = times;
 }

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -836,6 +836,7 @@ template <class T> void Initoutzone(Param& XParam, BlockP<T>& XBlock)
 		XzoneB.nblk = XParam.nblk;
 		XzoneB.maxlevel = XParam.maxlevel;
 		XzoneB.minlevel = XParam.minlevel;
+		XzoneB.OutputT = { XParam.totaltime, XParam.endtime };
 		AllocateCPU(XParam.nblk, 1, XzoneB.blk);
 		int I = 0;
 		for (int ib = 0; ib < XParam.nblk; ib++)
@@ -1408,6 +1409,11 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 			XBlock.outZone[ii].OutputT = times_partial;
 		}
 	}
+	else //If not zoneoutput, output zone saved in zoneoutput structure
+	{
+		XBlock.outZone[0].OutputT = times_partial;
+	}
+
 	// Sort the times for output
 	sort(times.begin(), times.end());
 	// remove duplicate

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -1393,6 +1393,13 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 	std::vector<double> times_partial;
 
 	times_partial = GetTimeOutput(XParam.Toutput);
+	printf("Time partial:\n");
+	for (int k = 0; k < times_partial.size(); k++)
+	{
+		printf("%f, ", times_partial[k]);
+	}
+	printf("\n");
+
 	times.insert(times.end(), times_partial.begin(), times_partial.end());
 
 	// if zoneOutputs, add their contribution
@@ -1401,21 +1408,31 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 		for (int ii = 0; ii < XParam.outzone.size(); ii++)
 		{
 			times_partial = GetTimeOutput(XParam.outzone[ii].Toutput);
+			
 			//Add to main vector
 			times.insert(times.end(), times_partial.begin(), times_partial.end());
 			//Sort and remove duplicate before saving in outZone struct
-			sort(times_partial.begin(), times_partial.end());
+			std::sort(times_partial.begin(), times_partial.end());
 			times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
+			std::sort(times_partial.begin(), times_partial.end());
 			XBlock.outZone[ii].OutputT = times_partial;
 		}
 	}
 	else //If not zoneoutput, output zone saved in zoneoutput structure
 	{
+		std::sort(times_partial.begin(), times_partial.end());
 		XBlock.outZone[0].OutputT = times_partial;
 	}
 
 	// Sort the times for output
-	sort(times.begin(), times.end());
+	std::sort(times.begin(), times.end());
+	printf("Times:\n");
+	for (int k = 0; k < times.size(); k++)
+	{
+		printf("%f, ", times[k]);
+	}
+	printf("\n");
+	
 	// remove duplicate
 	times.erase( unique ( times.begin(), times.end()), times.end());
 

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -1412,26 +1412,28 @@ template <class T> void initOutputTimes(Param XParam, std::vector<double>& Outpu
 			//Add to main vector
 			times.insert(times.end(), times_partial.begin(), times_partial.end());
 			//Sort and remove duplicate before saving in outZone struct
-			
-			times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
 			std::sort(times_partial.begin(), times_partial.end());
+			times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
+			
 			XBlock.outZone[ii].OutputT = times_partial;
 		}
 	}
 	else //If not zoneoutput, output zone saved in zoneoutput structure
 	{
-		times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
 		std::sort(times_partial.begin(), times_partial.end());
+		times_partial.erase(unique(times_partial.begin(), times_partial.end()), times_partial.end());
+		
 		XBlock.outZone[0].OutputT = times_partial;
 	}
 
 	// Sort the times for output
-	times.erase(unique(times.begin(), times.end()), times.end());
 	std::sort(times.begin(), times.end());
+	times.erase(unique(times.begin(), times.end()), times.end());
+	
 	printf("Times:\n");
 	for (int k = 0; k < times.size(); k++)
 	{
-		printf("%f, ", times[k]);
+		printf("%e, ", times[k]);
 	}
 	printf("\n");
 	

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -99,6 +99,9 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 		// Initialise infiltration to IL where h is already wet
 		initinfiltration(XParam, XModel.blocks, XModel.evolv.h, XModel.il, XModel.hgw);
 
+		// Initialise Output times' vector
+		initOutputTimes(XParam, XModel.OutputT)
+
 	}
 
 
@@ -1194,3 +1197,45 @@ void initinfiltration(Param XParam, BlockP<T> XBlock, T* h, T* initLoss ,T* hgw)
 		}
 	}
 }
+
+
+// Creation of a vector for times requiering a map output
+// Compilations of vectors and independent times from the general input
+// and the different zones outputs
+template <class T>
+void initOutputTimes(Param XParam, std::vector<double> OutputT)
+{
+	std::vector<double> times;
+
+	times.push_back(GetTimeOutput(XParam.Toutput));
+	// if zoneOutputs, add their contribution
+	if (XParam.outzone.size() > 0)
+	{
+		for (int ii = 0; ii < XParam.outzone.size(); ii++)
+		{
+			times.push_back(GetTimeOutput(XParam.outzone.Toutput));
+		}
+	}
+	// Sort the times for output
+	sort(times.begin(), times.end());
+	// remove duplicate
+	times.erase( unique ( times.begin(), times.end()), times.end());
+
+	OutputT = times;
+}
+
+std::vector<double> GetTimeOutput(Toutput time_info)
+{
+	std::vector<double> time_vect;
+	double time;
+
+	time_vect = time_info.val;
+	time = time_info.init;
+	while (time < time_info.end)
+	{
+		time_vect.push_back(time);
+		time += time_info.tstep;
+	}
+	return(time_vect);
+}
+

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -1356,7 +1356,7 @@ template <class T> void initinfiltration(Param XParam, BlockP<T> XBlock, T* h, T
 }
 
 // Create a vector of times steps from the input structure Toutput
-std::vector<double> GetTimeOutput(Toutput time_info)
+std::vector<double> GetTimeOutput(T_output time_info)
 {
 	std::vector<double> time_vect;
 	double time;

--- a/src/InitialConditions.h
+++ b/src/InitialConditions.h
@@ -33,5 +33,6 @@ template <class T> void InitzbgradientGPU(Param XParam, Model<T> XModel);
 
 template <class T> void calcactiveCellCPU(Param XParam, BlockP<T> XBlock, Forcing<float>& XForcing, T* zb);
 
+template <class T> void initOutputTimes(Param XParam, std::vector<double>& OutputT, BlockP<T>& XBlock);
 // End of global definition;
 #endif

--- a/src/Input.h
+++ b/src/Input.h
@@ -12,6 +12,13 @@ public:
 	std::string outname;
 };
 
+// Flexible definition of time outputs
+class Toutput {
+public: 
+	double init, tstep, end;
+	std::vector<double> val;
+};
+
 // Special output zones for nc files, informatin given by the user
 class outzoneP {
 public:

--- a/src/Input.h
+++ b/src/Input.h
@@ -26,6 +26,7 @@ public:
 	double xstart, xend, ystart, yend; // definition of the zone needed for special nc output (rectangular zone) by the user
 	//double xo, xmax, yo, ymax; // Real zone for output (because we output full blocks)
 	std::string outname; // name for the output file (one for each zone)
+	Toutput Toutput; // time for outputs for the zone
 };
 
 class Flowin {

--- a/src/Input.h
+++ b/src/Input.h
@@ -15,7 +15,9 @@ public:
 // Flexible definition of time outputs
 class Toutput {
 public: 
-	double init, tstep, end;
+	double init = NAN;
+	double tstep = NAN;
+	double end = NAN;
 	std::vector<double> val;
 };
 

--- a/src/Input.h
+++ b/src/Input.h
@@ -13,7 +13,7 @@ public:
 };
 
 // Flexible definition of time outputs
-class Toutput {
+class T_output {
 public: 
 	double init = NAN;
 	double tstep = NAN;
@@ -28,7 +28,7 @@ public:
 	double xstart, xend, ystart, yend; // definition of the zone needed for special nc output (rectangular zone) by the user
 	//double xo, xmax, yo, ymax; // Real zone for output (because we output full blocks)
 	std::string outname; // name for the output file (one for each zone)
-	Toutput Toutput; // time for outputs for the zone
+	T_output Toutput; // time for outputs for the zone
 };
 
 class Flowin {

--- a/src/Input.h
+++ b/src/Input.h
@@ -18,6 +18,7 @@ public:
 	double init = NAN;
 	double tstep = NAN;
 	double end = NAN;
+	std::vector<std::string> inputstr;
 	std::vector<double> val;
 };
 

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -246,7 +246,7 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop,Model<T> XModel, 
 		Save2Netcdf(XParam, XLoop, XModel);
 
 
-		XLoop.nextoutputtime = min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime);
+		XLoop.nextoutputtime = max(min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime), XParam.outputtimeinit);
 
 		XLoop.nstepout = 0;
 	}

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -235,7 +235,7 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop, Model<T>& XModel
 {
 	XLoop.nstepout++;
 	double tiny = 0.0000001;
-
+	/*
 	if  (abs(XLoop.nextoutputtime - XParam.totaltime) < tiny)
 	{
 		if (XParam.GPUDEVICE >= 0)
@@ -258,8 +258,8 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop, Model<T>& XModel
 		XLoop.nstepout = 0;
 
 	}
-
-	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.5))
+	*/
+	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * tiny)
 	{
 		if (XParam.GPUDEVICE >= 0)
 		{

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -225,11 +225,38 @@ template <class T> void updateBnd(Param XParam, Loop<T> XLoop, Forcing<float> XF
 
 
 
-template <class T> void mapoutput(Param XParam, Loop<T> &XLoop,Model<T> XModel, Model<T> XModel_g)
+template <class T> void mapoutput(Param XParam, Loop<T> &XLoop, Model<T>& XModel, Model<T> XModel_g)
 {
 	XLoop.nstepout++;
+	double tiny = 0.0000001;
 
-	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.5) && XParam.outputtimestep > 0.0)
+	if  (abs(XLoop.nextoutputtime - XParam.totaltime) < tiny)
+	{
+		//char buffer[256];
+		//sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
+		//std::string str(buffer);
+
+		//log("Output to map. Totaltime = "+ std::to_string(XLoop.totaltime) +" s; Mean dt = " + str + " s");
+		if (XParam.GPUDEVICE >= 0)
+		{
+			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
+			{
+				CUDA_CHECK(cudaMemcpy(XModel.OutputVarMap[XParam.outvars[ivar]], XModel_g.OutputVarMap[XParam.outvars[ivar]], XParam.nblkmem * XParam.blksize * sizeof(T), cudaMemcpyDeviceToHost));
+			}
+		}
+
+		SaveInitialisation2Netcdf(XParam, XModel);
+
+		//XLoop.nextoutputtime = max(min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime));// , XParam.outputtimeinit);
+		//XLoop.nextoutputtime = min(XModel.OutputT[indNextoutputtime] + XParam.outputtimestep, XParam.endtime);// , XParam.outputtimeinit);
+
+		XLoop.indNextoutputtime++;
+		XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
+
+		XLoop.nstepout = 0;
+	}
+
+	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.5))
 	{
 		//char buffer[256];
 		//sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
@@ -250,7 +277,10 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop,Model<T> XModel, 
 		//XLoop.nextoutputtime = min(XModel.OutputT[indNextoutputtime] + XParam.outputtimestep, XParam.endtime);// , XParam.outputtimeinit);
 		
 		XLoop.indNextoutputtime++;
-		XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
+		if (XLoop.indNextoutputtime < XModel.OutputT.size())
+		{
+			XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
+		}
 
 		XLoop.nstepout = 0;
 	}

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -171,7 +171,7 @@ template <class T> Loop<T> InitLoop(Param &XParam, Model<T> &XModel)
 	Loop<T> XLoop;
 	XLoop.atmpuni = T(XParam.Paref);
 	XLoop.totaltime = XParam.totaltime;
-	XLoop.nextoutputtime = XParam.totaltime + XParam.outputtimestep;
+	XLoop.nextoutputtime = XModel.OutputT[0];
 	
 	// Prepare output files
 	InitSave2Netcdf(XParam, XModel);
@@ -231,11 +231,11 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop,Model<T> XModel, 
 
 	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.5) && XParam.outputtimestep > 0.0)
 	{
-		char buffer[256];
-		sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
-		std::string str(buffer);
+		//char buffer[256];
+		//sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
+		//std::string str(buffer);
 
-		log("Output to map. Totaltime = "+ std::to_string(XLoop.totaltime) +" s; Mean dt = " + str + " s");
+		//log("Output to map. Totaltime = "+ std::to_string(XLoop.totaltime) +" s; Mean dt = " + str + " s");
 		if (XParam.GPUDEVICE >= 0)
 		{
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -12,11 +12,12 @@ template <class T> void MainLoop(Param &XParam, Forcing<float> XForcing, Model<T
 	//Define some useful variables 
 	Initmeanmax(XParam, XLoop, XModel, XModel_g);
 
-	
-
+	// Check for map output (output initialisation if needed)
+	mapoutput(XParam, XLoop, XModel, XModel_g);
 	
 	log("\t\tCompleted");
 	log("Model Running...");
+
 	while (XLoop.totaltime < XParam.endtime)
 	{
 		// Bnd stuff here
@@ -245,11 +246,15 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop,Model<T> XModel, 
 		
 		Save2Netcdf(XParam, XLoop, XModel);
 
-
-		XLoop.nextoutputtime = max(min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime), XParam.outputtimeinit);
+		//XLoop.nextoutputtime = max(min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime));// , XParam.outputtimeinit);
+		//XLoop.nextoutputtime = min(XModel.OutputT[indNextoutputtime] + XParam.outputtimestep, XParam.endtime);// , XParam.outputtimeinit);
+		
+		XLoop.indNextoutputtime++;
+		XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
 
 		XLoop.nstepout = 0;
 	}
+
 }
 
 template <class T> void pointoutputstep(Param XParam, Loop<T> &XLoop, Model<T> XModel, Model<T> XModel_g)

--- a/src/Mainloop.cu
+++ b/src/Mainloop.cu
@@ -232,11 +232,6 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop, Model<T>& XModel
 
 	if  (abs(XLoop.nextoutputtime - XParam.totaltime) < tiny)
 	{
-		//char buffer[256];
-		//sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
-		//std::string str(buffer);
-
-		//log("Output to map. Totaltime = "+ std::to_string(XLoop.totaltime) +" s; Mean dt = " + str + " s");
 		if (XParam.GPUDEVICE >= 0)
 		{
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
@@ -247,22 +242,19 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop, Model<T>& XModel
 
 		SaveInitialisation2Netcdf(XParam, XModel);
 
-		//XLoop.nextoutputtime = max(min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime));// , XParam.outputtimeinit);
-		//XLoop.nextoutputtime = min(XModel.OutputT[indNextoutputtime] + XParam.outputtimestep, XParam.endtime);// , XParam.outputtimeinit);
-
 		XLoop.indNextoutputtime++;
-		XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
+		if (XLoop.indNextoutputtime < XModel.OutputT.size())
+		{
+			XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
+
+		}
 
 		XLoop.nstepout = 0;
+
 	}
 
 	if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.5))
 	{
-		//char buffer[256];
-		//sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
-		//std::string str(buffer);
-
-		//log("Output to map. Totaltime = "+ std::to_string(XLoop.totaltime) +" s; Mean dt = " + str + " s");
 		if (XParam.GPUDEVICE >= 0)
 		{
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
@@ -270,21 +262,20 @@ template <class T> void mapoutput(Param XParam, Loop<T> &XLoop, Model<T>& XModel
 				CUDA_CHECK(cudaMemcpy(XModel.OutputVarMap[XParam.outvars[ivar]], XModel_g.OutputVarMap[XParam.outvars[ivar]], XParam.nblkmem * XParam.blksize * sizeof(T), cudaMemcpyDeviceToHost));
 			}
 		}
-		
+
 		Save2Netcdf(XParam, XLoop, XModel);
 
-		//XLoop.nextoutputtime = max(min(XLoop.nextoutputtime + XParam.outputtimestep, XParam.endtime));// , XParam.outputtimeinit);
-		//XLoop.nextoutputtime = min(XModel.OutputT[indNextoutputtime] + XParam.outputtimestep, XParam.endtime);// , XParam.outputtimeinit);
-		
 		XLoop.indNextoutputtime++;
 		if (XLoop.indNextoutputtime < XModel.OutputT.size())
 		{
 			XLoop.nextoutputtime = min(XModel.OutputT[XLoop.indNextoutputtime], XParam.endtime);
+
 		}
 
 		XLoop.nstepout = 0;
 	}
 
+	
 }
 
 template <class T> void pointoutputstep(Param XParam, Loop<T> &XLoop, Model<T> XModel, Model<T> XModel_g)

--- a/src/Param.h
+++ b/src/Param.h
@@ -82,7 +82,7 @@ public:
 	double dtinit = -1; // Maximum initial time steps in s (should be positive, advice 0.1 if dry domain initialement) 
 	double dtmin = 0.0005; //Minimum accepted time steps in s (a lower value will be concidered a crash of the code, and stop the run)
 
-	Toutput Toutput; /* Flexible time definition for outputs (nc files)
+	T_output Toutput; /* Flexible time definition for outputs (nc files)
 	Example: "Toutput = 0.0:3600:7200,7000,7100; which mean every 3600s from 0 to 7200s, and the two times 7000 and 7100"
 	Default = First and last timne steps*/
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -78,12 +78,15 @@ public:
 
 
 	//*Timekeeping
-	double outputtimeinit = -99999; //Initial time for the output, initialised to initial running time
+	//double outputtimeinit = -99999; //Initial time for the output, initialised to initial running time
 	double outputtimestep = 0.0; //Number of seconds between netCDF outputs, 0.0 for none
 	double endtime = std::numeric_limits<double>::max(); // Total runtime in s, will be calculated based on bnd input as min(length of the shortest time series, user defined) and should be shorter than any time-varying forcing
 	double totaltime = 0.0; // Total simulation time in s
 	double dtinit = -1; // Maximum initial time steps in s (should be positive, advice 0.1 if dry domain initialement) 
 	double dtmin = 0.0005; //Minimum accepted time steps in s (a lower value will be concidered a crash of the code, and stop the run)
+	Toutput Toutput; /* Flexible time definition for outputs (nc files)
+	Example: "Toutput = 0.0:3600:7200,7000,7100; which mean every 3600s from 0 to 7200s, and the two times 7000 and 7100" 
+	Default = First and last timne steps*/
 
 	//* Initialisation
 	double zsinit = nan(""); //Init zs for cold start in m. If not specified by user and no bnd file = 1 then sanity check will set it to 0.0

--- a/src/Param.h
+++ b/src/Param.h
@@ -31,7 +31,7 @@ public:
 
 	bool conserveElevation = false; //Switch to force the conservation of zs instead of h at the interface between coarse and fine blocks
 	bool wetdryfix = true; // Switch to remove wet/dry instability (i.e. true reoves instability and false leaves the model as is)
-  
+
 
 	double Pa2m = 0.00009916; // Conversion between atmospheric pressure changes to water level changes in Pa (if unit is hPa then user should use 0.009916)
 	double Paref = 101300.0; // Reference pressure in Pa (if unit is hPa then user should use 1013.0)
@@ -52,7 +52,7 @@ public:
 	int blkmemwidth = 0; // Calculated in sanity check as blkwidth+2*halowidth
 	int blksize = 0; // Calculated in sanity check as blkmemwidth*blkmemwidth
 	int halowidth = 1; // Use a halo around the blocks default is 1 cell: the memory for each blk is 18x18 when blkwidth is 16
-	
+
 
 	double xo = nan(""); // Grid x origin (if not alter by the user, will be defined based on the topography/bathymetry input map)
 	double yo = nan(""); // Grid y origin (if not alter by the user, will be defined based on the topography/bathymetry input map)
@@ -83,11 +83,11 @@ public:
 	double dtmin = 0.0005; //Minimum accepted time steps in s (a lower value will be concidered a crash of the code, and stop the run)
 
 	Toutput Toutput; /* Flexible time definition for outputs (nc files)
-	Example: "Toutput = 0.0:3600:7200,7000,7100; which mean every 3600s from 0 to 7200s, and the two times 7000 and 7100" 
+	Example: "Toutput = 0.0:3600:7200,7000,7100; which mean every 3600s from 0 to 7200s, and the two times 7000 and 7100"
 	Default = First and last timne steps*/
 
-  //*Boundaries
-  bool leftbnd = false; // bnd is forced (i.e. not a wall or neuman)
+	//*Boundaries
+	bool leftbnd = false; // bnd is forced (i.e. not a wall or neuman)
 	bool rightbnd = false; // bnd is forced (i.e. not a wall or neuman)
 	bool topbnd = false; // bnd is forced (i.e. not a wall or neuman)
 	bool botbnd = false; // bnd is forced (i.e. not a wall or neuman)
@@ -122,9 +122,9 @@ public:
 
 
 	//Timeseries output (save as a vector containing information for each Time Serie output)
-	std::vector<TSoutnode> TSnodesout; 
-	/*Time serie output, giving a file name and a (x,y) position 
-	(which will be converted to nearest grid position). 
+	std::vector<TSoutnode> TSnodesout;
+	/*Time serie output, giving a file name and a (x,y) position
+	(which will be converted to nearest grid position).
 	This keyword can be used multiple times to extract time series at different locations.
 	The data is stocked for each timestep and written by flocs.
 	The resulting file contains (t,zs,h,u,v)
@@ -133,14 +133,14 @@ public:
 	*/
 
 	std::string outfile = "Output.nc"; // netcdf output file name
-	std::vector<std::string> outvars; 
+	std::vector<std::string> outvars;
 	/*List of names of the variables to output (for 2D maps)
 	Supported variables = "zb", "zs", "u", "v", "h", "hmean", "zsmean", "umean", "vmean", "hUmean", "Umean", "hmax", "zsmax", "umax", "vmax", "hUmax", "Umax", "twet", "dhdx","dhdy","dzsdx","dzsdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm", "datmpdx","datmpdy","il","cl","hgw";
 	Default: "zb", "zs", "u", "v", "h"
 	*/
 	double wet_threshold = 0.1; //in m. Limit to consider a cell wet for the twet output (duration of inundation (s))
-	
-	std::vector<outzoneP> outzone; 
+
+	std::vector<outzoneP> outzone;
 	/*Zoned output (netcdf file), giving a file name and the position of two corner points
 	(which will be converted to a rectagle containing full blocks).
 	Time vector or values can also be added to specified special outputs for this one in particular.
@@ -190,13 +190,13 @@ public:
 	float addoffset = 0.0f; //Offset add during the short integer conversion for netcdf outputs
 
 #ifdef USE_CATALYST
-        //* ParaView Catalyst parameters (SPECIAL USE WITH PARAVIEW)
-        int use_catalyst = 0; // Switch to use ParaView Catalyst
-        int catalyst_python_pipeline = 0; //Pipeline to use ParaView Catalyst
-        int vtk_output_frequency = 0; // Output frequency for ParaView Catalyst
-        double vtk_output_time_interval = 1.0; // Output time step for ParaView Catalyst
-        std::string vtk_outputfile_root = "bg_out"; //output file name for ParaView Catalyst
-        std::string python_pipeline = "coproc.py"; //python pipeline for ParaView Catalyst
+		//* ParaView Catalyst parameters (SPECIAL USE WITH PARAVIEW)
+	int use_catalyst = 0; // Switch to use ParaView Catalyst
+	int catalyst_python_pipeline = 0; //Pipeline to use ParaView Catalyst
+	int vtk_output_frequency = 0; // Output frequency for ParaView Catalyst
+	double vtk_output_time_interval = 1.0; // Output time step for ParaView Catalyst
+	std::string vtk_outputfile_root = "bg_out"; //output file name for ParaView Catalyst
+	std::string python_pipeline = "coproc.py"; //python pipeline for ParaView Catalyst
 #endif
 
 
@@ -227,7 +227,7 @@ public:
 	std::string crs_ref = "no_crs"; //"PROJCS[\"NZGD2000 / New Zealand Transverse Mercator 2000\",GEOGCS[\"NZGD2000\",DATUM[\"New_Zealand_Geodetic_Datum_2000\",SPHEROID[\"GRS 1980\",6378137,298.257222101]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4167\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",173],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",1600000],PARAMETER[\"false_northing\",10000000],UNIT[\"metre\",1],AXIS[\"Northing\",NORTH],AXIS[\"Easting\",EAST],AUTHORITY[\"EPSG\",\"2193\"]]";
 
 
-	bool savebyblk=true;
+	bool savebyblk = true;
 
 };
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -78,6 +78,7 @@ public:
 
 
 	//*Timekeeping
+	double outputtimeinit = -99999; //Initial time for the output, initialised to initial running time
 	double outputtimestep = 0.0; //Number of seconds between netCDF outputs, 0.0 for none
 	double endtime = std::numeric_limits<double>::max(); // Total runtime in s, will be calculated based on bnd input as min(length of the shortest time series, user defined) and should be shorter than any time-varying forcing
 	double totaltime = 0.0; // Total simulation time in s

--- a/src/Param.h
+++ b/src/Param.h
@@ -131,8 +131,9 @@ public:
 	std::vector<outzoneP> outzone; 
 	/*Zoned output (netcdf file), giving a file name and the position of two corner points
 	(which will be converted to a rectagle containing full blocks).
+	Time vector or values can also be added to specified special outputs for this one in particular.
 	This keyword can be used multiple times to output maps of different areas.
-	Example: "outzone=zoomed.nc,5.3,5.4,0.5,0.8;" (*filename,x1,x2,y1,y2*)
+	Example: "outzone=zoomed.nc,5.3,5.4,0.5,0.8;" (*filename,x1,x2,y1,y2*) or "outzone=zoomed.nc,5.3,5.4,0.5,0.8, 3600:360:7200;" (*filename,x1,x2,y1,y2, t_init:t_step:t_end*)
 	Default: Full domain
 	*/
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -496,12 +496,18 @@ Param readparamstr(std::string line, Param param)
 		}
 		if (zoneitems.size() > 5)
 		{
-			std::vector<std::string> Toutputpar_vect = split(zoneitems[5], ':');
+			std::vector<std::string> Toutputpar_vect = split_full(zoneitems[5], ':');
 			if (Toutputpar_vect.size() == 3)
 			{
-				zone.Toutput.init = std::stod(Toutputpar_vect[0]);
-				zone.Toutput.tstep = std::stod(Toutputpar_vect[1]);
-				zone.Toutput.end = std::stod(Toutputpar_vect[2]);
+				if (!Toutputpar_vect[0].empty()) {
+					zone.Toutput.init = std::stod(Toutputpar_vect[0]);
+				}
+				if (!Toutputpar_vect[1].empty()) {
+					zone.Toutput.tstep = std::stod(Toutputpar_vect[1]);
+				}
+				if (!Toutputpar_vect[2].empty()) {
+					zone.Toutput.end = std::stod(Toutputpar_vect[2]);
+				}
 			}
 			else if (Toutputpar_vect.size() > 1)
 			{
@@ -793,12 +799,15 @@ Param readparamstr(std::string line, Param param)
 
 		if (!Toutputpar.empty())
 		{
-			std::vector<std::string> Toutputpar_vect = split(Toutputpar[0], ':');
+			std::vector<std::string> Toutputpar_vect = split_full(Toutputpar[0], ':');
 			if (Toutputpar_vect.size() == 3)
 			{
-				param.Toutput.init = std::stod(Toutputpar_vect[0]);
-				param.Toutput.tstep = std::stod(Toutputpar_vect[1]);
-				param.Toutput.end = std::stod(Toutputpar_vect[2]);
+				if (!Toutputpar_vect[0].empty()) {
+					param.Toutput.init = std::stod(Toutputpar_vect[0]); }
+				if (!Toutputpar_vect[1].empty()) {
+					param.Toutput.tstep = std::stod(Toutputpar_vect[1]); }
+				if (!Toutputpar_vect[2].empty()) {
+					param.Toutput.end = std::stod(Toutputpar_vect[2]); }
 			}
 			else if (Toutputpar_vect.size() > 1)
 			{
@@ -1457,19 +1466,19 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 }
 
 //Initialise default values for Toutput (output times for map outputs)
-void InitialiseToutput(Toutput & Toutput, Param XParam)
+void InitialiseToutput(Toutput& Toutput_loc, Param XParam)
 {
-	if (Toutput.init.empty())
+	if (std::isnan(Toutput_loc.init))
 	{
-		Toutput.init = XParam.totaltime;
+		Toutput_loc.init = XParam.totaltime;
 	}
-	if (Toutput.end.empty())
+	if (std::isnan(Toutput_loc.end))
 	{
-		Toutput.end = XParam.endtime;
+		Toutput_loc.end = XParam.endtime;
 	}
-	if (Toutput.tstep.empty())
+	if (std::isnan(Toutput_loc.tstep))
 	{
-		Toutput.tstep = XParam.outputtimestep;
+		Toutput_loc.tstep = XParam.outputtimestep;
 	}
 }
 
@@ -1592,6 +1601,33 @@ std::vector<std::string> split(const std::string &s, char delim) {
 	split(s, delim, elems);
 	return elems;
 }
+
+
+
+/*! \fn void split_full(const std::string &s, char delim, std::vector<std::string> &elems)
+* split string based in character, conserving empty item
+*
+*/
+void split_full(const std::string& s, char delim, std::vector<std::string>& elems) {
+	std::stringstream ss;
+	ss.str(s);
+	std::string item;
+	while (std::getline(ss, item, delim)) {
+		elems.push_back(item);
+
+	}
+}
+
+/*! \fn std::vector<std::string> split_full(const std::string &s, char delim)
+* split string based in character, conserving empty items
+*
+*/
+std::vector<std::string> split_full(const std::string& s, char delim) {
+	std::vector<std::string> elems;
+	split_full(s, delim, elems);
+	return elems;
+}
+
 
 std::vector<std::string> split(const std::string s, const std::string delim)
 {

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1552,7 +1552,7 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 }
 
 //Initialise default values for Toutput (output times for map outputs)
-void InitialiseToutput(Toutput& Toutput_loc, Param XParam)
+void InitialiseToutput(T_output& Toutput_loc, Param XParam)
 {
 	if (std::isnan(Toutput_loc.init))
 	{

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1385,8 +1385,31 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	//Initialisation of the main time output vector
 	//Initialise default values for Toutput (output times for map outputs)
 	InitialiseToutput(XParam.Toutput, XParam);
-	XParam.Toutput.val.push_back(XParam.totaltime);
-	XParam.Toutput.val.push_back(XParam.endtime);
+	if (XParam.Toutput.val.empty())
+	{
+		if (abs(XParam.outputtimestep - DefaultParams.outputtimestep) <= tiny)
+		{
+			XParam.Toutput.val.push_back(XParam.totaltime);
+			XParam.Toutput.val.push_back(XParam.endtime);
+		}
+		else
+		{
+			int nstep = (XParam.endtime - XParam.totaltime) / XParam.outputtimestep + 1;
+
+			for (int k = 0; k < nstep; k++)
+			{
+				XParam.Toutput.val.push_back(std::min(XParam.totaltime + XParam.outputtimestep * k, XParam.endtime));
+			}
+
+		}
+	}
+	else
+	{
+
+		XParam.Toutput.val.push_back(XParam.totaltime);
+		XParam.Toutput.val.push_back(XParam.endtime);
+	}
+	
 
 	// Initialisation of the time output vector for the zones outputs
 	if (XParam.outzone.size() > 0)
@@ -1910,11 +1933,11 @@ double ReadTvalstr(std::string timestr,double start, double end,std::string reft
 
 	bool isdatest = timestr.find('T') != std::string::npos;
 
-	if (case_insensitive_compare(timestr, STstr))
+	if (case_insensitive_compare(timestr, STstr) == 0)
 	{
 		time = start;
 	}
-	else if (case_insensitive_compare(timestr, ENstr))
+	else if (case_insensitive_compare(timestr, ENstr) == 0)
 	{
 		time = end;
 	}
@@ -1950,7 +1973,7 @@ std::vector<double> ReadTRangestr(std::vector<std::string> timestr, double start
 	bool isdatelast = laststr.find('T') != std::string::npos;
 
 	
-	if (case_insensitive_compare(initstr, STstr) || initstr.empty())
+	if (case_insensitive_compare(initstr, STstr) == 0 || initstr.empty())
 	{
 		init = start;
 	}
@@ -1963,7 +1986,7 @@ std::vector<double> ReadTRangestr(std::vector<std::string> timestr, double start
 		init = date_string_to_s(initstr, reftime);
 	}
 	
-	if (case_insensitive_compare(laststr, ENstr) || laststr.empty())
+	if (case_insensitive_compare(laststr, ENstr) == 0 || laststr.empty())
 	{
 		last = end;
 	}
@@ -2011,9 +2034,9 @@ double readApproxtimestr(std::string input)
 	// first split the digit from the string
 	for (auto e : input)
 	{
-		if (isalpha(e))
+		if (isalpha(e) && e!='.')
 			unit.push_back(e);
-		else if (isdigit(e))
+		else if (isdigit(e) || e == '.')
 			numberst.push_back(e);
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -30,17 +30,17 @@
 * template DynForcingP<float> readfileinfo<DynForcingP<float>>(std::string input, DynForcingP<float> outinfo);
 * template deformmap<float> readfileinfo<deformmap<float>>(std::string input, deformmap<float> outinfo);
 */
-template <class T> T readfileinfo(std::string input,T outinfo)
+template <class T> T readfileinfo(std::string input, T outinfo)
 {
 	// Outinfo is based on an inputmap (or it's sub classes)
-	
+
 	//filename include the file extension
 
 	std::vector<std::string> extvec = split(input, '.');
 
 	//outinfo.inputfile = extvec.front();
 
-	std::vector<std::string> nameelements,filename;
+	std::vector<std::string> nameelements, filename;
 	//
 	nameelements = split(extvec.back(), '?');
 
@@ -78,10 +78,10 @@ template deformmap<float> readfileinfo<deformmap<float>>(std::string input, defo
 * Open the BG_param.txt file and read the parameters
 * save the parameter in the Param class and or Forcing class.
 */
-void Readparamfile(Param &XParam, Forcing<float> & XForcing, std::string Paramfile)
+void Readparamfile(Param& XParam, Forcing<float>& XForcing, std::string Paramfile)
 {
 	//
-	log("\nReading parameter file: "+ Paramfile +" ...");
+	log("\nReading parameter file: " + Paramfile + " ...");
 	//std::ifstream fs("BG_param.txt");
 	std::ifstream fs(Paramfile);
 
@@ -114,7 +114,7 @@ void Readparamfile(Param &XParam, Forcing<float> & XForcing, std::string Paramfi
 
 
 	}
-	
+
 }
 
 
@@ -123,7 +123,7 @@ void Readparamfile(Param &XParam, Forcing<float> & XForcing, std::string Paramfi
 
 /*! \fn Param readparamstr(std::string line, Param param)
 * Read BG_param.txt line and convert parameter to the righ parameter in the class
-* retrun an updated Param class 
+* retrun an updated Param class
 */
 Param readparamstr(std::string line, Param param)
 {
@@ -134,7 +134,7 @@ Param readparamstr(std::string line, Param param)
 	///////////////////////////////////////////////////////
 	// General parameters
 	//
-	
+
 	parameterstr = "test";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -171,7 +171,7 @@ Param readparamstr(std::string line, Param param)
 				param.engine = 1;
 				foo = true;
 			}
-				
+
 		}
 		if (!foo)
 		{
@@ -222,7 +222,7 @@ Param readparamstr(std::string line, Param param)
 	{
 
 		param.wetdryfix = readparambool(parametervalue, param.wetdryfix);
-		
+
 	}
 
 
@@ -242,8 +242,8 @@ Param readparamstr(std::string line, Param param)
 	{
 		param.eps = std::stod(parametervalue);
 	}
-	
-	paramvec = { "cf","roughness","cfmap"};
+
+	paramvec = { "cf","roughness","cfmap" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -281,7 +281,7 @@ Param readparamstr(std::string line, Param param)
 	{
 		param.VelThreshold = std::stod(parametervalue);
 	}
-	
+
 	parameterstr = "Cd";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -351,7 +351,7 @@ Param readparamstr(std::string line, Param param)
 
 	}
 
-	paramvec = { "outputtimestep","outtimestep","outputstep"};
+	paramvec = { "outputtimestep","outtimestep","outputstep" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -367,7 +367,7 @@ Param readparamstr(std::string line, Param param)
 
 	}
 
-	paramvec = { "totaltime","inittime","starttime", "start_time", "init_time", "start", "init"};
+	paramvec = { "totaltime","inittime","starttime", "start_time", "init_time", "start", "init" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -398,16 +398,16 @@ Param readparamstr(std::string line, Param param)
 	///////////////////////////////////////////////////////
 	// Input and output files
 	//
-	
+
 	parameterstr = "outfile";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		param.outfile = parametervalue;
-		
+
 	}
 
-	
+
 	// Below is a bit more complex than usual because more than 1 node can be outputed as a timeseries
 	paramvec = { "TSnodesout","TSOutput" };
 	parametervalue = findparameter(paramvec, line);
@@ -427,12 +427,12 @@ Param readparamstr(std::string line, Param param)
 		{
 			std::cerr << "Node input failed there should be 3 arguments (comma separated) when inputing a outout node: TSOutput = filename, xvalue, yvalue; see log file for details" << std::endl;
 
-			log("Node input failed there should be 3 arguments (comma separated) when inputing a outout node: TSOutput = filename, xvalue, yvalue; see log file for details. Input was: "+ parametervalue);
-			
+			log("Node input failed there should be 3 arguments (comma separated) when inputing a outout node: TSOutput = filename, xvalue, yvalue; see log file for details. Input was: " + parametervalue);
+
 		}
-		
+
 	}
-	
+
 
 
 	//outvars
@@ -446,12 +446,12 @@ Param readparamstr(std::string line, Param param)
 			//Verify that the variable name makes sense?
 			//Need to add more here
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw"};
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw" };
 
 			std::string vvar = trim(vars[nv], " ");
 			for (int isup = 0; isup < SupportedVarNames.size(); isup++)
 			{
-				
+
 				//std::cout << "..." << vvar << "..." << std::endl;
 				if (vvar.compare(SupportedVarNames[isup]) == 0)
 				{
@@ -480,12 +480,12 @@ Param readparamstr(std::string line, Param param)
 			//param.outvort = (vvar.compare("vort") == 0) ? true : param.outvort;
 			//param.outU = (vvar.compare("U") == 0) ? true : param.outU;
 		}
-		
 
-		
+
+
 	}
 
-	
+
 	// Same as for TSnodesout, the same key word can be used for different zones Output
 	parameterstr = "outzone";
 	parametervalue = findparameter(parameterstr, line);
@@ -574,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 	}
 
 	////////////////////////////////////////////////////////////////
-	
+
 
 	parameterstr = "nx";
 	parametervalue = findparameter(parameterstr, line);
@@ -637,7 +637,7 @@ Param readparamstr(std::string line, Param param)
 	if (!parametervalue.empty())
 	{
 		param.g = std::stod(parametervalue);
-		
+
 	}
 
 	parameterstr = "rho";
@@ -711,7 +711,7 @@ Param readparamstr(std::string line, Param param)
 	}
 #endif
 
-	paramvec = { "zsinit", "initzs"};
+	paramvec = { "zsinit", "initzs" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -724,32 +724,32 @@ Param readparamstr(std::string line, Param param)
 	{
 		param.zsoffset = std::stod(parametervalue);
 	}
-	paramvec = {"rainbnd", "rainonbnd"};
+	paramvec = { "rainbnd", "rainonbnd" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
 		param.rainbnd = readparambool(parametervalue, param.rainbnd);
-		
+
 	}
-		
+
 
 	parameterstr = "hotstartfile";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		param.hotstartfile = parametervalue;
-		
+
 	}
-	
+
 	parameterstr = "hotstep";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		param.hotstep = std::stoi(parametervalue);
 	}
-	
 
-	paramvec = {"spherical", "geo"};
+
+	paramvec = { "spherical", "geo" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -769,7 +769,7 @@ Param readparamstr(std::string line, Param param)
 	{
 		param.frictionmodel = std::stoi(parametervalue);
 	}
-	
+
 	parameterstr = "Adaptation";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -812,11 +812,14 @@ Param readparamstr(std::string line, Param param)
 			if (Toutputpar_vect.size() == 3)
 			{
 				if (!Toutputpar_vect[0].empty()) {
-					param.Toutput.init = std::stod(Toutputpar_vect[0]); }
+					param.Toutput.init = std::stod(Toutputpar_vect[0]);
+				}
 				if (!Toutputpar_vect[1].empty()) {
-					param.Toutput.tstep = std::stod(Toutputpar_vect[1]); }
+					param.Toutput.tstep = std::stod(Toutputpar_vect[1]);
+				}
 				if (!Toutputpar_vect[2].empty()) {
-					param.Toutput.end = std::stod(Toutputpar_vect[2]); }
+					param.Toutput.end = std::stod(Toutputpar_vect[2]);
+				}
 			}
 			else if (Toutputpar_vect.size() > 1)
 			{
@@ -827,7 +830,8 @@ Param readparamstr(std::string line, Param param)
 				log(parametervalue);
 			}
 			else {
-				param.Toutput.val.push_back(std::stod(Toutputpar_vect[0])); }
+				param.Toutput.val.push_back(std::stod(Toutputpar_vect[0]));
+			}
 			if (Toutputpar.size() > 1)
 			{
 				for (int ii = 1; ii < Toutputpar.size(); ii++)
@@ -836,8 +840,8 @@ Param readparamstr(std::string line, Param param)
 				}
 			}
 		}
-  }
-  
+	}
+
 	paramvec = { "savebyblk", "writebyblk","saveperblk", "writeperblk","savebyblock", "writebyblock","saveperblock", "writeperblock" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -859,8 +863,8 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 {
 	std::string parameterstr, parametervalue;
 	std::vector<std::string> paramvec;
-       	
-	paramvec = { "Bathy","bathyfile","bathymetry","depfile","depthfile","topofile","topo","DEM"};
+
+	paramvec = { "Bathy","bathyfile","bathymetry","depfile","depthfile","topofile","topo","DEM" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -875,7 +879,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
-		forcing.AOI.file= parametervalue;
+		forcing.AOI.file = parametervalue;
 		forcing.AOI.active = true;
 	}
 
@@ -911,19 +915,19 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 
 
 	// Boundaries
-	
-	paramvec = { "left","leftbndfile","leftbnd"};
+
+	paramvec = { "left","leftbndfile","leftbnd" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
 		//forcing.left = readbndline(parametervalue);
 		forcing.bndseg.push_back(readbndlineside(parametervalue, "left"));
 
-		
-			
+
+
 	}
-	
-	paramvec = { "right","rightbndfile","rightbnd"};
+
+	paramvec = { "right","rightbndfile","rightbnd" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -932,7 +936,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 
 	}
 
-	paramvec = { "top","topbndfile","topbnd"};
+	paramvec = { "top","topbndfile","topbnd" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -1040,7 +1044,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 
 	// friction coefficient (mapped or constant)
 	// if it is a constant no-need to do anything below but if it is a file it overwrites any other value
-	paramvec = { "cf","roughness","cfmap"};
+	paramvec = { "cf","roughness","cfmap" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -1090,7 +1094,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		{
 			// If 2 parameters (files) are given then 1st file is U wind and second is V wind.
 			// This is for variable winds no rotation of the data is performed
-			
+
 			forcing.UWind = readfileinfo(trim(vars[0], " "), forcing.UWind);
 			forcing.VWind = readfileinfo(trim(vars[1], " "), forcing.VWind);
 		}
@@ -1100,7 +1104,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 			// wind direction is rotated (later) to the grid direction (via grdalpha)
 			forcing.UWind = readfileinfo(parametervalue, forcing.UWind);
 			forcing.UWind.uniform = 1;
-			
+
 			//apply the same for Vwind? seem unecessary but need to be careful later in the code
 		}
 		else
@@ -1115,7 +1119,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 	}
 
 	// atmospheric pressure forcing
-	paramvec = {"Atmp","atmpfile"};
+	paramvec = { "Atmp","atmpfile" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
@@ -1132,7 +1136,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		// netcdf file == Variable spatially
 		// txt file (other than .nc) == spatially cst (txt file with 2 col time and mmm/h )
 		forcing.Rain = readfileinfo(parametervalue, forcing.Rain);
-		
+
 		//set the expected type of input
 
 		if (forcing.Rain.extension.compare("nc") == 0)
@@ -1173,7 +1177,7 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 
 /*! \fn void checkparamsanity(Param & XParam, Forcing<float> & XForcing)
 * Check the Sanity of both Param and Forcing class
-* If required some parameter are infered 
+* If required some parameter are infered
 */
 void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 {
@@ -1298,7 +1302,7 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	// Read/setup bdn segment polygon. Note this can't be part of the "readforcing" step because xmin, xmax ymin ymax are not known then
 	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
 	{
-		XForcing.bndseg[iseg].poly= readbndpolysegment(XForcing.bndseg[iseg], XParam);
+		XForcing.bndseg[iseg].poly = readbndpolysegment(XForcing.bndseg[iseg], XParam);
 		if (XForcing.bndseg[iseg].type == 2)
 		{
 			XForcing.bndseg[iseg].type = 3;
@@ -1336,7 +1340,7 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	XForcing.bndseg.push_back(remainderblk);
 	for (int iseg = 0; iseg < XForcing.bndseg.size(); iseg++)
 	{
-		
+
 		AllocateCPU(1, 1, XForcing.bndseg[iseg].left.blk);
 		AllocateCPU(1, 1, XForcing.bndseg[iseg].right.blk);
 		AllocateCPU(1, 1, XForcing.bndseg[iseg].top.blk);
@@ -1348,10 +1352,10 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 		AllocateCPU(1, 1, XForcing.bndseg[iseg].bot.qmean);
 	}
 
-	
-	
-	
-	
+
+
+
+
 	//setup extra infor about boundaries
 	// This is not needed anymore
 	XForcing.left.side = 3;
@@ -1517,11 +1521,11 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	//Check that the Initial Loss/ Continuing Loss model is used if il, cl or hgw output are asked by user.
 	if (!XParam.infiltration) // (XForcing.il.inputfile.empty() && XForcing.cl.inputfile.empty() && (XParam.il == 0.0) && (XParam.cl == 0.0))
 	{
-		std::vector<std::string> namestr = { "il","cl","hgw"};
+		std::vector<std::string> namestr = { "il","cl","hgw" };
 		for (int ii = 0; ii < namestr.size(); ii++)
 		{
 			std::vector<std::string>::iterator itr = std::find(XParam.outvars.begin(), XParam.outvars.end(), namestr[ii]);
-			if (itr != XParam.outvars.end()) 
+			if (itr != XParam.outvars.end())
 			{
 				log("The output variable associated to the ILCL model \"" + namestr[ii] + "\" is requested but the model is not used. The variable is removed from the outputs.");
 				XParam.outvars.erase(itr);
@@ -1565,19 +1569,19 @@ void InitialiseToutput(Toutput& Toutput_loc, Param XParam)
 }
 
 /*! \fn double setendtime(Param XParam,Forcing<float> XForcing)
-* Calculate/modify endtime based on maximum time in forcing 
+* Calculate/modify endtime based on maximum time in forcing
 *
 */
-double setendtime(Param XParam,Forcing<float> XForcing)
+double setendtime(Param XParam, Forcing<float> XForcing)
 {
 	//endtime cannot be bigger than the smallest time set in a boundary
 	SLTS tempSLTS;
 	double endtime = XParam.endtime;
 	if (XForcing.left.on)
 	{
-		tempSLTS =XForcing.left.data.back();
-		endtime = utils::min( endtime, tempSLTS.time);
-		
+		tempSLTS = XForcing.left.data.back();
+		endtime = utils::min(endtime, tempSLTS.time);
+
 	}
 	if (XForcing.right.on)
 	{
@@ -1610,15 +1614,15 @@ double setendtime(Param XParam,Forcing<float> XForcing)
 std::string findparameter(std::vector<std::string> parameterstr, std::string line)
 {
 	std::size_t found;
-	std::string parameternumber,left,right;
+	std::string parameternumber, left, right;
 	std::vector<std::string> splittedstr;
-	
+
 	// first look for an equal sign
 	// No equal sign mean not a valid line so skip
-	splittedstr=split(line, '=' );
-	if (splittedstr.size()>1)
+	splittedstr = split(line, '=');
+	if (splittedstr.size() > 1)
 	{
-		left = trim(splittedstr[0]," ");
+		left = trim(splittedstr[0], " ");
 		right = splittedstr[1]; // if there are more than one equal sign in the line the second one is ignored
 		for (int ieq = 2; ieq < splittedstr.size(); ieq++)
 		{
@@ -1626,7 +1630,7 @@ std::string findparameter(std::vector<std::string> parameterstr, std::string lin
 		}
 		for (int ii = 0; ii < parameterstr.size(); ii++)
 		{
-			found = case_insensitive_compare(left,parameterstr[ii]);// it needs to strictly compare
+			found = case_insensitive_compare(left, parameterstr[ii]);// it needs to strictly compare
 			if (found == 0)
 				break;
 		}
@@ -1661,7 +1665,7 @@ std::string findparameter(std::string parameterstr, std::string line)
 * split string based in character
 *
 */
-void split(const std::string &s, char delim, std::vector<std::string> &elems) {
+void split(const std::string& s, char delim, std::vector<std::string>& elems) {
 	std::stringstream ss;
 	ss.str(s);
 	std::string item;
@@ -1670,7 +1674,7 @@ void split(const std::string &s, char delim, std::vector<std::string> &elems) {
 		{
 			elems.push_back(item);
 		}
-		
+
 	}
 }
 
@@ -1678,7 +1682,7 @@ void split(const std::string &s, char delim, std::vector<std::string> &elems) {
 * split string based in character
 *
 */
-std::vector<std::string> split(const std::string &s, char delim) {
+std::vector<std::string> split(const std::string& s, char delim) {
 	std::vector<std::string> elems;
 	split(s, delim, elems);
 	return elems;
@@ -1699,7 +1703,7 @@ void split_full(const std::string& s, char delim, std::vector<std::string>& elem
 		item.erase(end_pos, item.end());
 		elems.push_back(item);
 	}
-	if (s[s.length()-1] == delim)
+	if (s[s.length() - 1] == delim)
 	{
 		std::string item;
 		elems.push_back(item);
@@ -1719,15 +1723,15 @@ std::vector<std::string> split_full(const std::string& s, char delim) {
 
 std::vector<std::string> split(const std::string s, const std::string delim)
 {
-	size_t ide=0;
+	size_t ide = 0;
 	int loc = 0;
 	std::vector<std::string> output;
 	std::string rem = s;
-	
+
 
 	while (ide < std::string::npos || output.size() == 0)
 	{
-		
+
 		ide = rem.find(delim);
 		if (ide == 0 || ide == std::string::npos)
 		{
@@ -1738,7 +1742,7 @@ std::vector<std::string> split(const std::string s, const std::string delim)
 		{
 			output.push_back(rem.substr(loc, ide));
 		}
-		
+
 		if (ide < (rem.length() - delim.length()))
 		{
 			loc = int(ide + delim.length());
@@ -1748,7 +1752,7 @@ std::vector<std::string> split(const std::string s, const std::string delim)
 
 	return output;
 
-	
+
 
 }
 
@@ -1778,7 +1782,7 @@ std::size_t case_insensitive_compare(std::string s1, std::string s2)
 	//Convert s1 and s2 to lower case strings
 	std::transform(s1.begin(), s1.end(), s1.begin(), ::tolower);
 	std::transform(s2.begin(), s2.end(), s2.begin(), ::tolower);
-//if (s1.compare(s2) == 0)
+	//if (s1.compare(s2) == 0)
 	return s1.compare(s2);
 }
 
@@ -1813,16 +1817,16 @@ bndsegment readbndlineside(std::string parametervalue, std::string side)
 	else if (items.size() >= 2)
 	{
 		const char* cstr = items[1].c_str();
-		
+
 		if (isdigit(cstr[0]))
 		{
 			//?
 			bnd.type = std::stoi(items[1]);
 			bnd.inputfile = items[0];
 			bnd.on = true;
-			
-			
-			
+
+
+
 		}
 		else
 		{
@@ -1830,7 +1834,7 @@ bndsegment readbndlineside(std::string parametervalue, std::string side)
 			bnd.inputfile = items[1];
 			bnd.on = true;
 		}
-		
+
 	}
 	bnd.polyfile = side;
 	if (bnd.on)
@@ -1867,22 +1871,22 @@ bndsegment readbndline(std::string parametervalue)
 	else if (items.size() >= 2)
 	{
 		const char* cstr = items[1].c_str();
-		if (items[1].length()>2)
+		if (items[1].length() > 2)
 		{
 			bnd.polyfile = items[0];
 			bnd.type = std::stoi(items[2]);
 			bnd.inputfile = items[1];
 			bnd.on = true;
-			
+
 		}
 		else
 		{
 			bnd.polyfile = items[0];
-			bnd.type = std::max(std::stoi(items[1]),1); // only 2 param implies that it is either a wall or Neumann bnd
-	
+			bnd.type = std::max(std::stoi(items[1]), 1); // only 2 param implies that it is either a wall or Neumann bnd
+
 		}
 	}
-	
+
 
 	//set the expected type of input
 
@@ -1908,7 +1912,7 @@ bndsegment readbndline(std::string parametervalue)
 
 
 
-bool readparambool(std::string paramstr,bool defaultval)
+bool readparambool(std::string paramstr, bool defaultval)
 {
 	bool out = defaultval;
 	std::vector<std::string> truestr = { "1","true","yes", "on" };

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -506,20 +506,30 @@ Param readparamstr(std::string line, Param param)
 			std::vector<std::string> Toutputpar_vect = split_full(zoneitems[5], ':');
 			if (Toutputpar_vect.size() == 3)
 			{
+				double init, tstep, end;
+				double tiny = 0.000001;
 				if (!Toutputpar_vect[0].empty()) {
-					zone.Toutput.init = std::stod(Toutputpar_vect[0]);
+					init = std::stod(Toutputpar_vect[0]);
 				}
 				if (!Toutputpar_vect[1].empty()) {
-					zone.Toutput.tstep = std::stod(Toutputpar_vect[1]);
+					tstep = std::max(std::stod(Toutputpar_vect[1]),tiny);
 				}
 				if (!Toutputpar_vect[2].empty()) {
-					zone.Toutput.end = std::stod(Toutputpar_vect[2]);
+					end = std::stod(Toutputpar_vect[2]);
 				}
+
+				int nstep = (end - init) / tstep + 1;
+
+				for (int k = 0; k < nstep; k++)
+				{
+					zone.Toutput.val.push_back(std::min(init + tstep * k,end));
+				}
+
 			}
 			else if (Toutputpar_vect.size() > 1)
 			{
 				//Failed: Toutput must be exactly 3 values, separated by ":" for a vector shape, in virst position. "t_init:t_step:t_end" (with possible empty values as "t_init:t_setps: " to use the last time steps as t_end;
-				std::cerr << "Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end; see log file for details" << std::endl;
+				std::cerr << "Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in first position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end; see log file for details" << std::endl;
 
 				log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
 				log(parametervalue);
@@ -811,6 +821,7 @@ Param readparamstr(std::string line, Param param)
 			std::vector<std::string> Toutputpar_vect = split_full(Toutputpar[0], ':');
 			if (Toutputpar_vect.size() == 3)
 			{
+				/*
 				if (!Toutputpar_vect[0].empty()) {
 					param.Toutput.init = std::stod(Toutputpar_vect[0]);
 				}
@@ -820,6 +831,26 @@ Param readparamstr(std::string line, Param param)
 				if (!Toutputpar_vect[2].empty()) {
 					param.Toutput.end = std::stod(Toutputpar_vect[2]);
 				}
+				*/
+				double init, tstep, end;
+				double tiny = 0.000001;
+				if (!Toutputpar_vect[0].empty()) {
+					init = std::stod(Toutputpar_vect[0]);
+				}
+				if (!Toutputpar_vect[1].empty()) {
+					tstep = std::max(std::stod(Toutputpar_vect[1]), tiny);
+				}
+				if (!Toutputpar_vect[2].empty()) {
+					end = std::stod(Toutputpar_vect[2]);
+				}
+
+				int nstep = (end - init) / tstep + 1;
+
+				for (int k = 0; k < nstep; k++)
+				{
+					param.Toutput.val.push_back(std::min(init + tstep * k, end));
+				}
+
 			}
 			else if (Toutputpar_vect.size() > 1)
 			{

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -2001,7 +2001,7 @@ std::vector<double> ReadTRangestr(std::vector<std::string> timestr, double start
 
 	if (stepstr.empty())
 	{
-		step = 3600.0;
+		step = (last - init);
 	}
 	else
 	{

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -517,9 +517,10 @@ Param readparamstr(std::string line, Param param)
 				log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
 				log(parametervalue);
 			}
-			else
+			else { //only values
 				zone.Toutput.val.push_back(std::stod(Toutputpar_vect[0]));
-			if (zoneitems.size() > 6)
+			}
+			if (zoneitems.size() > 6) //vector + values
 			{
 				for (int ii = 6; ii < zoneitems.size(); ii++)
 				{
@@ -527,16 +528,17 @@ Param readparamstr(std::string line, Param param)
 				}
 			}
 		}
+		else if (zoneitems.size() == 5)//No time input in the zone area
+		{
+			zone.Toutput = param.Toutput;
+		}
 		else
 		{
-			std::cerr << "Zone input failed there should be 5 arguments (comma separated) when inputing a outout zone: outzone = filename, xstart, xend, ystart, yend; see log file for details" << std::endl;
-
-			log("Node input failed there should be 5 arguments (comma separated) when inputing a outout zone: outzone = filename, xstart, xend, ystart, yend; see log file for details (with possibly some time inputs after). Input was: " + parametervalue);
-
+			std::cerr << "Zone input failed there should be at least 5 arguments (comma separated) when inputing a outout zone: outzone = filename, xstart, xend, ystart, yend; see log file for details" << std::endl;
+			log("Node input failed there should be at least 5 arguments (comma separated) when inputing a outout zone: outzone = filename, xstart, xend, ystart, yend; see log file for details (with possibly some time inputs after). Input was: " + parametervalue);
 		}
 		param.outzone.push_back(zone);
 	}
-
 
 	parameterstr = "resetmax";
 	parametervalue = findparameter(parameterstr, line);
@@ -817,8 +819,8 @@ Param readparamstr(std::string line, Param param)
 				log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
 				log(parametervalue);
 			}
-			else
-				param.Toutput.val.push_back(std::stod(Toutputpar_vect[0]));
+			else {
+				param.Toutput.val.push_back(std::stod(Toutputpar_vect[0])); }
 			if (Toutputpar.size() > 1)
 			{
 				for (int ii = 1; ii < Toutputpar.size(); ii++)
@@ -826,7 +828,6 @@ Param readparamstr(std::string line, Param param)
 					param.Toutput.val.push_back(std::stod(Toutputpar[ii]));
 				}
 			}
-
 		}
 	}
 
@@ -1347,14 +1348,6 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 	{
 		for (int ii = 0; ii < XParam.outzone.size(); ii++)
 		{
-			if (XParam.outzone[ii].Toutput.val.empty()) // &
-				//XParam.outzone[ii].Toutput.init.empty() &
-				//XParam.outzone[ii].Toutput.tstep.empty() &
-				//XParam.outzone[ii].Toutput.end.empty())
-			{
-				XParam.outzone[ii].Toutput = XParam.Toutput;
-			}
-			else
 			{
 				InitialiseToutput(XParam.outzone[ii].Toutput, XParam);
 			}
@@ -1613,8 +1606,14 @@ void split_full(const std::string& s, char delim, std::vector<std::string>& elem
 	ss.str(s);
 	std::string item;
 	while (std::getline(ss, item, delim)) {
+		std::string::iterator end_pos = std::remove(item.begin(), item.end(), ' ');
+		item.erase(end_pos, item.end());
 		elems.push_back(item);
-
+	}
+	if (s[s.length()-1] == delim)
+	{
+		std::string item;
+		elems.push_back(item);
 	}
 }
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -1265,6 +1265,16 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 		//otherwise, no final output
 	}
 
+	//Initialisation of the intial step for outputs:
+	if (XParam.outputtimeinit == -99999)
+	{
+		XParam.outputtimeinit = XParam.dtinit;
+	}
+	if (XParam.outputtimeinit > XParam.endtime)
+	{
+		XParam.outputtimeinit = XParam.endtime;
+	}
+
 
 
 	if (XParam.outvars.empty() && XParam.outputtimestep > 0.0)

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -503,51 +503,25 @@ Param readparamstr(std::string line, Param param)
 		}
 		if (zoneitems.size() > 5)
 		{
-			std::vector<std::string> Toutputpar_vect = split_full(zoneitems[5], ':');
-			if (Toutputpar_vect.size() == 3)
+			// concatenate 5,6,.... together
+			std::string constr;
+
+			for (int ist = 5; ist < zoneitems.size(); ist++)
 			{
-				double init, tstep, end;
-				double tiny = 0.000001;
-				if (!Toutputpar_vect[0].empty()) {
-					init = std::stod(Toutputpar_vect[0]);
-				}
-				if (!Toutputpar_vect[1].empty()) {
-					tstep = std::max(std::stod(Toutputpar_vect[1]),tiny);
-				}
-				if (!Toutputpar_vect[2].empty()) {
-					end = std::stod(Toutputpar_vect[2]);
-				}
-
-				int nstep = (end - init) / tstep + 1;
-
-				for (int k = 0; k < nstep; k++)
+				constr = constr + zoneitems[ist];
+				if (ist < (zoneitems.size() - 1))
 				{
-					zone.Toutput.val.push_back(std::min(init + tstep * k,end));
+					constr = constr + ",";
 				}
 
 			}
-			else if (Toutputpar_vect.size() > 1)
-			{
-				//Failed: Toutput must be exactly 3 values, separated by ":" for a vector shape, in virst position. "t_init:t_step:t_end" (with possible empty values as "t_init:t_setps: " to use the last time steps as t_end;
-				std::cerr << "Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in first position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end; see log file for details" << std::endl;
-
-				log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
-				log(parametervalue);
-			}
-			else { //only values
-				zone.Toutput.val.push_back(std::stod(Toutputpar_vect[0]));
-			}
-			if (zoneitems.size() > 6) //vector + values
-			{
-				for (int ii = 6; ii < zoneitems.size(); ii++)
-				{
-					zone.Toutput.val.push_back(std::stod(zoneitems[ii]));
-				}
-			}
+			zone.Toutput = ReadToutput(constr);
+			
+			
 		}
 		else if (zoneitems.size() == 5)//No time input in the zone area
 		{
-			zone.Toutput = param.Toutput;
+			zone.Toutput = param.Toutput; // Thats needs to move to sanity check
 		}
 		else
 		{
@@ -814,63 +788,7 @@ Param readparamstr(std::string line, Param param)
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
-		std::vector<std::string> Toutputpar = split(parametervalue, ',');
-
-		if (!Toutputpar.empty())
-		{
-			std::vector<std::string> Toutputpar_vect = split_full(Toutputpar[0], ':');
-			if (Toutputpar_vect.size() == 3)
-			{
-				/*
-				if (!Toutputpar_vect[0].empty()) {
-					param.Toutput.init = std::stod(Toutputpar_vect[0]);
-				}
-				if (!Toutputpar_vect[1].empty()) {
-					param.Toutput.tstep = std::stod(Toutputpar_vect[1]);
-				}
-				if (!Toutputpar_vect[2].empty()) {
-					param.Toutput.end = std::stod(Toutputpar_vect[2]);
-				}
-				*/
-				double init, tstep, end;
-				double tiny = 0.000001;
-				if (!Toutputpar_vect[0].empty()) {
-					init = std::stod(Toutputpar_vect[0]);
-				}
-				if (!Toutputpar_vect[1].empty()) {
-					tstep = std::max(std::stod(Toutputpar_vect[1]), tiny);
-				}
-				if (!Toutputpar_vect[2].empty()) {
-					end = std::stod(Toutputpar_vect[2]);
-				}
-
-				int nstep = (end - init) / tstep + 1;
-
-				for (int k = 0; k < nstep; k++)
-				{
-					param.Toutput.val.push_back(std::min(init + tstep * k, end));
-				}
-
-			}
-			else if (Toutputpar_vect.size() > 1)
-			{
-				//Failed: Toutput must be exactly 3 values, separated by ":" for a vector shape, in virst position. "t_init:t_step:t_end" (with possible empty values as "t_init:t_setps: " to use the last time steps as t_end;
-				std::cerr << "Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end; see log file for details" << std::endl;
-
-				log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
-				log(parametervalue);
-			}
-			else {
-				param.Toutput.val.push_back(std::stod(Toutputpar_vect[0]));
-			}
-			if (Toutputpar.size() > 1)
-			{
-				for (int ii = 1; ii < Toutputpar.size(); ii++)
-				{
-					param.Toutput.val.push_back(std::stod(Toutputpar[ii]));
-				}
-			}
-		}
+		param.Toutput = ReadToutput(parametervalue);
 	}
 
 	paramvec = { "savebyblk", "writebyblk","saveperblk", "writeperblk","savebyblock", "writebyblock","saveperblock", "writeperblock" };
@@ -1585,6 +1503,7 @@ void checkparamsanity(Param& XParam, Forcing<float>& XForcing)
 //Initialise default values for Toutput (output times for map outputs)
 void InitialiseToutput(T_output& Toutput_loc, Param XParam)
 {
+	/*
 	if (std::isnan(Toutput_loc.init))
 	{
 		Toutput_loc.init = XParam.totaltime;
@@ -1596,7 +1515,18 @@ void InitialiseToutput(T_output& Toutput_loc, Param XParam)
 	if (std::isnan(Toutput_loc.tstep))
 	{
 		Toutput_loc.tstep = XParam.outputtimestep;
+	}*/
+
+	if (Toutput_loc.val.empty())
+	{
+		copy(XParam.Toutput.val.begin(), XParam.Toutput.val.end(), back_inserter(Toutput_loc.val));
+		//Toutput_loc.val = XParam.Toutput.val;
 	}
+	
+	Toutput_loc.val.push_back(XParam.totaltime);
+	Toutput_loc.val.push_back(XParam.endtime);
+
+	
 }
 
 /*! \fn double setendtime(Param XParam,Forcing<float> XForcing)
@@ -1969,4 +1899,72 @@ bool readparambool(std::string paramstr, bool defaultval)
 //	return (stat(name.c_str(), &buffer) == 0);
 //}
 
+
+T_output ReadToutput(std::string paramstr)
+{
+	//
+
+	T_output tout;
+
+	std::vector<std::string> Toutputpar = split(paramstr, ',');
+
+
+
+	if (!Toutputpar.empty())
+	{
+		std::vector<std::string> Toutputpar_vect = split_full(Toutputpar[0], ':');
+		if (Toutputpar_vect.size() == 3)
+		{
+			/*
+			if (!Toutputpar_vect[0].empty()) {
+				param.Toutput.init = std::stod(Toutputpar_vect[0]);
+			}
+			if (!Toutputpar_vect[1].empty()) {
+				param.Toutput.tstep = std::stod(Toutputpar_vect[1]);
+			}
+			if (!Toutputpar_vect[2].empty()) {
+				param.Toutput.end = std::stod(Toutputpar_vect[2]);
+			}
+			*/
+			double init, tstep, end;
+			double tiny = 0.000001;
+			if (!Toutputpar_vect[0].empty()) {
+				init = std::stod(Toutputpar_vect[0]);
+			}
+			if (!Toutputpar_vect[1].empty()) {
+				tstep = std::max(std::stod(Toutputpar_vect[1]), tiny);
+			}
+			if (!Toutputpar_vect[2].empty()) {
+				end = std::stod(Toutputpar_vect[2]);
+			}
+
+			int nstep = (end - init) / tstep + 1;
+
+			for (int k = 0; k < nstep; k++)
+			{
+				tout.val.push_back(std::min(init + tstep * k, end));
+			}
+
+		}
+		else if (Toutputpar_vect.size() > 1)
+		{
+			//Failed: Toutput must be exactly 3 values, separated by ":" for a vector shape, in virst position. "t_init:t_step:t_end" (with possible empty values as "t_init:t_setps: " to use the last time steps as t_end;
+			std::cerr << "Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end; see log file for details" << std::endl;
+
+			log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
+			log(paramstr);
+		}
+		else {
+			tout.val.push_back(std::stod(Toutputpar_vect[0]));
+		}
+		if (Toutputpar.size() > 1)
+		{
+			for (int ii = 1; ii < Toutputpar.size(); ii++)
+			{
+				tout.val.push_back(std::stod(Toutputpar[ii]));
+			}
+		}
+	}
+	return tout;
+}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -758,6 +758,43 @@ Param readparamstr(std::string line, Param param)
 		param.crs_ref = parametervalue;
 	}
 
+	//Read Flexible Toutput variable
+	parameterstr = "Toutput";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		std::vector<std::string> Toutputpar = split(parametervalue, ',');
+
+		if (!Toutputpar.empty())
+		{
+			std::vector<std::string> Toutputpar_vect = split(Toutputpar[0], ':');
+			if (Toutputpar_vect.size == 3)
+			{
+				param.Toutput.init = std::stod(Toutputpar_vect[0]);
+				param.Toutput.tstep = std::stod(Toutputpar_vect[1]);
+				param.Toutput.end = std::stod(Toutputpar_vect[2]);
+			}
+			else if (Toutputpar_vect.size > 1)
+			{
+				//Failed: Toutput must be exactly 3 values, separated by ":" for a vector shape, in virst position. "t_init:t_step:t_end" (with possible empty values as "t_init:t_setps: " to use the last time steps as t_end;
+				std::cerr << "Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end; see log file for details" << std::endl;
+
+				log("Failed: Toutput must be exactly 3 values, separated by ':' for a vector shape, in virst position. 't_init : t_step : t_end' (with possible empty values as 't_init : t_setps : ' to use the last time steps as t_end;");
+				log(parametervalue);
+			}
+			else
+				param.Toutput.val.push_back = std::stod(Toutputpar_vect[0]);
+			if (Toutputpar.size > 1)
+			{
+				for (int ii = 1; ii < Toutputpar.size(); ii++)
+				{
+					param.Toutput.val.push_back = std::stod(Toutputpar_vect[ii]);
+				}
+			}
+
+		}
+	}
+
 	return param;
 }
 

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -39,7 +39,7 @@ bndsegment readbndline(std::string parametervalue);
 bndsegment readbndlineside(std::string parametervalue, std::string side);
 
 //T_output ReadToutput(std::vector<std::string> paramstr, Param XParam);
-std::vector<double> ReadToutput(std::vector<std::string> paramstr, Param XParam)
+std::vector<double> ReadToutput(std::vector<std::string> paramstr, Param XParam);
 
 std::vector<std::string> ReadToutSTR(std::string paramstr);
 double ReadTvalstr(std::string timestr, double start, double end, std::string reftime);

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -34,7 +34,7 @@ std::string trim(const std::string& str, const std::string& whitespace);
 std::size_t case_insensitive_compare(std::string s1, std::string s2);
 std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> vecstr);
 bool readparambool(std::string paramstr, bool defaultval);
-void InitialiseToutput(Toutput& Toutput, Param XParam);
+void InitialiseToutput(T_output& Toutput, Param XParam);
 bndsegment readbndline(std::string parametervalue);
 bndsegment readbndlineside(std::string parametervalue, std::string side);
 

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -37,7 +37,7 @@ bool readparambool(std::string paramstr, bool defaultval);
 void InitialiseToutput(T_output& Toutput, Param XParam);
 bndsegment readbndline(std::string parametervalue);
 bndsegment readbndlineside(std::string parametervalue, std::string side);
-
+T_output ReadToutput(std::string paramstr);
 //inline bool fileexists(const std::string& name);
 
 // End of global definition

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -8,6 +8,7 @@
 #include "Forcing.h"
 #include "Util_CPU.h"
 #include "utctime.h"
+#include "Input.h"
 
 
 template <class T> T readfileinfo(std::string input, T outinfo);
@@ -31,6 +32,7 @@ std::size_t case_insensitive_compare(std::string s1, std::string s2);
 std::size_t case_insensitive_compare(std::string s1, std::vector<std::string> vecstr);
 bool readparambool(std::string paramstr, bool defaultval);
 bndparam readbndline(std::string parametervalue);
+void InitialiseToutput(Toutput& Toutput, Param XParam);
 
 // End of global definition
 #endif

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -22,11 +22,11 @@ Param readparamstr(std::string line, Param param);
 
 template <class T>Forcing<T> readparamstr(std::string line, Forcing<T> forcing);
 void checkparamsanity(Param& XParam, Forcing<float>& XForcing);
-double setendtime(Param XParam,Forcing<float> XForcing);
+double setendtime(Param XParam, Forcing<float> XForcing);
 std::string findparameter(std::vector<std::string> parameterstr, std::string line);
 std::string findparameter(std::string parameterstr, std::string line);
-void split(const std::string &s, char delim, std::vector<std::string> &elems);
-std::vector<std::string> split(const std::string &s, char delim);
+void split(const std::string& s, char delim, std::vector<std::string>& elems);
+std::vector<std::string> split(const std::string& s, char delim);
 void split_full(const std::string& s, char delim, std::vector<std::string>& elems);
 std::vector<std::string> split_full(const std::string& s, char delim);
 std::vector<std::string> split(const std::string s, const std::string delim);

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -26,6 +26,8 @@ std::string findparameter(std::vector<std::string> parameterstr, std::string lin
 std::string findparameter(std::string parameterstr, std::string line);
 void split(const std::string &s, char delim, std::vector<std::string> &elems);
 std::vector<std::string> split(const std::string &s, char delim);
+void split_full(const std::string& s, char delim, std::vector<std::string>& elems);
+std::vector<std::string> split_full(const std::string& s, char delim);
 std::vector<std::string> split(const std::string s, const std::string delim);
 std::string trim(const std::string& str, const std::string& whitespace);
 std::size_t case_insensitive_compare(std::string s1, std::string s2);

--- a/src/ReadInput.h
+++ b/src/ReadInput.h
@@ -37,7 +37,15 @@ bool readparambool(std::string paramstr, bool defaultval);
 void InitialiseToutput(T_output& Toutput, Param XParam);
 bndsegment readbndline(std::string parametervalue);
 bndsegment readbndlineside(std::string parametervalue, std::string side);
-T_output ReadToutput(std::string paramstr);
+
+//T_output ReadToutput(std::vector<std::string> paramstr, Param XParam);
+std::vector<double> ReadToutput(std::vector<std::string> paramstr, Param XParam)
+
+std::vector<std::string> ReadToutSTR(std::string paramstr);
+double ReadTvalstr(std::string timestr, double start, double end, std::string reftime);
+std::vector<double> ReadTRangestr(std::vector<std::string> timestr, double start, double end, std::string reftime);
+double readApproxtimestr(std::string input);
+
 //inline bool fileexists(const std::string& name);
 
 // End of global definition

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -252,73 +252,73 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			log("\t\tWet/dry Instability test : " + result);
 		}
 
-	if (mytest == 12)
-	{
-		/* Test 12 is to test the calendar time to second conversion
-			This test will fail if the system or compiler does not suport long long 
-			 
-		*/
-		bool timetest;
-		timetest = testime1(1) && testime2(2);
-		result = timetest ? "successful" : "failed";
-		log("\t\tCalendar time test : " + result);
-	}
+		if (mytest == 12)
+		{
+			/* Test 12 is to test the calendar time to second conversion
+				This test will fail if the system or compiler does not suport long long
 
-	if (mytest == 13)
-	{
-		/* Test 13 is to test the input of different roughness maps (and different bathymetry at the same time)
-			Test1: 2 DEM and 2 roughness netcdf files are created and saved; then read.
-				The max / min values are check to see if the z/z0 maps are created as expected
-			Test2: A roughness file name is changed to have a number in first position. We check that the 
-				file is read and not the number taken as z0 value.
-			Test3: A roughness is entered as a value, test that it is implemented for the whole domain.
-			Test4 :  Test value input for initial loss / continuous loss
-		*/
-		bool RoughBathyresult, RoughInput, RoughtInputnumber, ILCLInputnumber;
-		log("\t### Different bathy and different roughness file inputs ###");
-		RoughBathyresult = TestMultiBathyRough(0, 0.0, 0);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = RoughBathyresult ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Different Bathy and Roughness test : " + result + "\n");
-		RoughInput = TestMultiBathyRough(0, 0.0, 1);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = RoughInput ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Roughness file name test : " + result + "\n");
-		RoughtInputnumber = TestMultiBathyRough(0, 0.0, 2);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = RoughtInputnumber ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Roughness value input test : " + result + "\n");
-		log("\t\t ##### \n");
-		ILCLInputnumber = TestMultiBathyRough(0, 0.0, 3);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = ILCLInputnumber ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Initial Loss / Continuous Loss value input test : " + result + "\n");
-		log("\t\t ##### \n");
-		isfailed = (!RoughBathyresult || !RoughInput || !RoughtInputnumber || !ILCLInputnumber || isfailed) ? true : false;
-	}
-    
-	if (mytest == 14)
-	{
-		/* Test 14  This test AOI bnds aswall to start with
+			*/
+			bool timetest;
+			timetest = testime1(1) && testime2(2);
+			result = timetest ? "successful" : "failed";
+			log("\t\tCalendar time test : " + result);
+		}
 
-		*/
-		bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
-		log("\t###AOI bnd wall test ###");
-		wallbndleft = TestAIObnd(XParam, XModel, XModel_g, false, false, false);
-		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, false);
-		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, false);
-		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, false);
-		result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
-		log("\t\tBBox bnd wall test : " + result);
-		wallbndleft = TestAIObnd(XParam, XModel, XModel_g, false, false, true);
-		wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, true);
-		wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, true);
-		wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, true);
-		result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
-		log("\t\tAOI bnd wall test : " + result);
-	}
-    
-  if (mytest == 15)
+		if (mytest == 13)
+		{
+			/* Test 13 is to test the input of different roughness maps (and different bathymetry at the same time)
+				Test1: 2 DEM and 2 roughness netcdf files are created and saved; then read.
+					The max / min values are check to see if the z/z0 maps are created as expected
+				Test2: A roughness file name is changed to have a number in first position. We check that the
+					file is read and not the number taken as z0 value.
+				Test3: A roughness is entered as a value, test that it is implemented for the whole domain.
+				Test4 :  Test value input for initial loss / continuous loss
+			*/
+			bool RoughBathyresult, RoughInput, RoughtInputnumber, ILCLInputnumber;
+			log("\t### Different bathy and different roughness file inputs ###");
+			RoughBathyresult = TestMultiBathyRough(0, 0.0, 0);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = RoughBathyresult ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Different Bathy and Roughness test : " + result + "\n");
+			RoughInput = TestMultiBathyRough(0, 0.0, 1);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = RoughInput ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Roughness file name test : " + result + "\n");
+			RoughtInputnumber = TestMultiBathyRough(0, 0.0, 2);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = RoughtInputnumber ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Roughness value input test : " + result + "\n");
+			log("\t\t ##### \n");
+			ILCLInputnumber = TestMultiBathyRough(0, 0.0, 3);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = ILCLInputnumber ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Initial Loss / Continuous Loss value input test : " + result + "\n");
+			log("\t\t ##### \n");
+			isfailed = (!RoughBathyresult || !RoughInput || !RoughtInputnumber || !ILCLInputnumber || isfailed) ? true : false;
+		}
+
+		if (mytest == 14)
+		{
+			/* Test 14  This test AOI bnds aswall to start with
+
+			*/
+			bool wallbndleft, wallbndright, wallbndbot, wallbndtop;
+			log("\t###AOI bnd wall test ###");
+			wallbndleft = TestAIObnd(XParam, XModel, XModel_g, false, false, false);
+			wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, false);
+			wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, false);
+			wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, false);
+			result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
+			log("\t\tBBox bnd wall test : " + result);
+			wallbndleft = TestAIObnd(XParam, XModel, XModel_g, false, false, true);
+			wallbndright = TestAIObnd(XParam, XModel, XModel_g, false, true, true);
+			wallbndbot = TestAIObnd(XParam, XModel, XModel_g, true, false, true);
+			wallbndtop = TestAIObnd(XParam, XModel, XModel_g, true, true, true);
+			result = (wallbndleft & wallbndright & wallbndbot & wallbndtop) ? "successful" : "failed";
+			log("\t\tAOI bnd wall test : " + result);
+		}
+
+		if (mytest == 15)
 			/* Test 15 is to test the input of flexible times outputs (general and in zone_outputs)
 				Test1: Test of times in second/durations (for general and zone_outputs)
 					The data is read from paramfile and we test the reading and nc files created.
@@ -334,7 +334,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			isfailed = (!FlexibleOutTime || isfailed) ? true : false;
 
 		}
-    
+
 		if (mytest == 994)
 		{
 			Testzbinit(XParam, XForcing, XModel, XModel_g);
@@ -352,7 +352,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		{
 			TestGradientSpeed(XParam, XModel, XModel_g);
 		}
-		
+
 		if (mytest == 998)
 		{
 			//
@@ -4624,7 +4624,7 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 		result = false;
 	if (!XParam.Toutput.val[1] == 9.5)
 		result = false;
-	if (!XParam.outzone[2].Toutput.init == 0.0 )
+	if (!XParam.outzone[2].Toutput.init == 0.0)
 		result = false;
 	if (!XParam.outzone[3].Toutput.tstep == 11.0)
 		result = false;
@@ -4636,7 +4636,7 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 		result = false;
 	if (!XModel.blocks.outZone[0].OutputT.size() == 9)
 		result = false;
-	
+
 	return result;
 }
 
@@ -4781,7 +4781,7 @@ template <class T> void Testzbinit(Param XParam, Forcing<float> XForcing, Model<
 }
 
 
-template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel_g, bool bottop,bool flip, bool withaoi)
+template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel_g, bool bottop, bool flip, bool withaoi)
 {
 	Forcing<float> XForcing;
 
@@ -4817,16 +4817,16 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	XParam.aoibnd = 0;
 
 	XParam.outputtimestep = XParam.endtime;
-	
+
 	std::ofstream aoi_file(
 		"testaoi.tmp", std::ios_base::out | std::ios_base::trunc);
 	aoi_file << "5.0 3.0" << std::endl;
 	aoi_file << "27.0 3.0" << std::endl;
-	aoi_file << "27.0 27.0"<< std::endl;
+	aoi_file << "27.0 27.0" << std::endl;
 	aoi_file << "5.0 27.0" << std::endl;
 	aoi_file << "5.0 3.0" << std::endl;
 	aoi_file.close(); //destructor implicitly does it
-	
+
 	/*
 	std::ofstream aoi_file(
 		"testaoi.tmp", std::ios_base::out | std::ios_base::trunc);
@@ -4838,7 +4838,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	aoi_file.close(); //destructor implicitly does it
 	*/
 	if (withaoi)
-	{	
+	{
 		XForcing.AOI.file = "testaoi.tmp";
 		XForcing.AOI.active = true;
 		XForcing.AOI.poly = readPolygon(XForcing.AOI.file);
@@ -4871,7 +4871,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	XParam.Adapt_arg1 = "";
 	XParam.Adapt_arg2 = "";
 	XParam.Adapt_arg3 = "";
-	
+
 	StaticForcingP<int> targetlevel;
 	XForcing.targetadapt.push_back(targetlevel);
 
@@ -4911,7 +4911,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	thisriver.xstart = 10;
 	thisriver.xend = 12;
 	thisriver.ystart = 10;
-	thisriver.yend =12;
+	thisriver.yend = 12;
 
 	XForcing.rivers.push_back(thisriver);
 
@@ -4949,7 +4949,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	MainLoop(XParam, XForcing, XModel, XModel_g);
 
 	T TheoryInput = Q * XParam.endtime;
-	
+
 
 	T SimulatedVolume = T(0.0);
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
@@ -4962,7 +4962,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 			{
 				int i = memloc(XParam, ix, iy, ib);
 				SimulatedVolume = SimulatedVolume + XModel.evolv.h[i] * delta * delta;
-				
+
 			}
 		}
 	}
@@ -4973,7 +4973,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 
 	int modelgood = error / TheoryInput < 0.001;
 
-	printf("\nSim Vol = %f, theory=%f, Error = %f, (%f %%) \n", SimulatedVolume, TheoryInput, error, (error / TheoryInput)*100);
+	printf("\nSim Vol = %f, theory=%f, Error = %f, (%f %%) \n", SimulatedVolume, TheoryInput, error, (error / TheoryInput) * 100);
 
 	//log("#####");
 	return modelgood;

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4544,7 +4544,7 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 
 	// Creation of BG_param_test13.txt file
 	std::ofstream param_file(
-		"BG_param_test14.txt", std::ios_base::out | std::ios_base::trunc);
+		"BG_param_test15.txt", std::ios_base::out | std::ios_base::trunc);
 	//Add Bathymetries to the file
 	param_file << "bathy = Z0_map.nc?z ;" << std::endl;
 
@@ -4556,15 +4556,15 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 	param_file << "smallnc = 0;" << std::endl;
 	param_file << "doubleprecision = 1;" << std::endl;
 	param_file << "Toutput = 1:1:, 8.5,  9.5;" << std::endl;
-	param_file << "outzone = zoom1.nc,0.2,0.6,-0.2,0.2, 2:0.5:5, 5.6,6.9;" << std::endl;
-	param_file << "outzone = zoom2.nc,0.2,0.6,-0.2,0.2, 8:0.7:, 5.6;" << std::endl;
-	param_file << "outzone = zoom3.nc,0.2,0.6,-0.2,0.2, :0.8:2;" << std::endl;
-	param_file << "outzone = zoom4.nc,0.2,0.6,-0.2,0.2, 8::9;" << std::endl;
-	param_file << "outzone = zoom5.nc,0.2,0.6,-0.2,0.2;" << std::endl;
+	param_file << "outzone = Test15_zoom1.nc,0.2,0.6,-0.2,0.2, 2:0.5:5, 5.6,6.9;" << std::endl;
+	param_file << "outzone = Test15_zoom2.nc,0.2,0.6,-0.2,0.2, 8:0.7:, 5.6;" << std::endl;
+	param_file << "outzone = Test15_zoom3.nc,0.2,0.6,-0.2,0.2, :0.8:2;" << std::endl;
+	param_file << "outzone = Test15_zoom4.nc,0.2,0.6,-0.2,0.2, 8::9;" << std::endl;
+	param_file << "outzone = Test15_zoom5.nc,0.2,0.6,-0.2,0.2;" << std::endl;
 	param_file.close();
 
 	//read param file
-	Readparamfile(XParam, XForcing, "BG_param_test14.txt"); // "BG_param_test13.txt");
+	Readparamfile(XParam, XForcing, "BG_param_test15.txt"); // "BG_param_test13.txt");
 
 	//readforcing
 	readforcing(XParam, XForcing);
@@ -4603,28 +4603,6 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 		result = false;
 	if (!XModel.blocks.outZone[0].OutputT.size() == 9)
 		result = false;
-
-	/*//TEST 3: Netcdf files created
-	const std::string ncfilestr;
-	int status;
-	int ncid, ndimshh, ndims;
-	int varid;*/
-
-	//status = nc_open(ncfilestr.c_str(), NC_NOWRITE, &ncid);
-	//if (status != NC_NOERR) handle_ncerror(status);
-	//status = nc_inq_varid(ncid, varstr.c_str(), &varid);
-	//if (status != NC_NOERR)	handle_ncerror(status);
-	//status = nc_inq_varndims(ncid, varid, &ndimshh);
-	//if (status != NC_NOERR) handle_ncerror(status);
-
-
-
-//		eps = 0.0000001;
-		// IL is expected here to be value when dry and 0 where wet at the begining of the computation
-//		if ((abs(maxil - IL) < eps) && (abs(maxcl - CL) < eps) && (abs(minil - T(0.0)) < eps) && (abs(mincl - CL) < eps))
-//		{
-//			result = true;
-//		}
 	
 	return result;
 }

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4618,16 +4618,21 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 
 	//TEST 1: reading and default values check:
 	bool result = true;
-
+	/*
 	if (!XParam.Toutput.end == 11.0)
 		result = false;
 	if (!XParam.Toutput.val[1] == 9.5)
 		result = false;
+	
 	if (!XParam.outzone[2].Toutput.init == 0.0)
 		result = false;
 	if (!XParam.outzone[3].Toutput.tstep == 11.0)
 		result = false;
 	if (!XParam.outzone[4].Toutput.tstep == 1.0)
+		result = false;
+		*/
+
+	if (!XParam.Toutput.val[1] == 9.5)
 		result = false;
 
 	//TEST 2: calculation of the output steps

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -22,6 +22,8 @@
 * Test 11 Wet/dry Instability test with Conserve Elevation
 * Test 12 Calendar time to second conversion
 * Test 13 Multi bathy and roughness map input
+* Test 15 Flexible times reading
+
 
 * Test 99 Run all the test with test number < 99.
 
@@ -292,8 +294,8 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			isfailed = (!RoughBathyresult || !RoughInput || !RoughtInputnumber || !ILCLInputnumber || isfailed) ? true : false;
 
 		}
-		if (mytest == 14)
-			/* Test 14 is to test the input of flexible times outputs (general and in zone_outputs)
+		if (mytest == 15)
+			/* Test 15 is to test the input of flexible times outputs (general and in zone_outputs)
 				Test1: Test of times in second/durations (for general and zone_outputs)
 					The data is read from paramfile and we test the reading and nc files created.
 			*/
@@ -303,7 +305,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			FlexibleOutTime = TestFlexibleOutputTimes(0, 0.0, 0);
 			result = FlexibleOutTime ? "successful" : "failed";
 			log("\t\t ##### \n");
-			log("\t\t ##### Flexible output times test : " + result + "\n");
+			log("\t\t ##### Flexible output times reading test : " + result + "\n");
 			log("\t\t ##### \n");
 			isfailed = (!FlexibleOutTime || isfailed) ? true : false;
 
@@ -4540,50 +4542,16 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 	create2dnc("Z0_map.nc", NX, NY, xz, yz, map, "z");
 
 
-	//Creation of a refinement file
-	//xz = (double*)malloc(sizeof(double) * NX);
-	//yz = (double*)malloc(sizeof(double) * NY);
-	for (int i = 0; i < NX; i++) { xz[i] = -1.0 + 0.1 * i; }
-	for (int j = 0; j < NY; j++) { yz[j] = -1.0 + 0.1 * j; }
-
-	//map = (double*)malloc(sizeof(double) * NY * NX);
-
-	for (int j = 0; j < NY; j++)
-	{
-		for (int i = 0; i < NX; i++)
-		{
-			map[j * NX + i] = 0;
-			if ((abs(xz[i]) < 0.5) && (abs(yz[j]) < 0.5))
-			{
-				map[j * NX + i] = 1;
-			}
-		}
-	}
-	create2dnc("refinement.nc", NX, NY, xz, yz, map, "z");
-
-	/*// Creation of a rain fall file
-	std::ofstream rain_file(
-		"rainTest13.txt", std::ios_base::out | std::ios_base::trunc);
-	rain_file << "0.000000\t10.00" << std::endl;
-	rain_file << "1000.000\t10.00" << std::endl;
-	rain_file.close();*/
-
 	// Creation of BG_param_test13.txt file
 	std::ofstream param_file(
 		"BG_param_test14.txt", std::ios_base::out | std::ios_base::trunc);
 	//Add Bathymetries to the file
 	param_file << "bathy = Z0_map.nc?z ;" << std::endl;
-	//Add refinement to the file
-	param_file << "Adaptation = Targetlevel,refinement.nc?z ;" << std::endl;
-	param_file << "initlevel = 0; " << std::endl;
-	param_file << "maxlevel = 1; " << std::endl;
-	param_file << "minlevel = 0; " << std::endl;
-	//Add River forcing
-	//param_file << "rainfile = rainTest13.txt ;" << std::endl;
+
 	//Add endtime and outputvar
 	param_file << "endtime = 11.0 ;" << std::endl;
 	param_file << "outvars = zs,h,u,v,zb;" << std::endl;
-	param_file << "dx = 0.01;" << std::endl;
+	param_file << "dx = 0.05;" << std::endl;
 	param_file << "zsinit = 0.1;" << std::endl;
 	param_file << "smallnc = 0;" << std::endl;
 	param_file << "doubleprecision = 1;" << std::endl;
@@ -4614,7 +4582,7 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 	// Run first full step (i.e. 2 half steps)
 
 	//Loop<T> XLoop = InitLoop(XParam, XModel);
-	MainLoop(XParam, XForcing, XModel, XModel_g);
+	//MainLoop(XParam, XForcing, XModel, XModel_g);
 
 	//TEST 1: reading and default values check:
 	bool result = true;
@@ -4636,7 +4604,18 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 	if (!XModel.blocks.outZone[0].OutputT.size() == 9)
 		result = false;
 
-	//TEST 3: Netcdf files created
+	/*//TEST 3: Netcdf files created
+	const std::string ncfilestr;
+	int status;
+	int ncid, ndimshh, ndims;
+	int varid;*/
+
+	//status = nc_open(ncfilestr.c_str(), NC_NOWRITE, &ncid);
+	//if (status != NC_NOERR) handle_ncerror(status);
+	//status = nc_inq_varid(ncid, varstr.c_str(), &varid);
+	//if (status != NC_NOERR)	handle_ncerror(status);
+	//status = nc_inq_varndims(ncid, varid, &ndimshh);
+	//if (status != NC_NOERR) handle_ncerror(status);
 
 
 
@@ -4647,7 +4626,6 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 //			result = true;
 //		}
 	
-
 	return result;
 }
 

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4536,7 +4536,6 @@ template <class T> bool TestMultiBathyRough(int gpu, T ref, int scenario)
 * This function creates a case set-up with a param file, read it.
 * It tests the reading and default values used for times outputs.
 * It checks the vectors for time outputs.
-* It then test the nc saving of the user selected good times.
 *
 */
 template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -4582,16 +4582,17 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 
 	//Add endtime and outputvar
 	param_file << "endtime = 11.0 ;" << std::endl;
+	param_file << "reftime = 2020-01-01T00:00:00 ;" << std::endl;
 	param_file << "outvars = zs,h,u,v,zb;" << std::endl;
 	param_file << "dx = 0.05;" << std::endl;
 	param_file << "zsinit = 0.1;" << std::endl;
 	param_file << "smallnc = 0;" << std::endl;
 	param_file << "doubleprecision = 1;" << std::endl;
-	param_file << "Toutput = 1:1:, 8.5,  9.5;" << std::endl;
-	param_file << "outzone = Test15_zoom1.nc,0.2,0.6,-0.2,0.2, 2:0.5:5, 5.6,6.9;" << std::endl;
-	param_file << "outzone = Test15_zoom2.nc,0.2,0.6,-0.2,0.2, 8:0.7:, 5.6;" << std::endl;
-	param_file << "outzone = Test15_zoom3.nc,0.2,0.6,-0.2,0.2, :0.8:2;" << std::endl;
-	param_file << "outzone = Test15_zoom4.nc,0.2,0.6,-0.2,0.2, 8::9;" << std::endl;
+	param_file << "Toutput = 1|2|5, 2020-01-01T00:00:08,  9.5;" << std::endl;
+	param_file << "outzone = Test15_zoom1.nc,0.2,0.6,-0.2,0.2, 2020-01-01T00:00:02|0.008min|2020-01-01T00:00:03, 5.6,6.9;" << std::endl;
+	param_file << "outzone = Test15_zoom2.nc,0.2,0.6,-0.2,0.2, 8.1|0.7|, 5.6;" << std::endl;
+	param_file << "outzone = Test15_zoom3.nc,0.2,0.6,-0.2,0.2, |0.8|2;" << std::endl;
+	param_file << "outzone = Test15_zoom4.nc,0.2,0.6,-0.2,0.2, 8.2||9;" << std::endl; // Here the step in not given so assumed infinite
 	param_file << "outzone = Test15_zoom5.nc,0.2,0.6,-0.2,0.2;" << std::endl;
 	param_file.close();
 
@@ -4617,7 +4618,13 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 	//MainLoop(XParam, XForcing, XModel, XModel_g);
 
 	//TEST 1: reading and default values check:
-	bool result = true;
+	bool result = false;
+
+	if (XModel.OutputT.size()==20)
+	{
+		result = true;
+	}
+
 	/*
 	if (!XParam.Toutput.end == 11.0)
 		result = false;
@@ -4632,14 +4639,7 @@ template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
 		result = false;
 		*/
 
-	if (!XParam.Toutput.val[1] == 9.5)
-		result = false;
-
-	//TEST 2: calculation of the output steps
-	if (!XModel.OutputT.size() == 26)
-		result = false;
-	if (!XModel.blocks.outZone[0].OutputT.size() == 9)
-		result = false;
+	
 
 	return result;
 }

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -85,7 +85,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			log("\t\tCPU test: " + result);
 			isfailed = (!rivertest || isfailed) ? true : false;
 
-			log(" \t\t\t GPU device= " + XParam.GPUDEVICE);
+			log(" \t\t\t GPU device= " + std::to_string(XParam.GPUDEVICE));
 
 			if (XParam.GPUDEVICE >= 0)
 			{
@@ -835,7 +835,7 @@ template <class T> bool Rivertest(T zsnit, int gpu)
 		XLoop.totaltime = XLoop.totaltime + XLoop.dt;
 		//Save2Netcdf(XParam, XLoop, XModel);
 
-		if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.00001) && XParam.outputtimestep > 0.0)
+		if (XLoop.nextoutputtime - XLoop.totaltime <= XLoop.dt * T(0.00001))
 		{
 			if (XParam.GPUDEVICE >= 0)
 			{

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -92,7 +92,7 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 				isfailed = (!rivertest || isfailed) ? true : false;
 			}
 
-			rivertest=RiverVolumeAdapt(XParam, T(0.4));
+			rivertest = RiverVolumeAdapt(XParam, T(0.4));
 			result = rivertest ? "successful" : "failed";
 			log("\t\tRiver Volume Adapt: " + result);
 			isfailed = (!rivertest || isfailed) ? true : false;
@@ -239,59 +239,75 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			result = testrainlossesCPU ? "successful" : "failed";
 			log("\n\n\t IL-CL Rain losses test CPU: " + result);
 			isfailed = (!testrainlossesCPU || !testrainlossesGPU || isfailed) ? true : false;
-    }
-    if (mytest == 11)
-	  {
+		}
+		if (mytest == 11)
+		{
 			bool instab;
 			log("\t### Wet/dry Instability test with Conserve Elevation ###");
-			instab=TestInstability(XParam, XModel, XModel_g);
+			instab = TestInstability(XParam, XModel, XModel_g);
 			result = instab ? "successful" : "failed";
 			log("\t\tWet/dry Instability test : " + result);
 		}
-	if (mytest == 12)
-	{
-		/* Test 12 is to test the calendar time to second conversion
-			This test will fail if the system or compiler does not suport long long 
-			 
-		*/
-		bool timetest;
-		timetest = testime1(1) && testime2(2);
-		result = timetest ? "successful" : "failed";
-		log("\t\tCalendar time test : " + result);
-	}
-	if (mytest == 13)
-	{
-		/* Test 13 is to test the input of different roughness maps (and different bathymetry at the same time)
-			Test1: 2 DEM and 2 roughness netcdf files are created and saved; then read.
-				The max / min values are check to see if the z/z0 maps are created as expected
-			Test2: A roughness file name is changed to have a number in first position. We check that the 
-				file is read and not the number taken as z0 value.
-			Test3: A roughness is entered as a value, test that it is implemented for the whole domain.
-			Test4 :  Test value input for initial loss / continuous loss
-		*/
-		bool RoughBathyresult, RoughInput, RoughtInputnumber, ILCLInputnumber;
-		log("\t### Different bathy and different roughness file inputs ###");
-		RoughBathyresult = TestMultiBathyRough(0, 0.0, 0);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = RoughBathyresult ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Different Bathy and Roughness test : " + result + "\n");
-		RoughInput = TestMultiBathyRough(0, 0.0, 1);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = RoughInput ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Roughness file name test : " + result + "\n");
-		RoughtInputnumber = TestMultiBathyRough(0, 0.0, 2);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = RoughtInputnumber ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Roughness value input test : " + result + "\n");
-		log("\t\t ##### \n");
-		ILCLInputnumber = TestMultiBathyRough(0, 0.0, 3);//&& TestRoughness(XParam, XModel, XModel_g);
-		result = ILCLInputnumber ? "successful" : "failed";
-		log("\t\t ##### \n");
-		log("\t\t ##### Initial Loss / Continuous Loss value input test : " + result + "\n");
-		log("\t\t ##### \n");
-		isfailed = (!RoughBathyresult || !RoughInput || !RoughtInputnumber || !ILCLInputnumber || isfailed) ? true : false;
+		if (mytest == 12)
+		{
+			/* Test 12 is to test the calendar time to second conversion
+				This test will fail if the system or compiler does not suport long long
 
-	}
+			*/
+			bool timetest;
+			timetest = testime1(1) && testime2(2);
+			result = timetest ? "successful" : "failed";
+			log("\t\tCalendar time test : " + result);
+		}
+		if (mytest == 13)
+		{
+			/* Test 13 is to test the input of different roughness maps (and different bathymetry at the same time)
+				Test1: 2 DEM and 2 roughness netcdf files are created and saved; then read.
+					The max / min values are check to see if the z/z0 maps are created as expected
+				Test2: A roughness file name is changed to have a number in first position. We check that the
+					file is read and not the number taken as z0 value.
+				Test3: A roughness is entered as a value, test that it is implemented for the whole domain.
+				Test4 :  Test value input for initial loss / continuous loss
+			*/
+			bool RoughBathyresult, RoughInput, RoughtInputnumber, ILCLInputnumber;
+			log("\t### Different bathy and different roughness file inputs ###");
+			RoughBathyresult = TestMultiBathyRough(0, 0.0, 0);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = RoughBathyresult ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Different Bathy and Roughness test : " + result + "\n");
+			RoughInput = TestMultiBathyRough(0, 0.0, 1);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = RoughInput ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Roughness file name test : " + result + "\n");
+			RoughtInputnumber = TestMultiBathyRough(0, 0.0, 2);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = RoughtInputnumber ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Roughness value input test : " + result + "\n");
+			log("\t\t ##### \n");
+			ILCLInputnumber = TestMultiBathyRough(0, 0.0, 3);//&& TestRoughness(XParam, XModel, XModel_g);
+			result = ILCLInputnumber ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Initial Loss / Continuous Loss value input test : " + result + "\n");
+			log("\t\t ##### \n");
+			isfailed = (!RoughBathyresult || !RoughInput || !RoughtInputnumber || !ILCLInputnumber || isfailed) ? true : false;
+
+		}
+		if (mytest == 14)
+			/* Test 14 is to test the input of flexible times outputs (general and in zone_outputs)
+				Test1: Test of times in second/durations (for general and zone_outputs)
+					The data is read from paramfile and we test the reading and nc files created.
+			*/
+		{
+			bool FlexibleOutTime;
+			log("\t### Tests for flexible time outputs (general and zones outputs) ###");
+			FlexibleOutTime = TestFlexibleOutputTimes(0, 0.0, 0);
+			result = FlexibleOutTime ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Flexible output times test : " + result + "\n");
+			log("\t\t ##### \n");
+			isfailed = (!FlexibleOutTime || isfailed) ? true : false;
+
+		}
 		if (mytest == 994)
 		{
 			Testzbinit(XParam, XForcing, XModel, XModel_g);
@@ -303,12 +319,11 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 		}
 		if (mytest == 996)
 		{
-			TestHaloSpeed(XParam,XModel,XModel_g);
+			TestHaloSpeed(XParam, XModel, XModel_g);
 		}
 		if (mytest == 997)
 		{
 			TestGradientSpeed(XParam, XModel, XModel_g);
-
 		}
 		if (mytest == 998)
 		{
@@ -317,7 +332,6 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			log("\t### CPU vs GPU Test ###");
 			testresults = CPUGPUtest(XParam, XModel, XModel_g);
 			isfailed = (!testresults || isfailed) ? true : false;
-
 			if (testresults)
 			{
 				exit(0);
@@ -571,7 +585,7 @@ template <class T> bool GaussianHumptest(T zsnit, int gpu, bool compare)
 
 				// Theoretical size is 255x255
 				nbx = 256 / 16;
-				
+
 
 				ibx = ftoi(floor(ii / XParam.blkwidth));
 				iby = ftoi(floor(jj / XParam.blkwidth));
@@ -655,7 +669,7 @@ template <class T> bool Rivertest(T zsnit, int gpu)
 	// Enforece GPU/CPU
 	XParam.GPUDEVICE = gpu;
 
-	std::vector<std::string> outv = { "zb","h","zs","u","v","Fqux","Fqvx","Fquy","Fqvy", "Fhu", "Fhv", "dh", "dhu", "dhv", "Su", "Sv","dhdx", "dhdy", "dudx", "dvdx", "dzsdx", "twet", "hUmax", "Umean"};
+	std::vector<std::string> outv = { "zb","h","zs","u","v","Fqux","Fqvx","Fquy","Fqvy", "Fhu", "Fhv", "dh", "dhu", "dhv", "Su", "Sv","dhdx", "dhdy", "dudx", "dvdx", "dzsdx", "twet", "hUmax", "Umean" };
 	XParam.outvars = outv;
 
 	XParam.outmax = true;
@@ -1160,7 +1174,7 @@ template <class T> bool reductiontest(Param XParam, Model<T> XModel, Model<T> XM
 	{
 		char buffer[256]; sprintf(buffer, "%e", abs(reducedt - mininput));
 		std::string str(buffer);
-		log("\t\t CPU test failed! : Expected=" + std::to_string(mininput) + ";  Reduced=" + std::to_string(reducedt)+ ";  error=" +str);
+		log("\t\t CPU test failed! : Expected=" + std::to_string(mininput) + ";  Reduced=" + std::to_string(reducedt) + ";  error=" + str);
 	}
 
 	if (XParam.GPUDEVICE >= 0)
@@ -1504,7 +1518,7 @@ template <class T> T ThackerBathy(T x, T y, T L, T D)
 
 /*! \fn
 * \brief	Simulate the Lake-at-rest in a parabolic bassin
-* 
+*
 * This function creates a parabolic bassin filled to a given level and run the modle for a while and checks that the velocities in the lake remain very small
 * thus verifying the well-balancedness of teh engine and the Lake-at-rest condition.
 *
@@ -1514,11 +1528,11 @@ template <class T> T ThackerBathy(T x, T y, T L, T D)
 * Buttinger-Kreuzhuber, A., Horváth, Z., Noelle, S., Blöschl, G., and Waser, J.: A fast second-order shallow water scheme on two-dimensional
 * structured grids over abrupt topography, Advances in water resources, 127, 89–108, 2019.
 */
-template <class T> bool ThackerLakeAtRest(Param XParam,T zsinit)
+template <class T> bool ThackerLakeAtRest(Param XParam, T zsinit)
 {
 	bool test = true;
 	// Make a Parabolic bathy
-	
+
 	auto modeltype = XParam.doubleprecision < 1 ? float() : double();
 	Model<decltype(modeltype)> XModel; // For CPU pointers
 	Model<decltype(modeltype)> XModel_g; // For GPU pointers
@@ -1574,7 +1588,7 @@ template <class T> bool ThackerLakeAtRest(Param XParam,T zsinit)
 	XParam.zsinit = zsinit;
 	XParam.endtime = 1390.0;
 
-	XParam.outputtimestep = XParam.endtime; 
+	XParam.outputtimestep = XParam.endtime;
 
 	checkparamsanity(XParam, XForcing);
 
@@ -1584,7 +1598,7 @@ template <class T> bool ThackerLakeAtRest(Param XParam,T zsinit)
 
 	InitialAdaptation(XParam, XForcing, XModel);
 
-	
+
 	SetupGPU(XParam, XModel, XForcing, XModel_g);
 
 	MainLoop(XParam, XForcing, XModel, XModel_g);
@@ -1613,7 +1627,7 @@ template <class T> bool ThackerLakeAtRest(Param XParam,T zsinit)
 
 	return test;
 }
-template bool ThackerLakeAtRest<float>(Param XParam,float zsinit);
+template bool ThackerLakeAtRest<float>(Param XParam, float zsinit);
 template bool ThackerLakeAtRest<double>(Param XParam, double zsinit);
 
 
@@ -1627,7 +1641,7 @@ template bool ThackerLakeAtRest<double>(Param XParam, double zsinit);
 * * flow from fine to coarse
 *
 * and account for different flow direction
-* 
+*
 */
 template <class T> bool RiverVolumeAdapt(Param XParam, T maxslope)
 {
@@ -1642,12 +1656,12 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T maxslope)
 	XParam.minlevel = 1;
 	XParam.maxlevel = 1;
 	XParam.initlevel = 1;
-	
-	
-	UnitestA=RiverVolumeAdapt(XParam, maxslope, false, false);
-	UnitestB=RiverVolumeAdapt(XParam, maxslope, true, false);
-	UnitestC=RiverVolumeAdapt(XParam, maxslope, false, true);
-	UnitestD=RiverVolumeAdapt(XParam, maxslope, true, true);
+
+
+	UnitestA = RiverVolumeAdapt(XParam, maxslope, false, false);
+	UnitestB = RiverVolumeAdapt(XParam, maxslope, true, false);
+	UnitestC = RiverVolumeAdapt(XParam, maxslope, false, true);
+	UnitestD = RiverVolumeAdapt(XParam, maxslope, true, true);
 
 	if (UnitestA && UnitestB && UnitestC && UnitestD)
 	{
@@ -1657,7 +1671,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T maxslope)
 	{
 		log("River Volume Conservation Test: Uniform mesh: Failed");
 		details = UnitestA ? "successful" : "failed";
-		log("\t Uniform mesh A :"+ details);
+		log("\t Uniform mesh A :" + details);
 		details = UnitestB ? "successful" : "failed";
 		log("\t Uniform mesh B :" + details);
 		details = UnitestC ? "successful" : "failed";
@@ -1777,11 +1791,11 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 		}
 	}
 
-	
+
 
 	// Overrule whatever is set in the river forcing
 	T Q = T(1.0);
-	
+
 	double upstream = !flip ? 24.0 : 8;
 	double riverx = !bottop ? upstream : center;
 	double rivery = !bottop ? center : upstream;
@@ -1814,7 +1828,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 
 	XParam.dx = XForcing.Bathy[0].dx;
 
-	XParam.zsinit = mintopo+0.5;// Had a small amount of water to avoid a huge first step that would surely break the setup
+	XParam.zsinit = mintopo + 0.5;// Had a small amount of water to avoid a huge first step that would surely break the setup
 	XParam.endtime = 20.0;
 
 	XParam.outputtimestep = XParam.endtime;
@@ -1846,7 +1860,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 
 
 	MainLoop(XParam, XForcing, XModel, XModel_g);
-	
+
 	T TheoryInput = Q * XParam.endtime;
 
 
@@ -1882,7 +1896,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T slope, bool bottop, boo
 * and on all orientations
 *
 */
-template <class T> bool testboundaries(Param XParam,T maxslope)
+template <class T> bool testboundaries(Param XParam, T maxslope)
 {
 	//T maxslope = 0.45; // the mass conservation is better with smaller slopes 
 
@@ -1894,7 +1908,7 @@ template <class T> bool testboundaries(Param XParam,T maxslope)
 	std::string details;
 	int Bound_type;
 
-	
+
 	XParam.GPUDEVICE = 0;
 	maxslope = 0.0;
 	//Dir = 3;
@@ -2001,7 +2015,7 @@ template <class T> bool testboundaries(Param XParam,T maxslope)
 * * flowing to the bottom: Dir=3;
 *
 */
-template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound_type)
+template <class T> bool RiverOnBoundary(Param XParam, T slope, int Dir, int Bound_type)
 {
 	//bool test = true;
 	// Make a Parabolic bathy
@@ -2142,9 +2156,9 @@ template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound
 	// Overrule whatever is set in the river forcing
 	T Q = T(1.0);
 
-	double riverx = (Dir == 0 | Dir == 2)? 6.0 : 25.0; //Dir=1 =>leftward
-	double rivery = (Dir == 2 | Dir == 1)? 6.0 : 25.0; //Dir=2 =>topward
-	
+	double riverx = (Dir == 0 | Dir == 2) ? 6.0 : 25.0; //Dir=1 =>leftward
+	double rivery = (Dir == 2 | Dir == 1) ? 6.0 : 25.0; //Dir=2 =>topward
+
 	//Create a temporary file with river fluxes
 	std::ofstream river_file(
 		"testriver.tmp", std::ios_base::out | std::ios_base::trunc);
@@ -2243,7 +2257,7 @@ template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound
 
 	printf("error : %f \n", error);
 	printf("Theory input : %f \n", TheoryInput);
-	printf("return : %f \n", (error/TheoryInput));
+	printf("return : %f \n", (error / TheoryInput));
 
 
 	return error / TheoryInput < 0.01;
@@ -2273,7 +2287,7 @@ template <class T> bool LakeAtRest(Param XParam, Model<T> XModel)
 
 	refine_linear(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 	gradientHalo(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
-	
+
 
 
 
@@ -2348,13 +2362,13 @@ template <class T> bool LakeAtRest(Param XParam, Model<T> XModel)
 
 					printf("Fhu[i]=%f\n", XModel.flux.Fhu[i]);
 
-					printf("Fqux[i]=%f; Su[iright]=%f; Diff=%f \n",XModel.flux.Fqux[i], XModel.flux.Su[iright], (XModel.flux.Fqux[i] - XModel.flux.Su[iright]));
+					printf("Fqux[i]=%f; Su[iright]=%f; Diff=%f \n", XModel.flux.Fqux[i], XModel.flux.Su[iright], (XModel.flux.Fqux[i] - XModel.flux.Su[iright]));
 
-					printf(" At i: (ib=%d; ix=%d; iy=%d)\n", ib,ix,iy);
+					printf(" At i: (ib=%d; ix=%d; iy=%d)\n", ib, ix, iy);
 					testButtingerX(XParam, ib, ix, iy, XModel);
 
-					printf(" At iright: (ib=%d; ix=%d; iy=%d)\n", ib, ix+1, iy);
-					testButtingerX(XParam, ib, ix+1, iy, XModel);
+					printf(" At iright: (ib=%d; ix=%d; iy=%d)\n", ib, ix + 1, iy);
+					testButtingerX(XParam, ib, ix + 1, iy, XModel);
 
 				}
 
@@ -2426,7 +2440,7 @@ template <class T> void testButtingerX(Param XParam, int ib, int ix, int iy, Mod
 	levLB = XModel.blocks.level[LB];
 	RBLB = XModel.blocks.RightBot[LB];
 
-	
+
 	T cm = T(1.0);
 	T fmu = T(1.0);
 
@@ -2506,7 +2520,7 @@ template <class T> void testButtingerX(Param XParam, int ib, int ix, int iy, Mod
 		dt = hllc(g, delta, epsi, CFL, cm, fmu, hCNl, hCNr, ul, ur, fh, fu);
 		//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
 
-		
+
 
 		fv = (fh > 0. ? vl : vr) * fh;
 
@@ -2535,7 +2549,7 @@ template <class T> void testButtingerX(Param XParam, int ib, int ix, int iy, Mod
 		sr = ga * (hCNl + hn) * (zn - zCN);
 
 
-		printf("dt=%f; etar=%f; etal=%f; zCN=%f; zi=%f; zn=%f; zA=%f, zr=%f, zl=%f\n",dt, etar,etal,zCN,zi,zn,zA, zr,zl);
+		printf("dt=%f; etar=%f; etal=%f; zCN=%f; zi=%f; zn=%f; zA=%f, zr=%f, zl=%f\n", dt, etar, etal, zCN, zi, zn, zA, zr, zl);
 
 
 		printf("hi=%f; hn=%f,fh=%f; fu=%f; sl=%f; sr=%f; hCNl=%f; hCNr=%f; hr=%f; hl=%f; zr=%f; zl=%f;\n", hi, hn, fh, fu, sl, sr, hCNl, hCNr, hr, hl, zr, zl);
@@ -2785,7 +2799,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 
 	MainLoop(XParam, XForcing, XModel, XModel_g);
 
-	TheoryInput = Q/ T(1000.0) / T(3600.0) * XParam.endtime;
+	TheoryInput = Q / T(1000.0) / T(3600.0) * XParam.endtime;
 
 
 	T SimulatedVolume = T(0.0);
@@ -2807,7 +2821,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 
 	T error = abs(SimulatedVolume - TheoryInput);
 
-	T modelgood= error / TheoryInput < 0.05;
+	T modelgood = error / TheoryInput < 0.05;
 
 	//log("#####");
 	return modelgood;
@@ -2819,7 +2833,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 * This function tests the different inputs for rain forcing.
 * This test is based on the paper Aureli2020, the 3 slopes test
 * with regional rain. The experiment has been presented in Iwagaki1955.
-* The first test compares a time varying rain input using a uniform time serie 
+* The first test compares a time varying rain input using a uniform time serie
 * forcing and a time varying 2D field (with same value).
 * The second test check the 3D rain forcing (comparing it to expected values).
 */
@@ -2831,8 +2845,8 @@ bool Raintestinput(int gpu)
 	//int dim_flux;
 	std::vector<float> Flux1D, Flux3DUni, Flux3D, Flux_obs;
 	float diff, ref, error;
-	
-	
+
+
 	//Comparison between the 1D forcing and the 3D hommgeneous forcing
 	Flux1D = Raintestmap(gpu, 1, -0.03);
 	Flux3DUni = Raintestmap(gpu, 31, -0.03);
@@ -2897,7 +2911,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 	double* yRain;
 	double* tRain;
 	double* rainForcing;
-	
+
 
 	Param XParam;
 	T delta;
@@ -2906,7 +2920,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 	XParam.xo = 0;
 	XParam.yo = 0;
 	XParam.ymax = 0.196;
-	XParam.dx=(XParam.ymax - XParam.yo) / (1 << 1);
+	XParam.dx = (XParam.ymax - XParam.yo) / (1 << 1);
 	XParam.delta = XParam.dx;
 	double Xmax_exp = 28.0; //minimum Xmax position (adjust to have a "full blocks" config)
 	//Calculating xmax to have full blocs with at least a full block behaving as a reservoir
@@ -3050,7 +3064,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 				{
 					for (int i = 0; i < NX; i++)
 					{
-						if (tRain[k] < rainDuration+eps)
+						if (tRain[k] < rainDuration + eps)
 						{
 							if (xRain[i] < 8.0)
 							{
@@ -3110,10 +3124,10 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 		}
 		/*
 		//2D forcing (map without time variation is not working)
-		else if (dimf == 2)//dimf==2 for rain forcing 
+		else if (dimf == 2)//dimf==2 for rain forcing
 		{
 
-			//Create a non-uniform time-constant rain forcing 
+			//Create a non-uniform time-constant rain forcing
 			rainForcing = (double*)malloc(sizeof(double) * NY * NX);
 
 			//Create the rain forcing:
@@ -3156,7 +3170,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 		XForcing.Rain = readfileinfo("rainTemp.nc", XForcing.Rain);
 		XForcing.Rain.uniform = 0;
 		XForcing.Rain.varname = "myrainforcing";
-		
+
 
 		InitDynforcing(gpgpu, XParam, XForcing.Rain);
 
@@ -3246,7 +3260,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 			}
 
 			Save2Netcdf(XParam, XLoop, XModel);
-			
+
 
 			//Calculation of the flux at the bottom of the slope (x=24m)
 			ib = XModel.blocks.active[bl];
@@ -3257,7 +3271,7 @@ template <class T> std::vector<float> Raintestmap(int gpu, int dimf, T zinit)
 				int n = memloc(XParam, ixx, iy, ib);
 				finalFlux = finalFlux + XModel.evolv.h[n] * XModel.evolv.u[n] * delta;
 			}
-			finalFlux = finalFlux / float(XParam.ymax - XParam.yo)*100.0f*100.0f;
+			finalFlux = finalFlux / float(XParam.ymax - XParam.yo) * 100.0f * 100.0f;
 			Flux.push_back(finalFlux);
 			XLoop.nextoutputtime = XLoop.nextoutputtime + XParam.outputtimestep;
 			printf("\tTime = %f, Flux at bottom end of slope : %f \n", XLoop.totaltime, finalFlux);
@@ -3286,10 +3300,10 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 	log("#####");
 
 	Param XParam;
-	Forcing<float> XForcing; 
+	Forcing<float> XForcing;
 
-	
-	if (nzones  == 3)
+
+	if (nzones == 3)
 	{
 		// read param file
 		//readforcing(XParam, XForcing);
@@ -3301,8 +3315,8 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 		zone.yend = 10;
 		XParam.outzone.push_back(zone);
 		zone.outname = "zoomed.nc";
-		zone.xstart =1;
-		zone.xend =2;
+		zone.xstart = 1;
+		zone.xend = 2;
 		zone.ystart = -2;
 		zone.yend = 2;
 		XParam.outzone.push_back(zone);
@@ -3367,7 +3381,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
 
 	AllocateCPU(XForcing.Bathy[0].nx, XForcing.Bathy[0].ny, XForcing.Bathy[0].val);
-	
+
 	float rs, x, y, r, hm;
 	rs = 20; //hill radio 
 	hm = 5; //hill top
@@ -3380,7 +3394,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 			r = sqrt(x * x + y * y);
 			if (r < rs)
 			{
-				XForcing.Bathy[0].val[i + j * XForcing.Bathy[0].nx] = hm*(1-r/rs);
+				XForcing.Bathy[0].val[i + j * XForcing.Bathy[0].nx] = hm * (1 - r / rs);
 			}
 			if (x < -4.7 | x > 4.7 | y < -4.7 | y > 4.7)
 			{
@@ -3391,7 +3405,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 
 	//Adaptation
 	XParam.AdaptCrit = "Targetlevel";
-	
+
 	StaticForcingP<int> Target;
 	XForcing.targetadapt.push_back(Target);
 
@@ -3476,7 +3490,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 	for (int o = 0; o < XModel.blocks.outZone.size(); o++)
 	{
 		std::ifstream fs(XModel.blocks.outZone[o].outname);
-		if (fs.fail()) 
+		if (fs.fail())
 		{
 			error++;
 		}
@@ -3491,7 +3505,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit)
 		}
 	}
 
-	bool modelgood = (1-abs(error)) < 0.05;
+	bool modelgood = (1 - abs(error)) < 0.05;
 
 	//log("#####");
 	return modelgood;
@@ -3516,7 +3530,7 @@ template <class T> bool Rainlossestest(T zsinit, int gpu, float alpha)
 	double* yLoss;
 	double* ilForcing;
 	double* clForcing;
-	
+
 	log("#####");
 	Param XParam;
 	T initVol, TheoryInput;
@@ -3579,7 +3593,7 @@ template <class T> bool Rainlossestest(T zsinit, int gpu, float alpha)
 
 	AllocateCPU(XForcing.Bathy[0].nx, XForcing.Bathy[0].ny, XForcing.Bathy[0].val);
 
-	
+
 	for (int j = 0; j < XForcing.Bathy[0].ny; j++)
 	{
 		for (int i = 0; i < XForcing.Bathy[0].nx; i++)
@@ -3587,7 +3601,7 @@ template <class T> bool Rainlossestest(T zsinit, int gpu, float alpha)
 			XForcing.Bathy[0].val[i + j * XForcing.Bathy[0].nx] = T(0.0);
 		}
 	}
-	
+
 
 	// Add wall boundary conditions
 	XForcing.right.type = 0;
@@ -3654,7 +3668,7 @@ template <class T> bool Rainlossestest(T zsinit, int gpu, float alpha)
 	}
 
 	XForcing.il = readfileinfo("ilrainlossTempt.nc", XForcing.il);
-    XForcing.il.varname = "initialloss";
+	XForcing.il.varname = "initialloss";
 	XForcing.cl = readfileinfo("clrainlossTempt.nc", XForcing.cl);
 	XForcing.cl.varname = "continuousloss";
 	readstaticforcing(XForcing.il);
@@ -3667,7 +3681,7 @@ template <class T> bool Rainlossestest(T zsinit, int gpu, float alpha)
 
 	//XParam.infiltration = false;
 
-    //// General code
+	//// General code
 	checkparamsanity(XParam, XForcing);
 	//printf("h: %f \n", XModel.evolv.h[10]);
 	InitMesh(XParam, XForcing, XModel);
@@ -3744,7 +3758,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 	dim3 gridDim(XParam.nblk, 1, 1);
 
 	// for flux reconstruction the loop overlap the right(or top for the y direction) halo
-	dim3 blockDimX2(XParam.blkwidth + XParam.halowidth*2, XParam.blkwidth + XParam.halowidth * 2, 1);
+	dim3 blockDimX2(XParam.blkwidth + XParam.halowidth * 2, XParam.blkwidth + XParam.halowidth * 2, 1);
 
 
 
@@ -3774,7 +3788,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 
 	cudaEventCreate(&startA);
 
-	
+
 	cudaEventCreate(&stopA);
 
 	// Record the start event
@@ -3841,7 +3855,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 	cudaEventDestroy(stopC);
 
 
-	
+
 
 	CopyGPUtoCPU(XParam.nblkmem, XParam.blksize, XModel.grad.dudx, XModel_g.grad.dzbdx);
 	CopyGPUtoCPU(XParam.nblkmem, XParam.blksize, XModel.grad.dudy, XModel_g.grad.dzbdy);
@@ -3865,7 +3879,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 	}
 
 	diffArray(XParam, XLoop, XModel.blocks, "SMdx", false, XModel.grad.dzbdx, XModel_g.grad.dzsdx, XModel.time.arrmax, XModel.grad.dzsdx);
-	
+
 
 	diffArray(XParam, XLoop, XModel.blocks, "SMBdx", false, XModel.grad.dzbdx, XModel_g.grad.dhdx, XModel.time.arrmax, XModel.grad.dhdx);
 
@@ -3883,7 +3897,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 	maxdiffsmby = T(0.0);
 	T diffsm, diffsmb;
 
-	
+
 
 	for (int ibl = 0; ibl < XParam.nblk; ibl++)
 	{
@@ -3903,7 +3917,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 				maxdiffx = max(maxdiffx, diffsm);
 
 				diffsm = abs(XModel.grad.dzbdx[i] - XModel.grad.dzsdx[i]);
-				
+
 				maxdiffsmx = max(maxdiffsmx, diffsm);
 
 				diffsm = abs(XModel.grad.dzbdy[i] - XModel.grad.dzsdy[i]);
@@ -3913,14 +3927,14 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 				diffsm = abs(XModel.grad.dzbdx[i] - XModel.grad.dhdx[i]);
 				maxdiffsmbx = max(maxdiffsmbx, diffsm);
 
-				diffsm =  abs(XModel.grad.dzbdy[i] - XModel.grad.dhdy[i]);
+				diffsm = abs(XModel.grad.dzbdy[i] - XModel.grad.dhdy[i]);
 				maxdiffsmby = max(maxdiffsmby, diffsm);
 				//
 			}
 		}
 	}
 
-	
+
 	printf("max error : normx=%e, normy=%e, smx=%e, smy=%e,  smbx=%e, smby=%e in m\n", maxdiffx, maxdiffy, maxdiffsmx, maxdiffsmy, maxdiffsmbx, maxdiffsmby);
 
 
@@ -3977,7 +3991,7 @@ template <class T> int TestGradientSpeed(Param XParam, Model<T> XModel, Model<T>
 	CompareCPUvsGPU(XParam, XModel, XModel_g, { "dhdx","dhdy", "dzsdx","dzsdy","dudx","dudy","dvdx","dvdy" }, true);
 
 	printf("Runtime : old gradient=%f, new Gradient=%f in msec\n", msecTotalG, msecTotalGnew);
-	
+
 	return fastest;
 
 }
@@ -4039,7 +4053,7 @@ template <class T> bool TestHaloSpeed(Param XParam, Model<T> XModel, Model<T> XM
 
 	SetupGPU(XParam, XModel, XForcing, XModel_g);
 
-	
+
 
 
 	// Copy zs from CPU to GPU ... again
@@ -4155,7 +4169,7 @@ template <class T> int TestInstability(Param XParam, Model<T> XModel, Model<T> X
 	// Run first full step (i.e. 2 half steps)
 
 	Loop<T> XLoop = InitLoop(XParam, XModel);
-	
+
 	//FlowCPU(XParam, XLoop, XForcing, XModel);
 	HalfStepCPU(XParam, XLoop, XForcing, XModel);
 
@@ -4201,7 +4215,7 @@ template <class T> int TestInstability(Param XParam, Model<T> XModel, Model<T> X
 
 
 //TestMultiBathyRough(int gpu, T ref, int scenario)
-/*! \fn 
+/*! \fn
 *
 * This function creates bathy and roughtness files and tests their reading (and interpolation)
 * The objectif is particularly to test multi bathy/roughness inputs and value/file input.
@@ -4245,7 +4259,7 @@ template <class T> bool TestMultiBathyRough(int gpu, T ref, int scenario)
 		}
 	}
 	create2dnc("Z0_map.nc", NX, NY, xz, yz, map, "z");
-	
+
 	//Creation of a smaller Bathy file
 
 	//xz = (double*)malloc(sizeof(double) * NX);
@@ -4382,7 +4396,7 @@ template <class T> bool TestMultiBathyRough(int gpu, T ref, int scenario)
 	Readparamfile(XParam, XForcing, "BG_param_test13.txt"); // "BG_param_test13.txt");
 
 	//readforcing
-    readforcing(XParam, XForcing);
+	readforcing(XParam, XForcing);
 
 	checkparamsanity(XParam, XForcing);
 
@@ -4401,10 +4415,10 @@ template <class T> bool TestMultiBathyRough(int gpu, T ref, int scenario)
 
 	//if XModel.cf[0]
 	//	XModel.zb
-	
-	T maxz = T(-1.0)*std::numeric_limits<float>::max();
+
+	T maxz = T(-1.0) * std::numeric_limits<float>::max();
 	T minz = std::numeric_limits<float>::max();
-	T maxr = T(-1.0)*std::numeric_limits<float>::max();
+	T maxr = T(-1.0) * std::numeric_limits<float>::max();
 	T minr = std::numeric_limits<float>::max();
 
 
@@ -4430,7 +4444,7 @@ template <class T> bool TestMultiBathyRough(int gpu, T ref, int scenario)
 	bool result = false;
 	eps = 0.0000001;
 
-	if ((abs(maxz - Z1)<eps) && (abs(maxr - R1)<eps) && (abs(minz - Z0)<eps) && (abs(minr - R0)<eps))
+	if ((abs(maxz - Z1) < eps) && (abs(maxr - R1) < eps) && (abs(minz - Z0) < eps) && (abs(minr - R0) < eps))
 	{
 		result = true;
 	}
@@ -4475,15 +4489,176 @@ template <class T> bool TestMultiBathyRough(int gpu, T ref, int scenario)
 			result = true;
 		}
 	}
-	
+
 	return result;
 }
 
 
 
+//TestFlexibleOutputTimes(int gpu, T ref, int scenario)
+/*! \fn
+*
+* This function creates a case set-up with a param file, read it.
+* It tests the reading and default values used for times outputs.
+* It checks the vectors for time outputs.
+* It then test the nc saving of the user selected good times.
+*
+*/
+template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario)
+{
+	T Z0 = ref + 0.0;
+	T Z1 = ref + 2.0;
+	T eps;
+	int NX = 21;
+	int NY = 21;
+	double* xz;
+	double* yz;
+	double* map;
+	Param XParam;
+	Forcing<float> XForcing;
+	Model<float> XModel;
+	Model<float> XModel_g;
+	char* name_file_R1;
+
+
+	//Creation of a Bathy file
+
+	xz = (double*)malloc(sizeof(double) * NX);
+	yz = (double*)malloc(sizeof(double) * NY);
+	for (int i = 0; i < NX; i++) { xz[i] = -1.0 + 0.1 * i; }
+	for (int j = 0; j < NY; j++) { yz[j] = -1.0 + 0.1 * j; }
+
+	map = (double*)malloc(sizeof(double) * NY * NX);
+
+	for (int j = 0; j < NY; j++)
+	{
+		for (int i = 0; i < NX; i++)
+		{
+			map[j * NX + i] = Z0; //+ (yz[j] + 1) * 0.5;
+		}
+	}
+	create2dnc("Z0_map.nc", NX, NY, xz, yz, map, "z");
+
+
+	//Creation of a refinement file
+	//xz = (double*)malloc(sizeof(double) * NX);
+	//yz = (double*)malloc(sizeof(double) * NY);
+	for (int i = 0; i < NX; i++) { xz[i] = -1.0 + 0.1 * i; }
+	for (int j = 0; j < NY; j++) { yz[j] = -1.0 + 0.1 * j; }
+
+	//map = (double*)malloc(sizeof(double) * NY * NX);
+
+	for (int j = 0; j < NY; j++)
+	{
+		for (int i = 0; i < NX; i++)
+		{
+			map[j * NX + i] = 0;
+			if ((abs(xz[i]) < 0.5) && (abs(yz[j]) < 0.5))
+			{
+				map[j * NX + i] = 1;
+			}
+		}
+	}
+	create2dnc("refinement.nc", NX, NY, xz, yz, map, "z");
+
+	/*// Creation of a rain fall file
+	std::ofstream rain_file(
+		"rainTest13.txt", std::ios_base::out | std::ios_base::trunc);
+	rain_file << "0.000000\t10.00" << std::endl;
+	rain_file << "1000.000\t10.00" << std::endl;
+	rain_file.close();*/
+
+	// Creation of BG_param_test13.txt file
+	std::ofstream param_file(
+		"BG_param_test14.txt", std::ios_base::out | std::ios_base::trunc);
+	//Add Bathymetries to the file
+	param_file << "bathy = Z0_map.nc?z ;" << std::endl;
+	//Add refinement to the file
+	param_file << "Adaptation = Targetlevel,refinement.nc?z ;" << std::endl;
+	param_file << "initlevel = 0; " << std::endl;
+	param_file << "maxlevel = 1; " << std::endl;
+	param_file << "minlevel = 0; " << std::endl;
+	//Add River forcing
+	//param_file << "rainfile = rainTest13.txt ;" << std::endl;
+	//Add endtime and outputvar
+	param_file << "endtime = 11.0 ;" << std::endl;
+	param_file << "outvars = zs,h,u,v,zb;" << std::endl;
+	param_file << "dx = 0.01;" << std::endl;
+	param_file << "zsinit = 0.1;" << std::endl;
+	param_file << "smallnc = 0;" << std::endl;
+	param_file << "doubleprecision = 1;" << std::endl;
+	param_file << "Toutput = 1:1:, 8.5,  9.5;" << std::endl;
+	param_file << "outzone = zoom1.nc,0.2,0.6,-0.2,0.2, 2:0.5:5, 5.6,6.9;" << std::endl;
+	param_file << "outzone = zoom2.nc,0.2,0.6,-0.2,0.2, 8:0.7:, 5.6;" << std::endl;
+	param_file << "outzone = zoom3.nc,0.2,0.6,-0.2,0.2, :0.8:2;" << std::endl;
+	param_file << "outzone = zoom4.nc,0.2,0.6,-0.2,0.2, 8::9;" << std::endl;
+	param_file << "outzone = zoom5.nc,0.2,0.6,-0.2,0.2;" << std::endl;
+	param_file.close();
+
+	//read param file
+	Readparamfile(XParam, XForcing, "BG_param_test14.txt"); // "BG_param_test13.txt");
+
+	//readforcing
+	readforcing(XParam, XForcing);
+
+	checkparamsanity(XParam, XForcing);
+
+	InitMesh(XParam, XForcing, XModel);
+
+	InitialConditions(XParam, XForcing, XModel);
+
+	InitialAdaptation(XParam, XForcing, XModel);
+
+	SetupGPU(XParam, XModel, XForcing, XModel_g);
+
+	// Run first full step (i.e. 2 half steps)
+
+	//Loop<T> XLoop = InitLoop(XParam, XModel);
+	MainLoop(XParam, XForcing, XModel, XModel_g);
+
+	//TEST 1: reading and default values check:
+	bool result = true;
+
+	if (!XParam.Toutput.end == 11.0)
+		result = false;
+	if (!XParam.Toutput.val[1] == 9.5)
+		result = false;
+	if (!XParam.outzone[2].Toutput.init == 0.0 )
+		result = false;
+	if (!XParam.outzone[3].Toutput.tstep == 11.0)
+		result = false;
+	if (!XParam.outzone[4].Toutput.tstep == 1.0)
+		result = false;
+
+	//TEST 2: calculation of the output steps
+	if (!XModel.OutputT.size() == 26)
+		result = false;
+	if (!XModel.blocks.outZone[0].OutputT.size() == 9)
+		result = false;
+
+	//TEST 3: Netcdf files created
+
+
+
+//		eps = 0.0000001;
+		// IL is expected here to be value when dry and 0 where wet at the begining of the computation
+//		if ((abs(maxil - IL) < eps) && (abs(maxcl - CL) < eps) && (abs(minil - T(0.0)) < eps) && (abs(mincl - CL) < eps))
+//		{
+//			result = true;
+//		}
+	
+
+	return result;
+}
+
+
+
+
+
+
 template <class T> void TestFirsthalfstep(Param XParam, Forcing<float> XForcing, Model<T> XModel, Model<T> XModel_g)
 {
-	
+
 	// Setup Model(s)
 
 	XParam.outvars = { "zb","h","zs","u","v","Fqux","Fqvx","Fquy","Fqvy", "Fhu", "Fhv", "dh", "dhu", "dhv", "Su", "Sv","dhdx", "dhdy", "dzsdx", "dzsdy", "dzbdx", "dzbdy" };
@@ -4539,7 +4714,7 @@ template <class T> void TestFirsthalfstep(Param XParam, Forcing<float> XForcing,
 	bool test = false;
 
 	//test = true;
-	
+
 	InitSave2Netcdf(XParam, XModel);
 
 }
@@ -4566,14 +4741,14 @@ template <class T> void Testzbinit(Param XParam, Forcing<float> XForcing, Model<
 
 	Loop<T> XLoop = InitLoop(XParam, XModel);
 
-	
+
 	//FlowCPU(XParam, XLoop, XForcing, XModel);
 	//HalfStepCPU(XParam, XLoop, XForcing, XModel);
 	if (XParam.conserveElevation)
 	{
 		refine_linear(XParam, XModel.blocks, XModel.zb, XModel.grad.dzbdx, XModel.grad.dzbdy);
 	}
-	
+
 	//HalfStepGPU(XParam, XLoop, XForcing, XModel_g);
 
 	if (XParam.conserveElevation)
@@ -4612,7 +4787,7 @@ template <class T> void Testzbinit(Param XParam, Forcing<float> XForcing, Model<
 
 	//InitSave2Netcdf(XParam, XModel);
 
-	
+
 
 }
 
@@ -4760,7 +4935,7 @@ void alloc_init2Darray(float** arr, int NX, int NY)
 }
 
 /*! \fn void init3Darray(float*** arr, int rows, int cols, int depths)
-* This function fill a 3D array with zero values 
+* This function fill a 3D array with zero values
 *
 *
 */
@@ -4780,7 +4955,7 @@ void init3Darray(float*** arr, int rows, int cols, int depths)
 /*! \fn void fillrandom(Param XParam, BlockP<T> XBlock, T* z)
 * This function fill an array with random values (0 - 1)
 *
-* 
+*
 */
 template <class T> void fillrandom(Param XParam, BlockP<T> XBlock, T* z)
 {
@@ -4804,7 +4979,7 @@ template void fillrandom<double>(Param XParam, BlockP<double> XBlock, double* z)
 
 /*! \fn void fillgauss(Param XParam, BlockP<T> XBlock, T amp, T* z)
 * This function fill an array with a gaussian bump
-* 
+*
 * borrowed/adapted from Basilisk test (?)
 */
 template <class T> void fillgauss(Param XParam, BlockP<T> XBlock, T amp, T* z)
@@ -4986,7 +5161,7 @@ template void copyBlockinfo2var<double>(Param XParam, BlockP<double> XBlock, int
 * This function compares the Valiables in a CPU model and a GPU models
 * This function is quite useful when checking both are identical enough
 * one needs to provide a list (vector<string>) of variable to check
-* 
+*
 */
 template <class T> void CompareCPUvsGPU(Param XParam, Model<T> XModel, Model<T> XModel_g, std::vector<std::string> varlist, bool checkhalo)
 {
@@ -5085,7 +5260,7 @@ template <class T> void diffdh(Param XParam, BlockP<T> XBlock, T* input, T* outp
 }
 
 /*! \fn void diffSource(Param XParam, BlockP<T> XBlock, T* Fqux, T* Su, T* output)
-* This function Calculate The source term of the equation. 
+* This function Calculate The source term of the equation.
 * This function is quite useful when checking for Lake-at-Rest states
 * This function requires an outputCPU pointers to save the result of teh calculation
 */

--- a/src/Testing.h
+++ b/src/Testing.h
@@ -41,6 +41,7 @@ template <class T> bool testboundaries(Param XParam, T maxslope);
 template <class T> bool ZoneOutputTest(int nzones, T zsinit);
 template <class T> bool Rainlossestest(T zsnit, int gpu, float alpha);
 template <class T> bool TestMultiBathyRough(int gpu, T ref, int secnario);
+template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario);
 
 // End of global definition
 #endif

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -1499,7 +1499,7 @@ template void InitSave2Netcdf<float>(Param& XParam, Model<float>& XModel);
 template void InitSave2Netcdf<double>(Param& XParam, Model<double>& XModel);
 
 //Save initialisation in maps outpout if require
-template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XModel)
+/*template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XModel)
 {
 	double NextZoneOutTime;
 
@@ -1527,7 +1527,7 @@ template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XMode
 }
 template void SaveInitialisation2Netcdf<float>(Param& XParam, Model<float>& XModel);
 template void SaveInitialisation2Netcdf<double>(Param& XParam, Model<double>& XModel);
-
+*/
 
 template <class T> void Save2Netcdf(Param XParam, Loop<T> XLoop, Model<T>& XModel)
 {

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -320,7 +320,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 	AllocateCPU(1, nblk, blkwidth);
 	AllocateCPU(1, nblk, blkid);
 
-	printf("blockId:\n");
+	//printf("blockId:\n");
 	for (int ib = 0; ib < nblk; ib++)
 	{
 		//int ibl = activeblk[Xzone.blk[ib]];
@@ -940,6 +940,12 @@ template void InitSave2Netcdf<double>(Param &XParam, Model<double> &XModel);
 template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T>& XModel)
 {
 	double NextZoneOutTime;
+
+	char buffer[256];
+	sprintf(buffer, "%e", XParam.outputtimestep / XLoop.nstepout);
+	std::string str(buffer);
+	//std::string maps;
+
 	if (!XParam.outvars.empty())
 	{
 		//creatncfileBUQ(XParam);
@@ -948,6 +954,10 @@ template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T>& XModel
 			NextZoneOutTime = XModel.blocks.outZone[o].OutputT[XModel.blocks.outZone[o].index_next_OutputT];
 			if (XLoop.nextoutputtime == NextZoneOutTime)
 			{
+				//maps +=  + ", ";
+				log("Output to map: " + XModel.blocks.outZone[o].outname + ", Totaltime = " + std::to_string(XLoop.totaltime) + " s; Mean dt = " + str + " s");
+
+
 				writenctimestep(XModel.blocks.outZone[o].outname, XLoop.totaltime);
 				for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
 				{
@@ -957,6 +967,7 @@ template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T>& XModel
 			}
 		}
 	}
+	//maps.erase(maps.size() - 2);
 }
 template void Save2Netcdf<float>(Param XParam, Loop<float> XLoop, Model<float>& XModel);
 template void Save2Netcdf<double>(Param XParam, Loop<double> XLoop, Model<double>& XModel);

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -922,7 +922,7 @@ template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 		log("Create netCDF output file...");
 		creatncfileBUQ(XParam, XModel.blocks);
 		//creatncfileBUQ(XParam);
-		for (int o = 0; o < XModel.blocks.outZone.size(); o++)
+		/*for (int o = 0; o < XModel.blocks.outZone.size(); o++)
 		{
 			writenctimestep(XModel.blocks.outZone[o].outname, XParam.totaltime);
 			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
@@ -930,30 +930,36 @@ template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 				std::string varstr = XParam.outvars[ivar];
 				defncvarBUQ(XParam, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, varstr,XModel.Outvarlongname[varstr],XModel.Outvarstdname[varstr],XModel.Outvarunits[varstr], 3, XModel.OutputVarMap[varstr], XModel.blocks.outZone[o]);
 			}
-		}
+		}*/
 	}
 }
 template void InitSave2Netcdf<float>(Param &XParam, Model<float> &XModel);
 template void InitSave2Netcdf<double>(Param &XParam, Model<double> &XModel);
 
 
-template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T> XModel)
+template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T>& XModel)
 {
+	double NextZoneOutTime;
 	if (!XParam.outvars.empty())
 	{
 		//creatncfileBUQ(XParam);
 		for (int o = 0; o < XModel.blocks.outZone.size(); o++)
 		{
-			writenctimestep(XModel.blocks.outZone[o].outname, XLoop.totaltime);
-			for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
+			NextZoneOutTime = XModel.blocks.outZone[o].OutputT[XModel.blocks.outZone[o].index_next_OutputT];
+			if (XLoop.nextoutputtime == NextZoneOutTime)
 			{
-				writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				writenctimestep(XModel.blocks.outZone[o].outname, XLoop.totaltime);
+				for (int ivar = 0; ivar < XParam.outvars.size(); ivar++)
+				{
+					writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+				}
+				XModel.blocks.outZone[o].index_next_OutputT++;
 			}
 		}
 	}
 }
-template void Save2Netcdf<float>(Param XParam, Loop<float> XLoop, Model<float> XModel);
-template void Save2Netcdf<double>(Param XParam, Loop<double> XLoop, Model<double> XModel);
+template void Save2Netcdf<float>(Param XParam, Loop<float> XLoop, Model<float>& XModel);
+template void Save2Netcdf<double>(Param XParam, Loop<double> XLoop, Model<double>& XModel);
 
 
 //The following functions are tools to create 2D or 3D netcdf files (for testing for example)

--- a/src/Write_netcdf.cu
+++ b/src/Write_netcdf.cu
@@ -50,13 +50,13 @@ void Calcnxnyzone(Param XParam, int level, int& nx, int& ny, outzoneB Xzone)
 std::vector<int> Calcactiveblockzone(Param XParam, int* activeblk, outzoneB Xzone)
 {
 	std::vector<int> actblkzone(Xzone.nblk, -1);
-	int * inactive, * inblock;
+	int* inactive, * inblock;
 
 	for (int ib = 0; ib < Xzone.nblk; ib++)
 	{
 		//printf("loop=%i \n", Xzone.blk[ib]);
-		inactive = std::find (activeblk, activeblk + XParam.nblk, Xzone.blk[ib]);
-		inblock = std::find (Xzone.blk, Xzone.blk + Xzone.nblk, Xzone.blk[ib]);
+		inactive = std::find(activeblk, activeblk + XParam.nblk, Xzone.blk[ib]);
+		inblock = std::find(Xzone.blk, Xzone.blk + Xzone.nblk, Xzone.blk[ib]);
 		//if ((inactive != activeblk + XParam.nblk) && (inblock != Xzone.blk + Xzone.nblk))
 		if (inactive != activeblk + XParam.nblk)
 		{
@@ -77,7 +77,7 @@ std::vector<int> Calcactiveblockzone(Param XParam, int* activeblk, outzoneB Xzon
 }
 
 template<class T>
-void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T * blockyo, outzoneB &Xzone)
+void creatncfileBUQ(Param& XParam, int* activeblk, int* level, T* blockxo, T* blockyo, outzoneB& Xzone)
 {
 
 	int status;
@@ -85,7 +85,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 	//double dx = XParam.dx;
 	size_t nxx, nyy;
 	int ncid, xx_dim, yy_dim, time_dim, blockid_dim, nblk;
-	double * xval, *yval;
+	double* xval, * yval;
 
 	//const int minlevzone = XParam.minlevel;
 	//const int maxlevzone = XParam.maxlevel;
@@ -96,7 +96,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 
 
 	// create the netcdf dataset Xzone.outname.c_str()
-	status = nc_create(Xzone.outname.c_str(), NC_NOCLOBBER|NC_NETCDF4, &ncid);
+	status = nc_create(Xzone.outname.c_str(), NC_NOCLOBBER | NC_NETCDF4, &ncid);
 	if (status != NC_NOERR)
 	{
 		if (status == NC_EEXIST) // File already exist so automatically rename the output file 
@@ -118,7 +118,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 				}
 				newname = newname + "_" + std::to_string(fileinc) + "." + bathyext;
 				Xzone.outname = newname;
-				status = nc_create(Xzone.outname.c_str(), NC_NOCLOBBER|NC_NETCDF4, &ncid);
+				status = nc_create(Xzone.outname.c_str(), NC_NOCLOBBER | NC_NETCDF4, &ncid);
 				fileinc++;
 			}
 			//printf("New file name: %s  ", Xzone.outname.c_str());
@@ -134,14 +134,14 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 
 	// status could be a new error after renaming the file
 	if (status != NC_NOERR) handle_ncerror(status);
-	
+
 	double initdx = calcres(XParam.dx, XParam.initlevel);
 	double xmin, xmax, ymin, ymax;
 
-	xmin = Xzone.xo ;
-	xmax = Xzone.xmax ;
-	ymin = Xzone.yo ;
-	ymax = Xzone.ymax ;
+	xmin = Xzone.xo;
+	xmax = Xzone.xmax;
+	ymin = Xzone.yo;
+	ymax = Xzone.ymax;
 
 	// Define global attributes
 	status = nc_put_att_int(ncid, NC_GLOBAL, "maxlevel", NC_INT, 1, &Xzone.maxlevel);
@@ -169,11 +169,11 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 
 	int time_id, xx_id, yy_id;
 	int tdim[] = { time_dim };
-	
+
 	//########################
 	//static size_t tst[] = { 0 };
 	size_t blkstart[] = { 0 }; // Xzone.blk[0]};
-	size_t blkcount[] = { (size_t) Xzone.nblk };
+	size_t blkcount[] = { (size_t)Xzone.nblk };
 	size_t xcount[] = { 0 };
 	size_t ycount[] = { 0 };
 	static size_t xstart[] = { 0 }; // start at first value
@@ -182,11 +182,11 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 	if (status != NC_NOERR) handle_ncerror(status);
 
 	static char txtname[] = "time";
-	status = nc_put_att_text(ncid, time_id, "standard_name", strlen(txtname), txtname );
+	status = nc_put_att_text(ncid, time_id, "standard_name", strlen(txtname), txtname);
 	//status = nc_put_att_string(ncid, time_id, "standard_name", 1, "time");
 	//units = "days since 1990-1-1 0:0:0";
 
-	std::string timestr= "seconds since " + XParam.reftime;
+	std::string timestr = "seconds since " + XParam.reftime;
 	const char* timeunit = timestr.c_str();
 
 	status = nc_put_att_text(ncid, time_id, "units", strlen(timeunit), timeunit);
@@ -220,7 +220,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 	{
 		crsname = "projected";
 		std::string proj = XParam.crs_ref;
-			//"+proj=tmerc +lat_0=0 +lon_0=173 +k=0.9996 +x_0=1600000 +y_0=10000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
+		//"+proj=tmerc +lat_0=0 +lon_0=173 +k=0.9996 +x_0=1600000 +y_0=10000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
 		status = nc_put_att_text(ncid, crsid, "grid_mapping_name", crsname.size(), crsname.c_str());
 		status = nc_put_att_text(ncid, crsid, "crs_wkt", proj.size(), proj.c_str());
 		status = nc_put_att_text(ncid, crsid, "spatial_ref", proj.size(), proj.c_str());
@@ -262,7 +262,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 	// For each level Define xx yy 
 	for (int lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
 	{
-		
+
 		Calcnxnyzone(XParam, lev, nx, ny, Xzone);
 
 		//printf("lev=%d;  xxmin=%f; xxmax=%f; nx=%d\n", lev, xmin, xmax, nx);
@@ -275,7 +275,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 		//Define dimensions: Name and length
 		std::string xxname, yyname, sign;
 
-		lev < 0?sign="N":sign = "P";
+		lev < 0 ? sign = "N" : sign = "P";
 
 
 		xxname = "xx_" + sign + std::to_string(abs(lev));
@@ -300,7 +300,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 		if (status != NC_NOERR) handle_ncerror(status);
 
 
-		
+
 
 		status = nc_put_att_text(ncid, xx_id, "axis", xaxis.size(), xaxis.c_str());
 		status = nc_put_att_text(ncid, yy_id, "axis", yaxis.size(), yaxis.c_str());
@@ -328,7 +328,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 		blkwidth[ib] = (float)calcres(XParam.dx, level[ibl]);
 		blkid[ib] = ibl;
 	}
-	
+
 
 	status = nc_put_vara_int(ncid, blkid_id, blkstart, blkcount, blkid);
 	if (status != NC_NOERR) handle_ncerror(status);
@@ -347,7 +347,7 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 		ibl = activeblkzone[ib];
 		blkwidth[ib] = float(T(XParam.xo) + blockxo[ibl]);
 		blkid[ib] = level[ibl];
-		
+
 	}
 
 	status = nc_put_vara_float(ncid, blkxo_id, blkstart, blkcount, blkwidth);
@@ -363,82 +363,82 @@ void creatncfileBUQ(Param &XParam,int * activeblk, int * level, T * blockxo, T *
 	}
 
 	status = nc_put_vara_float(ncid, blkyo_id, blkstart, blkcount, blkwidth);
-	
+
 
 	free(blkid);
 	free(blkwidth);
 
 	if (status != NC_NOERR) handle_ncerror(status);
-	
+
 	std::string xxname, yyname, sign;
 
-for (int lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
-{
-	Calcnxnyzone(XParam, lev, nx, ny, Xzone);
-
-	// start at first value
-	//static size_t thstart[] = { 0 };
-	xcount[0] = nx;
-	ycount[0] = ny;
-	//Recreat the x, y
-	xval = (double*)malloc(nx * sizeof(double));
-	yval = (double*)malloc(ny * sizeof(double));
-
-	double ddx = calcres(XParam.dx, lev);
-	double dxp = calcres(XParam.dx, lev + 1);
-	double  xxmin,  yymin;
-	//doublle xxmax, yymax
-	//xxmax = Xzone.xmax - dxp;
-	//yymax = Xzone.ymax - dxp;
-
-	xxmin = Xzone.xo + dxp;
-	yymin = Xzone.yo + dxp;
-
-	for (int i = 0; i < nx; i++)
+	for (int lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
 	{
-		xval[i] = xxmin + double(i) * ddx;
+		Calcnxnyzone(XParam, lev, nx, ny, Xzone);
+
+		// start at first value
+		//static size_t thstart[] = { 0 };
+		xcount[0] = nx;
+		ycount[0] = ny;
+		//Recreat the x, y
+		xval = (double*)malloc(nx * sizeof(double));
+		yval = (double*)malloc(ny * sizeof(double));
+
+		double ddx = calcres(XParam.dx, lev);
+		double dxp = calcres(XParam.dx, lev + 1);
+		double  xxmin, yymin;
+		//doublle xxmax, yymax
+		//xxmax = Xzone.xmax - dxp;
+		//yymax = Xzone.ymax - dxp;
+
+		xxmin = Xzone.xo + dxp;
+		yymin = Xzone.yo + dxp;
+
+		for (int i = 0; i < nx; i++)
+		{
+			xval[i] = xxmin + double(i) * ddx;
+		}
+
+		for (int i = 0; i < ny; i++)
+		{
+			yval[i] = yymin + double(i) * ddx;
+		}
+
+
+		lev < 0 ? sign = "N" : sign = "P";
+
+
+		xxname = "xx_" + sign + std::to_string(abs(lev));
+		yyname = "yy_" + sign + std::to_string(abs(lev));
+
+		//printf("lev=%d; xxname=%s; yyname=%s;\n", lev, xxname.c_str(), yyname.c_str());
+
+		status = nc_inq_varid(ncid, xxname.c_str(), &xx_id);
+		if (status != NC_NOERR) handle_ncerror(status);
+		status = nc_inq_varid(ncid, yyname.c_str(), &yy_id);
+		if (status != NC_NOERR) handle_ncerror(status);
+
+		//Provide values for variables
+
+		status = nc_put_vara_double(ncid, xx_id, xstart, xcount, xval);
+		if (status != NC_NOERR) handle_ncerror(status);
+		status = nc_put_vara_double(ncid, yy_id, ystart, ycount, yval);
+		if (status != NC_NOERR) handle_ncerror(status);
+
+
+
+		free(xval);
+		free(yval);
 	}
 
-	for (int i = 0; i < ny; i++)
-	{
-		yval[i] = yymin + double(i) * ddx;
-	}
-
-
-	lev < 0 ? sign = "N" : sign = "P";
-
-
-	xxname = "xx_" + sign + std::to_string(abs(lev));
-	yyname = "yy_" + sign + std::to_string(abs(lev));
-
-	//printf("lev=%d; xxname=%s; yyname=%s;\n", lev, xxname.c_str(), yyname.c_str());
-
-	status = nc_inq_varid(ncid, xxname.c_str(), &xx_id);
-	if (status != NC_NOERR) handle_ncerror(status);
-	status = nc_inq_varid(ncid, yyname.c_str(), &yy_id);
-	if (status != NC_NOERR) handle_ncerror(status);
-
-	//Provide values for variables
-
-	status = nc_put_vara_double(ncid, xx_id, xstart, xcount, xval);
-	if (status != NC_NOERR) handle_ncerror(status);
-	status = nc_put_vara_double(ncid, yy_id, ystart, ycount, yval);
+	//close and save new file
+	status = nc_close(ncid);
 	if (status != NC_NOERR) handle_ncerror(status);
 
 
 
-	free(xval);
-	free(yval);
-}
 
-//close and save new file
-status = nc_close(ncid);
-if (status != NC_NOERR) handle_ncerror(status);
-
-
-
-
-//return XParam;void
+	//return XParam;void
 }
 
 template void creatncfileBUQ<float>(Param& XParam, int* activeblk, int* level, float* blockxo, float* blockyo, outzoneB& Xzone);
@@ -446,19 +446,19 @@ template void creatncfileBUQ<double>(Param& XParam, int* activeblk, int* level, 
 
 
 template<class T>
-void creatncfileBUQ(Param& XParam, BlockP<T> &XBlock)
+void creatncfileBUQ(Param& XParam, BlockP<T>& XBlock)
 {
 	for (int o = 0; o < XBlock.outZone.size(); o++)
 	{
 		creatncfileBUQ(XParam, XBlock.active, XBlock.level, XBlock.xo, XBlock.yo, XBlock.outZone[o]);
 	}
 }
-template void creatncfileBUQ<float>(Param &XParam, BlockP<float> &XBlock);
-template void creatncfileBUQ<double>(Param &XParam, BlockP<double> &XBlock);
+template void creatncfileBUQ<float>(Param& XParam, BlockP<float>& XBlock);
+template void creatncfileBUQ<double>(Param& XParam, BlockP<double>& XBlock);
 
 template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T* blockxo, T* blockyo, std::string varst, int vdim, T* var, outzoneB Xzone)
 {
-	defncvarBUQ(XParam, activeblk, level, blockxo, blockyo, varst, "", "","", vdim, var, Xzone);
+	defncvarBUQ(XParam, activeblk, level, blockxo, blockyo, varst, "", "", "", vdim, var, Xzone);
 }
 
 template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T* blockxo, T* blockyo, std::string varst, std::string longname, std::string stdname, std::string unit, int vdim, T* var, outzoneB Xzone)
@@ -496,7 +496,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 	//count3D[0] = 1;
 	//count3D[1] = XParam.blkwidth;
 	//count3D[2] = XParam.blkwidth;
-	
+
 	//int minlevzone, maxlevzone;
 
 	std::string outfile = Xzone.outname;
@@ -526,15 +526,15 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 	status = nc_inq_unlimdim(ncid, &recid);//time
 	if (status != NC_NOERR) handle_ncerror(status);
 
-	varblk = (float *)malloc(XParam.blkwidth* XParam.blkwidth * sizeof(float));
+	varblk = (float*)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(float));
 	if (smallnc > 0)
 	{
 
-		varblk_s = (short *)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(short));
+		varblk_s = (short*)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(short));
 	}
 
 
-	std::string xxname, yyname, varname,sign;
+	std::string xxname, yyname, varname, sign;
 
 	//generate a different variable name for each level and add attribute as necessary
 	for (lev = Xzone.minlevel; lev <= Xzone.maxlevel; lev++)
@@ -593,25 +593,25 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 
 			if (status != NC_NOERR) handle_ncerror(status);
 		}
-		
+
 
 		if (smallnc > 0)
 		{
-			
+
 			status = nc_put_att_float(ncid, var_id, "scale_factor", NC_FLOAT, 1, &scalefactor);
 			if (status != NC_NOERR) handle_ncerror(status);
 			status = nc_put_att_float(ncid, var_id, "add_offset", NC_FLOAT, 1, &addoffset);
 			if (status != NC_NOERR) handle_ncerror(status);
 		}
-		
+
 
 		status = nc_put_att_text(ncid, var_id, "standard_name", stdname.size(), stdname.c_str());
 		status = nc_put_att_text(ncid, var_id, "long_name", longname.size(), longname.c_str());
-		status = nc_put_att_text(ncid, var_id, "units", unit.size(),unit.c_str());
+		status = nc_put_att_text(ncid, var_id, "units", unit.size(), unit.c_str());
 
 		std::string crsstrname = "crs";
 		status = nc_put_att_text(ncid, var_id, "grid_mapping", crsstrname.size(), crsstrname.c_str());
-		
+
 
 		int shuffle = 1;
 		int deflate = 1;        // This switches compression on (1) or off (0).
@@ -632,7 +632,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 	//####################
 	for (ibl = 0; ibl < Xzone.nblk; ibl++)
 	{
-		
+
 		//bl = activeblk[Xzone.blk[ibl]];
 		bl = activeblkzone[ibl];
 		lev = level[bl];
@@ -642,14 +642,14 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 		double xxmin, yymin;
 		double initdx = calcres(XParam.dx, XParam.initlevel);
 
-		
+
 
 		//xxmax = Xzone.xmax - calcres(XParam.dx, lev) / 2.0;
 		//yymax = Xzone.ymax - calcres(XParam.dx, lev )/2.0;
 
-		
+
 		xxmin = Xzone.xo + calcres(XParam.dx, lev) / 2.0;
-		yymin = Xzone.yo + calcres(XParam.dx, lev )/2.0;
+		yymin = Xzone.yo + calcres(XParam.dx, lev) / 2.0;
 		//printf("xxmin=%f, yymin=%f, lev=$d \n", xxmin, yymin, lev);
 
 		//std::string xxname, yyname, sign;
@@ -660,7 +660,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 		xxname = "xx_" + sign + std::to_string(abs(lev));
 		yyname = "yy_" + sign + std::to_string(abs(lev));
 
-		varname = varst +  "_" + sign + std::to_string(abs(lev));
+		varname = varst + "_" + sign + std::to_string(abs(lev));
 		status = nc_inq_dimid(ncid, xxname.c_str(), &xid);
 		if (status != NC_NOERR) handle_ncerror(status);
 		status = nc_inq_dimid(ncid, yyname.c_str(), &yid);
@@ -706,8 +706,8 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 			//
 			start3D[1] = (size_t)round((XParam.yo + blockyo[bl] - yymin) / calcres(XParam.dx, lev));
 			start3D[2] = (size_t)round((XParam.xo + blockxo[bl] - xxmin) / calcres(XParam.dx, lev));
-	
- 			if (smallnc > 0)
+
+			if (smallnc > 0)
 			{
 				status = nc_put_vara_short(ncid, var_id, start3D, count3D, varblk_s);
 				if (status != NC_NOERR) handle_ncerror(status);
@@ -718,7 +718,7 @@ template <class T> void defncvarBUQ(Param XParam, int* activeblk, int* level, T*
 
 				if (status != NC_NOERR)
 				{
-					printf("\n ib=%d start=[%d,%d,%d]; initlevel=%d; initdx=%f; level=%d; xo=%f; yo=%f; blockxo[ib]=%f xxmin=%f blockyo[ib]=%f yymin=%f startfl=%f\n", bl, (int)start3D[0], (int)start3D[1], (int)start3D[2], XParam.initlevel,initdx,lev, Xzone.xo, Xzone.yo, blockxo[bl], xxmin, blockyo[bl], yymin, (blockyo[bl] - yymin) / calcres(XParam.dx, lev));
+					printf("\n ib=%d start=[%d,%d,%d]; initlevel=%d; initdx=%f; level=%d; xo=%f; yo=%f; blockxo[ib]=%f xxmin=%f blockyo[ib]=%f yymin=%f startfl=%f\n", bl, (int)start3D[0], (int)start3D[1], (int)start3D[2], XParam.initlevel, initdx, lev, Xzone.xo, Xzone.yo, blockxo[bl], xxmin, blockyo[bl], yymin, (blockyo[bl] - yymin) / calcres(XParam.dx, lev));
 					//printf("\n varblk[0]=%f varblk[255]=%f\n", varblk[0], varblk[255]);
 					handle_ncerror(status);
 				}
@@ -1085,12 +1085,12 @@ template <class T> void defncvarBUQlev(Param XParam, int* activeblk, int* level,
 
 
 
-template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activeblk, int* level, T * blockxo, T *blockyo, std::string varst, T * var, outzoneB Xzone)
+template <class T> void writencvarstepBUQ(Param XParam, int vdim, int* activeblk, int* level, T* blockxo, T* blockyo, std::string varst, T* var, outzoneB Xzone)
 {
 	int status, ncid, recid, var_id;
 	static size_t nrec;
-	short *varblk_s;
-	float * varblk;
+	short* varblk_s;
+	float* varblk;
 	//int nx, ny;
 	//int dimids[NC_MAX_VAR_DIMS];
 	//size_t  *ddim, *start, *count;
@@ -1118,11 +1118,11 @@ template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activebl
 
 	start3D[0] = nrec - 1;
 
-	varblk = (float *)malloc(XParam.blkwidth* XParam.blkwidth * sizeof(float));
+	varblk = (float*)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(float));
 	if (smallnc > 0)
 	{
 
-		varblk_s = (short *)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(short));
+		varblk_s = (short*)malloc(XParam.blkwidth * XParam.blkwidth * sizeof(short));
 	}
 
 
@@ -1139,15 +1139,15 @@ template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activebl
 		bl = activeblkzone[ibl];
 		lev = level[bl];
 		lev < 0 ? sign = "N" : sign = "P";
-		double  xxmin,  yymin;
+		double  xxmin, yymin;
 		//double xxmax, yymax;
 		double initdx = calcres(XParam.dx, XParam.initlevel);
 
-		
+
 		//xxmax = Xzone.xmax - calcres(XParam.dx, lev) / 2.0;
 		//yymax = Xzone.ymax - calcres(XParam.dx, lev) / 2.0;
 
-		
+
 		xxmin = Xzone.xo + calcres(XParam.dx, lev) / 2.0;
 		yymin = Xzone.yo + calcres(XParam.dx, lev) / 2.0;
 
@@ -1229,8 +1229,8 @@ template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activebl
 
 // Scope for compiler to know what function to compile
 
-template void writencvarstepBUQ<float>(Param XParam, int vdim, int * activeblk, int* level, float * blockxo, float *blockyo, std::string varst, float * var, outzoneB Xzone);
-template void writencvarstepBUQ<double>(Param XParam, int vdim, int * activeblk, int* level, double * blockxo, double *blockyo, std::string varst, double * var, outzoneB Xzone);
+template void writencvarstepBUQ<float>(Param XParam, int vdim, int* activeblk, int* level, float* blockxo, float* blockyo, std::string varst, float* var, outzoneB Xzone);
+template void writencvarstepBUQ<double>(Param XParam, int vdim, int* activeblk, int* level, double* blockxo, double* blockyo, std::string varst, double* var, outzoneB Xzone);
 
 extern "C" void writenctimestep(std::string outfile, double totaltime)
 {
@@ -1337,7 +1337,7 @@ template <class T> void writencvarstepBUQlev(Param XParam, int vdim, int* active
 	//{
 		bl = activeblkzone[ibl];
 		lev = level[bl];
-		
+
 		double  xxmin, yymin;
 		int nxlev, nylev;
 		//double xxmax, yymax;
@@ -1353,11 +1353,11 @@ template <class T> void writencvarstepBUQlev(Param XParam, int vdim, int* active
 		xxmin = Xzone.xo + calcres(XParam.dx, lev) / 2.0;
 		yymin = Xzone.yo + calcres(XParam.dx, lev) / 2.0;
 
-		
+
 
 		jo = round((XParam.yo + blockyo[bl] - yymin) / calcres(XParam.dx, lev));
 		io = round((XParam.xo + blockxo[bl] - xxmin) / calcres(XParam.dx, lev));
-		
+
 
 		for (int j = 0; j < XParam.blkwidth; j++)
 		{
@@ -1398,11 +1398,11 @@ template <class T> void writencvarstepBUQlev(Param XParam, int vdim, int* active
 
 		if (vdim == 2)
 		{
-			
+
 
 			start2D[0] = 0; // (size_t)round((XParam.yo - yymin) / calcres(XParam.dx, levi));
 			start2D[1] = 0; // (size_t)round((XParam.xo - xxmin) / calcres(XParam.dx, levi));
-			
+
 			count2D[0] = (size_t)nylev;
 			count2D[1] = (size_t)nxlev;
 
@@ -1468,7 +1468,7 @@ template void writencvarstepBUQlev<double>(Param XParam, int vdim, int* activebl
 
 
 //Initialise netcdf files
-template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
+template <class T> void InitSave2Netcdf(Param& XParam, Model<T>& XModel)
 {
 	if (!XParam.outvars.empty())
 	{
@@ -1495,14 +1495,14 @@ template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel)
 		}*/
 	}
 }
-template void InitSave2Netcdf<float>(Param &XParam, Model<float> &XModel);
-template void InitSave2Netcdf<double>(Param &XParam, Model<double> &XModel);
+template void InitSave2Netcdf<float>(Param& XParam, Model<float>& XModel);
+template void InitSave2Netcdf<double>(Param& XParam, Model<double>& XModel);
 
 //Save initialisation in maps outpout if require
 template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XModel)
 {
 	double NextZoneOutTime;
-	
+
 	if (!XParam.outvars.empty())
 	{
 		for (int o = 0; o < XModel.blocks.outZone.size(); o++)
@@ -1520,7 +1520,7 @@ template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XMode
 				}
 				XModel.blocks.outZone[o].index_next_OutputT++;
 			}
-			
+
 
 		}
 	}
@@ -1529,7 +1529,7 @@ template void SaveInitialisation2Netcdf<float>(Param& XParam, Model<float>& XMod
 template void SaveInitialisation2Netcdf<double>(Param& XParam, Model<double>& XModel);
 
 
-template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T>& XModel)
+template <class T> void Save2Netcdf(Param XParam, Loop<T> XLoop, Model<T>& XModel)
 {
 	double NextZoneOutTime;
 	double tiny = 0.0000001;
@@ -1560,14 +1560,14 @@ template <class T> void Save2Netcdf(Param XParam,Loop<T> XLoop, Model<T>& XModel
 					}
 					else
 					{
-            if (XParam.savebyblk)
-				{
-					writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
-				}
-				else
-				{
-					writencvarstepBUQlev(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
-				}
+						if (XParam.savebyblk)
+						{
+							writencvarstepBUQ(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+						}
+						else
+						{
+							writencvarstepBUQlev(XParam, 3, XModel.blocks.active, XModel.blocks.level, XModel.blocks.xo, XModel.blocks.yo, XParam.outvars[ivar], XModel.OutputVarMap[XParam.outvars[ivar]], XModel.blocks.outZone[o]);
+						}
 					}
 				}
 				XModel.blocks.outZone[o].index_next_OutputT++;
@@ -1620,7 +1620,7 @@ extern "C" void create2dnc(char* filename, int nx, int ny, double* xx, double* y
 
 	static size_t xstart[] = { 0 }; // start at first value
 	static size_t xcount[] = { (size_t)nx };
-	
+
 	static size_t ystart[] = { 0 }; // start at first value
 	static size_t ycount[] = { (size_t)ny };
 

--- a/src/Write_netcdf.h
+++ b/src/Write_netcdf.h
@@ -16,7 +16,7 @@ template <class T> void defncvarBUQ(Param XParam, int * activeblk, int * level, 
 template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activeblk, int* level, T * blockxo, T *blockyo, std::string varst, T * var, outzoneB Xzone);
 template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel);
 extern "C" void writenctimestep(std::string outfile, double totaltime);
-template <class T> void Save2Netcdf(Param XParam, Loop<T> XLoop, Model<T> XModel);
+template <class T> void Save2Netcdf(Param XParam, Loop<T> XLoop, Model<T> &XModel);
 
 extern "C" void create2dnc(char* filename, int nx, int ny, double* xx, double* yy, double* var, char* varname);
 extern "C" void create3dnc(char* name, int nx, int ny, int nt, double* xx, double* yy, double* theta, double* var, char* varname);

--- a/src/Write_netcdf.h
+++ b/src/Write_netcdf.h
@@ -16,7 +16,7 @@ template<class T> void creatncfileBUQ(Param &XParam, BlockP<T> &XBlock);
 template <class T> void defncvarBUQ(Param XParam, int * activeblk, int * level, T * blockxo, T *blockyo, std::string varst, int vdim, T * var, outzoneB Xzone);
 template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activeblk, int* level, T * blockxo, T *blockyo, std::string varst, T * var, outzoneB Xzone);
 template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel);
-template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XModel);
+//template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XModel);
 extern "C" void writenctimestep(std::string outfile, double totaltime);
 template <class T> void Save2Netcdf(Param XParam, Loop<T> XLoop, Model<T> &XModel);
 

--- a/src/Write_netcdf.h
+++ b/src/Write_netcdf.h
@@ -15,6 +15,7 @@ template<class T> void creatncfileBUQ(Param &XParam, BlockP<T> &XBlock);
 template <class T> void defncvarBUQ(Param XParam, int * activeblk, int * level, T * blockxo, T *blockyo, std::string varst, int vdim, T * var, outzoneB Xzone);
 template <class T> void writencvarstepBUQ(Param XParam, int vdim, int * activeblk, int* level, T * blockxo, T *blockyo, std::string varst, T * var, outzoneB Xzone);
 template <class T> void InitSave2Netcdf(Param &XParam, Model<T> &XModel);
+template <class T> void SaveInitialisation2Netcdf(Param& XParam, Model<T>& XModel);
 extern "C" void writenctimestep(std::string outfile, double totaltime);
 template <class T> void Save2Netcdf(Param XParam, Loop<T> XLoop, Model<T> &XModel);
 

--- a/src/utctime.cu
+++ b/src/utctime.cu
@@ -256,16 +256,27 @@ double date_string_to_s(std::string datetime, std::string refdate)
 	//UTCTime ttime = date_string_to_time(datetime);
 	//UTCTime reftime = date_string_to_time(refdate);
 
-	long long ttime = date_string_to_time(datetime);
-	long long reftime = date_string_to_time(refdate);
+	double diff;
 
-	//double diff = difftime(ttime, reftime);
+	std::string::size_type n = datetime.find('T');
+	if (std::string::npos == n)
+	{
+		diff = std::stod(datetime);
+	}
+	else
+	{
 
-	//std::chrono::microseconds timeDiff = ttime - reftime;
+		long long ttime = date_string_to_time(datetime);
+		long long reftime = date_string_to_time(refdate);
 
-	//double diff = ((double) duration_cast<std::chrono::milliseconds>(ttime - reftime).count())/1000.0;
+		//double diff = difftime(ttime, reftime);
 
-	double diff = (double)(ttime - reftime);
+		//std::chrono::microseconds timeDiff = ttime - reftime;
+
+		//double diff = ((double) duration_cast<std::chrono::milliseconds>(ttime - reftime).count())/1000.0;
+
+		diff = (double)(ttime - reftime);
+	}
 
 	return diff;
 }


### PR DESCRIPTION
This is link to the task: Add more fexibility in time of output (Projects for FY24/25)
- [x] : Reading a vector input in the shape: t_init : t_steps : t_end
- [x] : Reading a vector in the shape: t1,t2,t3, ... , tn
- [x] : Modifying the timing for outputs
- [x] : Add / review sanity checks and initialisations of the XParam values
- [x] : Testing the two different forms
- [x] : Testing with dates
- [x] : Adding the Toutput vector to the Zone_output input shape
- [x] : Modifying the code to take the appropriate Toutput vector
- [x] : Add a automatic test
- [x] : Add in documentation