### PR TITLE
Many Rivers

### DIFF
--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -82,6 +82,16 @@ struct maskinfo
 
 };
 
+struct RiverInfo
+{
+	int nbir;
+	int nburmax; // size of (max number of) unique block with rivers  
+	int nribmax; // size of (max number of) rivers in one block
+	int* Xbidir; // array of block id for each river size()
+	int* Xridib; // array of river id in each block
+
+};
+
 
 // outzone info used to actually write the nc files (one nc file by zone, the default zone is the full domain)
 struct outzoneB 


### PR DESCRIPTION
# Improve efficiency if may rivers are involved
I'm changing the structure of the model workflow to be efficient if a lot of rivers are in the model.
Currently kernels are launched in serial for each river. This is very inefficient when you have many rivers.
In an example using a crud model of the lower Waitaki River. 

| n rivers | Run times |
| -------- | ------- |
| 1 | 6    |
| 10 | 7    |
| 100    | 14    |
| 675 | 71 | 

This doesn't look too bad but things gets worse in other setting (may need a better example to make the point about the point of this)

