### PR TITLE
Add Mass conservation switch

### DIFF
--- a/src/Advection.cu
+++ b/src/Advection.cu
@@ -307,7 +307,7 @@ template <class T> __host__ void AdvkernelCPU(Param XParam, BlockP<T> XBlock, T 
 
 				dhi = XAdv.dh[i];
 
-				T edt = dhi > T(0.0) ? dt : min(dt, hold / (T(-1.0) * dhi));
+				T edt = XParam.ForceMassConserve ? dt : dhi >= T(0.0) ? dt : min(dt, max(hold, XParam.eps) / abs(dhi));
 
 				ho = hold + edt * dhi;
 

--- a/src/Advection.cu
+++ b/src/Advection.cu
@@ -251,8 +251,8 @@ template <class T> __global__ void AdvkernelGPU(Param XParam, BlockP<T> XBlock, 
 	T ho, uo, vo;
 	T dhi = XAdv.dh[i];
 
-	T edt = dhi >= T(0.0) ? dt : min(dt, max(hold, XParam.eps) / abs(dhi));
-
+	T edt = XParam.ForceMassConserve ? dt : dhi >= T(0.0) ? dt : min(dt, max(hold, XParam.eps) / abs(dhi));
+	
 	//ho = max(hold + edt * dhi,T(0.0));
 	ho = hold + edt * dhi;
 

--- a/src/Param.h
+++ b/src/Param.h
@@ -31,6 +31,7 @@ public:
 
 	bool conserveElevation = false; //Switch to force the conservation of zs instead of h at the interface between coarse and fine blocks
 	bool wetdryfix = true; // Switch to remove wet/dry instability (i.e. true reoves instability and false leaves the model as is)
+	bool ForceMassConserve = false; // Switch to enforce mass conservation 
 
 	bool leftbnd = false; // bnd is forced (i.e. not a wall or neuman) // Not in use anymore
 	bool rightbnd = false; // bnd is forced (i.e. not a wall or neuman) // Not in use anymore

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -699,6 +699,8 @@ template <class T> bool Rivertest(T zsnit, int gpu)
 	XParam.outmean = true;
 	XParam.outtwet = true;
 
+	XParam.ForceMassConserve = true;
+
 	// create Model setup
 	Model<T> XModel;
 	Model<T> XModel_g;
@@ -923,6 +925,7 @@ template <class T> bool MassConserveSteepSlope(T zsnit, int gpu)
 	XParam.frictionmodel = 1;
 
 	XParam.conserveElevation = false;
+	XParam.ForceMassConserve = true;
 
 	// Enforce GPU/CPU
 	XParam.GPUDEVICE = gpu;
@@ -1679,6 +1682,7 @@ template <class T> bool RiverVolumeAdapt(Param XParam, T maxslope)
 	XParam.minlevel = 1;
 	XParam.maxlevel = 1;
 	XParam.initlevel = 1;
+	XParam.ForceMassConserve = true;
 	
 	
 	UnitestA=RiverVolumeAdapt(XParam, maxslope, false, false);
@@ -2217,6 +2221,7 @@ template <class T> bool RiverOnBoundary(Param XParam,T slope, int Dir, int Bound
 	XParam.mask = 999.0;
 	XParam.outishift = 0;
 	XParam.outjshift = 0;
+	XParam.ForceMassConserve = true;
 
 
 	XParam.outputtimestep = 10.0;// XParam.endtime;
@@ -2726,6 +2731,7 @@ template <class T> bool Raintest(T zsnit, int gpu, float alpha)
 	//Specification of the test
 	//XParam.test = 7;
 	XParam.rainforcing = true;
+	XParam.ForceMassConserve = true;
 
 	// Enforce GPU/CPU
 	XParam.GPUDEVICE = gpu;


### PR DESCRIPTION
# Add a mass conservation switch
This is so the user can decide between 

- unstable velocity on steep slopes that can conserve overall mass but may lead to negative water depth
- realistic velocities and no negative depth but with potentially loss of mass

## Task

- [ ] Add switch to param file. Defaults to 'off'
- [ ] Add switch to the advection kernel
- [ ] Add the tests so that the mass conservation test succeed
- [ ] Add parameter to the input detection