### PR TITLE
Implement Groundwater module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,12 @@ jobs:
         run: |
           sed -i 's/test = 14/test = 15/' BG_param.txt
           ./BG_Flood
-          ./BG_Flood BG_param_test15.txt
+          
+      - name: running test 16, Test on Groundwater input
+        run: |
+          sed -i 's/test = 15/test = 16/' BG_param.txt
+          ./BG_Flood
+          
        ##   var=$(ncdump -v h_P0 Test15_zoom2.nc)
        ## if: echo ${{ ${#var} == 7 }}
 

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ ifeq ($(SAMPLE_ENABLED),0)
 EXEC ?= @echo "[@]"
 endif
 
-OBJ = BG_Flood.o AdaptCriteria.o Adaptation.o Advection.o  Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o utctime.o Write_txtlog.o FlowMLGPU.o Multilayer.o
+OBJ = BG_Flood.o AdaptCriteria.o Adaptation.o Advection.o  Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o utctime.o Write_txtlog.o FlowMLGPU.o Multilayer.o groundwater.o
 
 
 ################################################################################
@@ -361,7 +361,10 @@ FlowMLGPU.o:./src/FlowMLGPU.cu
 Multilayer.o:./src/Multilayer.cu
 	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
 
-BG_Flood: BG_Flood.o AdaptCriteria.o Adaptation.o Advection.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o Spherical.o utctime.o FlowMLGPU.o Multilayer.o
+groundwater.o:./src/groundwater.cu
+	$(EXEC) $(NVCC) $(INCLUDES) $(ALL_CCFLAGS) $(GENCODE_FLAGS) -o $@ -c $<
+
+BG_Flood: BG_Flood.o AdaptCriteria.o Adaptation.o Advection.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o Spherical.o utctime.o FlowMLGPU.o Multilayer.o groundwater.o
 
 	$(EXEC) $(NVCC) $(ALL_LDFLAGS) $(GENCODE_FLAGS) -o $@ $+ $(LIBRARIES)
 	$(EXEC) mkdir -p ../../bin/$(TARGET_ARCH)/$(TARGET_OS)/$(BUILD_TYPE)
@@ -372,7 +375,7 @@ run: build
 
 clean:
 
-	rm -f BG_Flood AdaptCriteria.o Adaptation.o Advection.o BG_Flood.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o Spherical.o utctime.o FlowMLGPU.o Multilayer.o
+	rm -f BG_Flood AdaptCriteria.o Adaptation.o Advection.o BG_Flood.o Boundary.o ConserveElevation.o FlowCPU.o FlowGPU.o Friction.o Gradients.o GridManip.o Halo.o InitEvolv.o InitialConditions.o Kurganov.o Mainloop.o Meanmax.o MemManagement.o Mesh.o ReadForcing.o ReadInput.o Read_netcdf.o Reimann.o Setup_GPU.o Testing.o Updateforcing.o Util_CPU.o Write_netcdf.o Write_txtlog.o Poly.o Spherical.o utctime.o FlowMLGPU.o Multilayer.o groundwater.o
 
 	rm -rf ../../bin/$(TARGET_ARCH)/$(TARGET_OS)/$(BUILD_TYPE)/template
 

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -174,21 +174,7 @@ struct AdvanceP
 	T* dhv;
 };
 
-template <class T>
-struct GoundWaterP
-{
-	// Groundwater Physical Parameters
-	T* zs;// groundwater celing elevation
-	T* h;// groundwater depth (z_gw - zaqb)
-	T* K;
-	T* fs;
-	T* Sy;
-	T* zb;// Elevation of aquifer bottom
 
-	// Groundwater Fluxes
-	T* Qx;
-	T* Qy;
-};
 struct outP
 {
 	float* z;
@@ -330,7 +316,15 @@ struct Model
 	//GroundWater elevation (due to the accumulation of water by infiltration during the simulation)
 	T* hgw;
 
-	GoundWaterP<T> gw;
+	// Groundwater Physical Parameters
+	T* K_gw;
+	T* fs_gw;
+	T* Sy_gw;
+	T* Aquifer_Depth;
+
+	// Groundwater Fluxes
+	T* Qx;
+	T* Qy;
 	
 	// Used for external forcing too
 	// May need a better placeholder

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -315,6 +315,16 @@ struct Model
 
 	//GroundWater elevation (due to the accumulation of water by infiltration during the simulation)
 	T* hgw;
+
+	// Groundwater Physical Parameters
+	T* K_gw;
+	T* fs_gw;
+	T* Sy_gw;
+	T* Aquifer_Depth;
+
+	// Groundwater Fluxes
+	T* Qx;
+	T* Qy;
 	
 	// Used for external forcing too
 	// May need a better placeholder

--- a/src/Arrays.h
+++ b/src/Arrays.h
@@ -174,7 +174,21 @@ struct AdvanceP
 	T* dhv;
 };
 
+template <class T>
+struct GoundWaterP
+{
+	// Groundwater Physical Parameters
+	T* zs;// groundwater celing elevation
+	T* h;// groundwater depth (z_gw - zaqb)
+	T* K;
+	T* fs;
+	T* Sy;
+	T* zb;// Elevation of aquifer bottom
 
+	// Groundwater Fluxes
+	T* Qx;
+	T* Qy;
+};
 struct outP
 {
 	float* z;
@@ -316,15 +330,7 @@ struct Model
 	//GroundWater elevation (due to the accumulation of water by infiltration during the simulation)
 	T* hgw;
 
-	// Groundwater Physical Parameters
-	T* K_gw;
-	T* fs_gw;
-	T* Sy_gw;
-	T* Aquifer_Depth;
-
-	// Groundwater Fluxes
-	T* Qx;
-	T* Qy;
+	GoundWaterP<T> gw;
 	
 	// Used for external forcing too
 	// May need a better placeholder

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -1,4 +1,5 @@
 #include "FlowGPU.h"
+#include "groundwater.h"
 
 /**
  * @brief Main GPU flow solver for the flood model.
@@ -288,7 +289,11 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 		CUDA_CHECK(cudaDeviceSynchronize());
 	}
 
-	if (XParam.infiltration)
+	if (XParam.groundwater)
+	{
+		GroundwaterStepGPU(XParam, XLoop, XModel);
+	}
+	else if (XParam.infiltration)
 	{
 		AddinfiltrationImplicitGPU <<< gridDim, blockDim, 0 >>> (XParam, XLoop, XModel.blocks, XModel.il, XModel.cl, XModel.evolv, XModel.hgw);
 		CUDA_CHECK(cudaDeviceSynchronize());

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -80,11 +80,7 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	reset_var <<< gridDim, blockDim, 0 >>> (XParam.halowidth,XModel.blocks.active,XLoop.hugeposval,XModel.time.dtmax);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
-	if (XParam.groundwater)
-	{
-		GroundwaterCFLGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.hgw, XModel.zb, XModel.K_gw, XModel.Sy_gw, XModel.Aquifer_Depth, XModel.time.dtmax);
-		CUDA_CHECK(cudaDeviceSynchronize());
-	}
+	
 
 	//============================================
 	// Calculate gradient for evolving parameters for predictor step

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -80,7 +80,11 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	reset_var <<< gridDim, blockDim, 0 >>> (XParam.halowidth,XModel.blocks.active,XLoop.hugeposval,XModel.time.dtmax);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
-	
+	if (XParam.groundwater)
+	{
+		GroundwaterCFLGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.hgw, XModel.zb, XModel.K_gw, XModel.Sy_gw, XModel.Aquifer_Depth, XModel.time.dtmax);
+		CUDA_CHECK(cudaDeviceSynchronize());
+	}
 
 	//============================================
 	// Calculate gradient for evolving parameters for predictor step

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -80,6 +80,12 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	reset_var <<< gridDim, blockDim, 0 >>> (XParam.halowidth,XModel.blocks.active,XLoop.hugeposval,XModel.time.dtmax);
 	CUDA_CHECK(cudaDeviceSynchronize());
 
+	if (XParam.groundwater)
+	{
+		GroundwaterCFLGPU <<< gridDim, blockDim, 0 >>> (XParam, XModel.blocks, XModel.hgw, XModel.zb, XModel.K_gw, XModel.Sy_gw, XModel.Aquifer_Depth, XModel.time.dtmax);
+		CUDA_CHECK(cudaDeviceSynchronize());
+	}
+
 	//============================================
 	// Calculate gradient for evolving parameters for predictor step
 	gradientGPUnew(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.zb);

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -235,15 +235,15 @@ struct Forcing
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> Aquifer_Depth;
+	StaticForcingP<T> zb_gw;
 	/*Aquifer depth map (m)
 	Ex: Aquifer_Depth=Aquifer_Depth.nc?depth;
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> hgw_init;
+	StaticForcingP<T> zs_gw_init;
 	/*Initial groundwater elevation map (m)
-	Ex: hgw_init=hgw_init.nc?hgw;
+	Ex: zgw_init=zgw_init.nc?zgw;
 	Default: (see constant in parameters)
 	*/
 

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -235,21 +235,15 @@ struct Forcing
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> Aquifer_Depth;
+	StaticForcingP<T> zb_gw;
 	/*Aquifer depth map (m)
 	Ex: Aquifer_Depth=Aquifer_Depth.nc?depth;
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> zb_gw;
-	/*Aquifer bed elevation map (m)
-	Ex: zb_gw=zb_gw.nc?zb;
-	Default: (topo - Aquifer_Depth)
-	*/
-
-	StaticForcingP<T> hgw_init;
+	StaticForcingP<T> zs_gw_init;
 	/*Initial groundwater elevation map (m)
-	Ex: hgw_init=hgw_init.nc?hgw;
+	Ex: zgw_init=zgw_init.nc?zgw;
 	Default: (see constant in parameters)
 	*/
 

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -217,6 +217,36 @@ struct Forcing
 	Default: (see constant in parameters)
 	*/
 
+	StaticForcingP<T> K_gw;
+	/*Hydraulic conductivity map (m/s)
+	Ex: K_gw=K_gw.nc?K;
+	Default: (see constant in parameters)
+	*/
+
+	StaticForcingP<T> fs_gw;
+	/*Saturated infiltration rate map (m/s)
+	Ex: fs_gw=fs_gw.nc?fs;
+	Default: (see constant in parameters)
+	*/
+
+	StaticForcingP<T> Sy_gw;
+	/*Specific yield map
+	Ex: Sy_gw=Sy_gw.nc?Sy;
+	Default: (see constant in parameters)
+	*/
+
+	StaticForcingP<T> Aquifer_Depth;
+	/*Aquifer depth map (m)
+	Ex: Aquifer_Depth=Aquifer_Depth.nc?depth;
+	Default: (see constant in parameters)
+	*/
+
+	StaticForcingP<T> hgw_init;
+	/*Initial groundwater elevation map (m)
+	Ex: hgw_init=hgw_init.nc?hgw;
+	Default: (see constant in parameters)
+	*/
+
 	std::vector<StaticForcingP<int>> targetadapt;
 
 	std::vector<deformmap<T>> deform;

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -235,15 +235,21 @@ struct Forcing
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> zb_gw;
+	StaticForcingP<T> Aquifer_Depth;
 	/*Aquifer depth map (m)
 	Ex: Aquifer_Depth=Aquifer_Depth.nc?depth;
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> zs_gw_init;
+	StaticForcingP<T> zb_gw;
+	/*Aquifer bed elevation map (m)
+	Ex: zb_gw=zb_gw.nc?zb;
+	Default: (topo - Aquifer_Depth)
+	*/
+
+	StaticForcingP<T> hgw_init;
 	/*Initial groundwater elevation map (m)
-	Ex: zgw_init=zgw_init.nc?zgw;
+	Ex: hgw_init=hgw_init.nc?hgw;
 	Default: (see constant in parameters)
 	*/
 

--- a/src/Forcing.h
+++ b/src/Forcing.h
@@ -235,15 +235,15 @@ struct Forcing
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> zb_gw;
+	StaticForcingP<T> Aquifer_Depth;
 	/*Aquifer depth map (m)
 	Ex: Aquifer_Depth=Aquifer_Depth.nc?depth;
 	Default: (see constant in parameters)
 	*/
 
-	StaticForcingP<T> zs_gw_init;
+	StaticForcingP<T> hgw_init;
 	/*Initial groundwater elevation map (m)
-	Ex: zgw_init=zgw_init.nc?zgw;
+	Ex: hgw_init=hgw_init.nc?hgw;
 	Default: (see constant in parameters)
 	*/
 

--- a/src/InitEvolv.cu
+++ b/src/InitEvolv.cu
@@ -548,34 +548,6 @@ int AddZSoffset(Param XParam, BlockP<T> XBlock, EvolvingP<T> &XEv, T*zb)
 	return success;
 }
 
-template <class T>
-int Inith(Param XParam, BlockP<T> XBlock, T* h_gw,T* zs_gw,T* zb_gw)
-{
-	int success = 1;
-	int ib;
-	for (int ibl = 0; ibl < XParam.nblk; ibl++)
-	{
-		ib = XBlock.active[ibl];
-		for (int j = 0; j < XParam.blkwidth; j++)
-		{
-			for (int i = 0; i < XParam.blkwidth; i++)
-			{
-				int n = memloc(XParam, i, j, ib);
-
-				zs_gw[n] = max(zs_gw[n], zb_gw[n]);
-
-				h_gw[n] = utils::max(zs_gw[n] - zb_gw[n], T(0.0));
-				
-			}
-
-		}
-	}
-
-	return success;
-}
-template int Inith<float>(Param XParam, BlockP<float> XBlock, float* h_gw, float* zs_gw, float* zb_gw);
-template int Inith<double>(Param XParam, BlockP<double> XBlock, double* h_gw, double* zs_gw, double* zb_gw);
-
 
 /**
  * @brief Read BG_Flood hotstart file and extract block attributes.

--- a/src/InitEvolv.cu
+++ b/src/InitEvolv.cu
@@ -548,6 +548,34 @@ int AddZSoffset(Param XParam, BlockP<T> XBlock, EvolvingP<T> &XEv, T*zb)
 	return success;
 }
 
+template <class T>
+int Inith(Param XParam, BlockP<T> XBlock, T* h_gw,T* zs_gw,T* zb_gw)
+{
+	int success = 1;
+	int ib;
+	for (int ibl = 0; ibl < XParam.nblk; ibl++)
+	{
+		ib = XBlock.active[ibl];
+		for (int j = 0; j < XParam.blkwidth; j++)
+		{
+			for (int i = 0; i < XParam.blkwidth; i++)
+			{
+				int n = memloc(XParam, i, j, ib);
+
+				zs_gw[n] = max(zs_gw[n], zb_gw[n]);
+
+				h_gw[n] = utils::max(zs_gw[n] - zb_gw[n], T(0.0));
+				
+			}
+
+		}
+	}
+
+	return success;
+}
+template int Inith<float>(Param XParam, BlockP<float> XBlock, float* h_gw, float* zs_gw, float* zb_gw);
+template int Inith<double>(Param XParam, BlockP<double> XBlock, double* h_gw, double* zs_gw, double* zb_gw);
+
 
 /**
  * @brief Read BG_Flood hotstart file and extract block attributes.

--- a/src/InitEvolv.h
+++ b/src/InitEvolv.h
@@ -22,7 +22,5 @@ template <class T> int AddZSoffset(Param XParam, BlockP<T> XBlock, EvolvingP<T>&
 
 template <class T> int readhotstartfile(Param XParam, BlockP<T> XBlock, EvolvingP<T>& XEv, T*& zb);
 
-template <class T> int Inith(Param XParam, BlockP<T> XBlock, T* h_gw, T* zs_gw, T* zb_gw);
-
 // End of global definition;
 #endif

--- a/src/InitEvolv.h
+++ b/src/InitEvolv.h
@@ -22,5 +22,7 @@ template <class T> int AddZSoffset(Param XParam, BlockP<T> XBlock, EvolvingP<T>&
 
 template <class T> int readhotstartfile(Param XParam, BlockP<T> XBlock, EvolvingP<T>& XEv, T*& zb);
 
+template <class T> int Inith(Param XParam, BlockP<T> XBlock, T* h_gw, T* zs_gw, T* zb_gw);
+
 // End of global definition;
 #endif

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -145,7 +145,7 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk * XParam.blksize, 1, XModel.hgw, XModel.zb);
+			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.hgw, XModel.zb);
 		}
 
 		// Initialise fluxes to 0

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -114,6 +114,53 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	}
 
 	//=====================================
+	// Initialise groundwater parameters map
+	if (XParam.groundwater)
+	{
+		log("\tInitializing groundwater parameters");
+		if (!XForcing.K_gw.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.K_gw);
+		else
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.K_gw);
+
+		if (!XForcing.fs_gw.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.fs_gw);
+		else
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.fs_gw);
+
+		if (!XForcing.Sy_gw.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.Sy_gw);
+		else
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.Sy_gw);
+
+		if (!XForcing.Aquifer_Depth.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.Aquifer_Depth, XModel.Aquifer_Depth);
+		else
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.Aquifer_Depth);
+
+		if (!XForcing.hgw_init.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.hgw_init, XModel.hgw);
+		else if (!std::isnan(XParam.hgw_init))
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.hgw);
+		else
+		{
+			// Default: hgw = zb (saturated to the surface)
+			Copy2CartCPU(XParam.nblk * XParam.blksize, XModel.hgw, XModel.zb);
+		}
+
+		// Initialise fluxes to 0
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qx);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qy);
+
+		// Set edges for all groundwater parameters
+		setedges(XParam, XModel.blocks, XModel.K_gw);
+		setedges(XParam, XModel.blocks, XModel.fs_gw);
+		setedges(XParam, XModel.blocks, XModel.Sy_gw);
+		setedges(XParam, XModel.blocks, XModel.Aquifer_Depth);
+		setedges(XParam, XModel.blocks, XModel.hgw);
+	}
+
+	//=====================================
 	// Initialize output variables
 	initoutput(XParam, XModel);
 
@@ -891,6 +938,23 @@ template<class T> void Initmaparray(Model<T>& XModel)
 	XModel.OutputVarMap["twet"] = XModel.wettime;
 	XModel.Outvarlongname["twet"] = "time since the cell has been wet";
 	XModel.Outvarunits["twet"] = "s";
+
+	XModel.OutputVarMap["K_gw"] = XModel.K_gw;
+	XModel.Outvarlongname["K_gw"] = "Groundwater hydraulic conductivity";
+	XModel.Outvarunits["K_gw"] = "m s-1";
+
+	XModel.OutputVarMap["fs_gw"] = XModel.fs_gw;
+	XModel.Outvarlongname["fs_gw"] = "Saturated infiltration rate";
+	XModel.Outvarunits["fs_gw"] = "m s-1";
+
+	XModel.OutputVarMap["Sy_gw"] = XModel.Sy_gw;
+	XModel.Outvarlongname["Sy_gw"] = "Specific yield";
+	XModel.Outvarunits["Sy_gw"] = "dimensionless";
+
+	XModel.OutputVarMap["Aquifer_Depth"] = XModel.Aquifer_Depth;
+	XModel.Outvarlongname["Aquifer_Depth"] = "Aquifer depth to bed";
+	XModel.Outvarunits["Aquifer_Depth"] = "m";
+
 	//XModel.OutputVarMap["vort"] = XModel.vort;
 }
 

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -119,45 +119,47 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	{
 		log("\tInitializing groundwater parameters");
 		if (!XForcing.K_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.K_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.gw.K);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.K_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.gw.K);
 
 		if (!XForcing.fs_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.fs_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.gw.fs);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.fs_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.gw.fs);
 
 		if (!XForcing.Sy_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.Sy_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.gw.Sy);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.Sy_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.gw.Sy);
 
-		if (!XForcing.Aquifer_Depth.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Aquifer_Depth, XModel.Aquifer_Depth);
+		if (!XForcing.zb_gw.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.gw.zb);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.Aquifer_Depth);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.gw.zb);
 
-		if (!XForcing.hgw_init.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.hgw_init, XModel.hgw);
+		if (!XForcing.zs_gw_init.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.zs_gw_init, XModel.gw.zs);
 		else if (!std::isnan(XParam.hgw_init))
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.hgw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.gw.zs);
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk * XParam.blksize, 1, XModel.hgw, XModel.zb);
+			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.gw.zs, XModel.zb);
 		}
 
+		Inith(XParam, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb);
+
 		// Initialise fluxes to 0
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qx);
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qy);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qx);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qy);
 
 		// Set edges for all groundwater parameters
-		setedges(XParam, XModel.blocks, XModel.K_gw);
-		setedges(XParam, XModel.blocks, XModel.fs_gw);
-		setedges(XParam, XModel.blocks, XModel.Sy_gw);
-		setedges(XParam, XModel.blocks, XModel.Aquifer_Depth);
-		setedges(XParam, XModel.blocks, XModel.hgw);
+		setedges(XParam, XModel.blocks, XModel.gw.K);
+		setedges(XParam, XModel.blocks, XModel.gw.fs);
+		setedges(XParam, XModel.blocks, XModel.gw.Sy);
+		setedges(XParam, XModel.blocks, XModel.gw.zb);
+		setedges(XParam, XModel.blocks, XModel.gw.h);
 	}
 
 	//=====================================
@@ -939,29 +941,29 @@ template<class T> void Initmaparray(Model<T>& XModel)
 	XModel.Outvarlongname["twet"] = "time since the cell has been wet";
 	XModel.Outvarunits["twet"] = "s";
 
-	XModel.OutputVarMap["K_gw"] = XModel.K_gw;
+	XModel.OutputVarMap["K_gw"] = XModel.gw.K;
 	XModel.Outvarlongname["K_gw"] = "Groundwater hydraulic conductivity";
 	XModel.Outvarunits["K_gw"] = "m s-1";
 
-	XModel.OutputVarMap["fs_gw"] = XModel.fs_gw;
+	XModel.OutputVarMap["fs_gw"] = XModel.gw.fs;
 	XModel.Outvarlongname["fs_gw"] = "Saturated infiltration rate";
 	XModel.Outvarunits["fs_gw"] = "m s-1";
 
-	XModel.OutputVarMap["Sy_gw"] = XModel.Sy_gw;
+	XModel.OutputVarMap["Sy_gw"] = XModel.gw.Sy;
 	XModel.Outvarlongname["Sy_gw"] = "Specific yield";
 	XModel.Outvarunits["Sy_gw"] = "dimensionless";
 
-	XModel.OutputVarMap["Aquifer_Depth"] = XModel.Aquifer_Depth;
-	XModel.Outvarlongname["Aquifer_Depth"] = "Aquifer depth to bed";
-	XModel.Outvarunits["Aquifer_Depth"] = "m";
+	XModel.OutputVarMap["zb_gw"] = XModel.gw.zb;
+	XModel.Outvarlongname["zb_gw"] = "Aquifer bed elevation above datum ";
+	XModel.Outvarunits["zb_gw"] = "m";
 
-	XModel.OutputVarMap["Qx"] = XModel.Qx;
-	XModel.Outvarlongname["Qx"] = "Groundwater Darcy flux in x-direction";
-	XModel.Outvarunits["Qx"] = "m2 s-1";
+	XModel.OutputVarMap["zs_gw"] = XModel.gw.zs;
+	XModel.Outvarlongname["zs_gw"] = "Aquifer water surface elevation above datum ";
+	XModel.Outvarunits["zs_gw"] = "m";
 
-	XModel.OutputVarMap["Qy"] = XModel.Qy;
-	XModel.Outvarlongname["Qy"] = "Groundwater Darcy flux in y-direction";
-	XModel.Outvarunits["Qy"] = "m2 s-1";
+	XModel.OutputVarMap["h_gw"] = XModel.gw.h;
+	XModel.Outvarlongname["h_gw"] = "Aquifer thickness ";
+	XModel.Outvarunits["h_gw"] = "m";
 
 	//XModel.OutputVarMap["vort"] = XModel.vort;
 }

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -118,27 +118,27 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	if (XParam.groundwater)
 	{
 		log("\tInitializing groundwater parameters");
-		if (!XForcing.K_gw.inputfile.empty())
+		if (XForcing.K_gw.nx > 0)
 			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.gw.K);
 		else
 			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.gw.K);
 
-		if (!XForcing.fs_gw.inputfile.empty())
+		if (XForcing.fs_gw.nx > 0)
 			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.gw.fs);
 		else
 			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.gw.fs);
 
-		if (!XForcing.Sy_gw.inputfile.empty())
+		if (XForcing.Sy_gw.nx > 0)
 			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.gw.Sy);
 		else
 			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.gw.Sy);
 
-		if (!XForcing.zb_gw.inputfile.empty())
+		if (XForcing.zb_gw.nx > 0)
 			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.gw.zb);
 		else
 			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.gw.zb);
 
-		if (!XForcing.zs_gw_init.inputfile.empty())
+		if (XForcing.zs_gw_init.nx > 0)
 			interp2BUQ(XParam, XModel.blocks, XForcing.zs_gw_init, XModel.gw.zs);
 		else if (!std::isnan(XParam.hgw_init))
 			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.gw.zs);

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -145,7 +145,7 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk * XParam.blksize, XModel.hgw, XModel.zb);
+			Copy2CartCPU(XParam.nblk , XParam.blksize, XModel.hgw, XModel.zb);
 		}
 
 		// Initialise fluxes to 0

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -119,59 +119,47 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	{
 		log("\tInitializing groundwater parameters");
 		if (!XForcing.K_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.K_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.gw.K);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.K_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.gw.K);
 
 		if (!XForcing.fs_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.fs_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.gw.fs);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.fs_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.gw.fs);
 
 		if (!XForcing.Sy_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.Sy_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.gw.Sy);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.Sy_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.gw.Sy);
 
-		if (!XForcing.Aquifer_Depth.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Aquifer_Depth, XModel.Aquifer_Depth);
-		else if (!XForcing.zb_gw.inputfile.empty())
-		{
-			// If zb_gw is provided, Aquifer_Depth = zb - zb_gw
-			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.Aquifer_Depth);
-			for (int ibl = 0; ibl < XParam.nblk; ibl++)
-			{
-				int ib = XModel.blocks.active[ibl];
-				for (int n = 0; n < XParam.blksize; n++)
-				{
-					int idx = n + ib * XParam.blksize;
-					XModel.Aquifer_Depth[idx] = XModel.zb[idx] - XModel.Aquifer_Depth[idx];
-				}
-			}
-		}
+		if (!XForcing.zb_gw.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.gw.zb);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.Aquifer_Depth);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.gw.zb);
 
-		if (!XForcing.hgw_init.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.hgw_init, XModel.hgw);
+		if (!XForcing.zs_gw_init.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.zs_gw_init, XModel.gw.zs);
 		else if (!std::isnan(XParam.hgw_init))
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.hgw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.gw.zs);
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk * XParam.blksize, 1, XModel.hgw, XModel.zb);
+			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.gw.zs, XModel.zb);
 		}
 
+		Inith(XParam, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb);
+
 		// Initialise fluxes to 0
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qx);
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qy);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qx);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qy);
 
 		// Set edges for all groundwater parameters
-		setedges(XParam, XModel.blocks, XModel.K_gw);
-		setedges(XParam, XModel.blocks, XModel.fs_gw);
-		setedges(XParam, XModel.blocks, XModel.Sy_gw);
-		setedges(XParam, XModel.blocks, XModel.Aquifer_Depth);
-		setedges(XParam, XModel.blocks, XModel.hgw);
+		setedges(XParam, XModel.blocks, XModel.gw.K);
+		setedges(XParam, XModel.blocks, XModel.gw.fs);
+		setedges(XParam, XModel.blocks, XModel.gw.Sy);
+		setedges(XParam, XModel.blocks, XModel.gw.zb);
+		setedges(XParam, XModel.blocks, XModel.gw.h);
 	}
 
 	//=====================================
@@ -953,29 +941,29 @@ template<class T> void Initmaparray(Model<T>& XModel)
 	XModel.Outvarlongname["twet"] = "time since the cell has been wet";
 	XModel.Outvarunits["twet"] = "s";
 
-	XModel.OutputVarMap["K_gw"] = XModel.K_gw;
+	XModel.OutputVarMap["K_gw"] = XModel.gw.K;
 	XModel.Outvarlongname["K_gw"] = "Groundwater hydraulic conductivity";
 	XModel.Outvarunits["K_gw"] = "m s-1";
 
-	XModel.OutputVarMap["fs_gw"] = XModel.fs_gw;
+	XModel.OutputVarMap["fs_gw"] = XModel.gw.fs;
 	XModel.Outvarlongname["fs_gw"] = "Saturated infiltration rate";
 	XModel.Outvarunits["fs_gw"] = "m s-1";
 
-	XModel.OutputVarMap["Sy_gw"] = XModel.Sy_gw;
+	XModel.OutputVarMap["Sy_gw"] = XModel.gw.Sy;
 	XModel.Outvarlongname["Sy_gw"] = "Specific yield";
 	XModel.Outvarunits["Sy_gw"] = "dimensionless";
 
-	XModel.OutputVarMap["Aquifer_Depth"] = XModel.Aquifer_Depth;
-	XModel.Outvarlongname["Aquifer_Depth"] = "Aquifer depth to bed";
-	XModel.Outvarunits["Aquifer_Depth"] = "m";
+	XModel.OutputVarMap["zb_gw"] = XModel.gw.zb;
+	XModel.Outvarlongname["zb_gw"] = "Aquifer bed elevation above datum ";
+	XModel.Outvarunits["zb_gw"] = "m";
 
-	XModel.OutputVarMap["Qx"] = XModel.Qx;
-	XModel.Outvarlongname["Qx"] = "Groundwater Darcy flux in x-direction";
-	XModel.Outvarunits["Qx"] = "m2 s-1";
+	XModel.OutputVarMap["zs_gw"] = XModel.gw.zs;
+	XModel.Outvarlongname["zs_gw"] = "Aquifer water surface elevation above datum ";
+	XModel.Outvarunits["zs_gw"] = "m";
 
-	XModel.OutputVarMap["Qy"] = XModel.Qy;
-	XModel.Outvarlongname["Qy"] = "Groundwater Darcy flux in y-direction";
-	XModel.Outvarunits["Qy"] = "m2 s-1";
+	XModel.OutputVarMap["h_gw"] = XModel.gw.h;
+	XModel.Outvarlongname["h_gw"] = "Aquifer thickness ";
+	XModel.Outvarunits["h_gw"] = "m";
 
 	//XModel.OutputVarMap["vort"] = XModel.vort;
 }

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -119,45 +119,47 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	{
 		log("\tInitializing groundwater parameters");
 		if (!XForcing.K_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.K_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.gw.K);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.K_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.gw.K);
 
 		if (!XForcing.fs_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.fs_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.gw.fs);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.fs_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.gw.fs);
 
 		if (!XForcing.Sy_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.Sy_gw);
+			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.gw.Sy);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.Sy_gw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.gw.Sy);
 
-		if (!XForcing.Aquifer_Depth.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Aquifer_Depth, XModel.Aquifer_Depth);
+		if (!XForcing.zb_gw.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.gw.zb);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.Aquifer_Depth);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.gw.zb);
 
-		if (!XForcing.hgw_init.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.hgw_init, XModel.hgw);
+		if (!XForcing.zs_gw_init.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.zs_gw_init, XModel.gw.zs);
 		else if (!std::isnan(XParam.hgw_init))
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.hgw);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.gw.zs);
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.hgw, XModel.zb);
+			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.gw.zs, XModel.zb);
 		}
 
+		Inith(XParam, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb);
+
 		// Initialise fluxes to 0
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qx);
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qy);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qx);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qy);
 
 		// Set edges for all groundwater parameters
-		setedges(XParam, XModel.blocks, XModel.K_gw);
-		setedges(XParam, XModel.blocks, XModel.fs_gw);
-		setedges(XParam, XModel.blocks, XModel.Sy_gw);
-		setedges(XParam, XModel.blocks, XModel.Aquifer_Depth);
-		setedges(XParam, XModel.blocks, XModel.hgw);
+		setedges(XParam, XModel.blocks, XModel.gw.K);
+		setedges(XParam, XModel.blocks, XModel.gw.fs);
+		setedges(XParam, XModel.blocks, XModel.gw.Sy);
+		setedges(XParam, XModel.blocks, XModel.gw.zb);
+		setedges(XParam, XModel.blocks, XModel.gw.h);
 	}
 
 	//=====================================
@@ -939,21 +941,29 @@ template<class T> void Initmaparray(Model<T>& XModel)
 	XModel.Outvarlongname["twet"] = "time since the cell has been wet";
 	XModel.Outvarunits["twet"] = "s";
 
-	XModel.OutputVarMap["K_gw"] = XModel.K_gw;
+	XModel.OutputVarMap["K_gw"] = XModel.gw.K;
 	XModel.Outvarlongname["K_gw"] = "Groundwater hydraulic conductivity";
 	XModel.Outvarunits["K_gw"] = "m s-1";
 
-	XModel.OutputVarMap["fs_gw"] = XModel.fs_gw;
+	XModel.OutputVarMap["fs_gw"] = XModel.gw.fs;
 	XModel.Outvarlongname["fs_gw"] = "Saturated infiltration rate";
 	XModel.Outvarunits["fs_gw"] = "m s-1";
 
-	XModel.OutputVarMap["Sy_gw"] = XModel.Sy_gw;
+	XModel.OutputVarMap["Sy_gw"] = XModel.gw.Sy;
 	XModel.Outvarlongname["Sy_gw"] = "Specific yield";
 	XModel.Outvarunits["Sy_gw"] = "dimensionless";
 
-	XModel.OutputVarMap["Aquifer_Depth"] = XModel.Aquifer_Depth;
-	XModel.Outvarlongname["Aquifer_Depth"] = "Aquifer depth to bed";
-	XModel.Outvarunits["Aquifer_Depth"] = "m";
+	XModel.OutputVarMap["zb_gw"] = XModel.gw.zb;
+	XModel.Outvarlongname["zb_gw"] = "Aquifer bed elevation above datum ";
+	XModel.Outvarunits["zb_gw"] = "m";
+
+	XModel.OutputVarMap["zs_gw"] = XModel.gw.zs;
+	XModel.Outvarlongname["zs_gw"] = "Aquifer water surface elevation above datum ";
+	XModel.Outvarunits["zs_gw"] = "m";
+
+	XModel.OutputVarMap["h_gw"] = XModel.gw.h;
+	XModel.Outvarlongname["h_gw"] = "Aquifer thickness ";
+	XModel.Outvarunits["h_gw"] = "m";
 
 	//XModel.OutputVarMap["vort"] = XModel.vort;
 }

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -119,47 +119,59 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	{
 		log("\tInitializing groundwater parameters");
 		if (!XForcing.K_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.gw.K);
+			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.K_gw);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.gw.K);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.K_gw);
 
 		if (!XForcing.fs_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.gw.fs);
+			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.fs_gw);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.gw.fs);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.fs_gw);
 
 		if (!XForcing.Sy_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.gw.Sy);
+			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.Sy_gw);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.gw.Sy);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.Sy_gw);
 
-		if (!XForcing.zb_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.gw.zb);
+		if (!XForcing.Aquifer_Depth.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.Aquifer_Depth, XModel.Aquifer_Depth);
+		else if (!XForcing.zb_gw.inputfile.empty())
+		{
+			// If zb_gw is provided, Aquifer_Depth = zb - zb_gw
+			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.Aquifer_Depth);
+			for (int ibl = 0; ibl < XParam.nblk; ibl++)
+			{
+				int ib = XModel.blocks.active[ibl];
+				for (int n = 0; n < XParam.blksize; n++)
+				{
+					int idx = n + ib * XParam.blksize;
+					XModel.Aquifer_Depth[idx] = XModel.zb[idx] - XModel.Aquifer_Depth[idx];
+				}
+			}
+		}
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.gw.zb);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.Aquifer_Depth);
 
-		if (!XForcing.zs_gw_init.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.zs_gw_init, XModel.gw.zs);
+		if (!XForcing.hgw_init.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.hgw_init, XModel.hgw);
 		else if (!std::isnan(XParam.hgw_init))
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.gw.zs);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.hgw);
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.gw.zs, XModel.zb);
+			Copy2CartCPU(XParam.nblk * XParam.blksize, 1, XModel.hgw, XModel.zb);
 		}
 
-		Inith(XParam, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb);
-
 		// Initialise fluxes to 0
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qx);
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qy);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qx);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qy);
 
 		// Set edges for all groundwater parameters
-		setedges(XParam, XModel.blocks, XModel.gw.K);
-		setedges(XParam, XModel.blocks, XModel.gw.fs);
-		setedges(XParam, XModel.blocks, XModel.gw.Sy);
-		setedges(XParam, XModel.blocks, XModel.gw.zb);
-		setedges(XParam, XModel.blocks, XModel.gw.h);
+		setedges(XParam, XModel.blocks, XModel.K_gw);
+		setedges(XParam, XModel.blocks, XModel.fs_gw);
+		setedges(XParam, XModel.blocks, XModel.Sy_gw);
+		setedges(XParam, XModel.blocks, XModel.Aquifer_Depth);
+		setedges(XParam, XModel.blocks, XModel.hgw);
 	}
 
 	//=====================================
@@ -941,29 +953,29 @@ template<class T> void Initmaparray(Model<T>& XModel)
 	XModel.Outvarlongname["twet"] = "time since the cell has been wet";
 	XModel.Outvarunits["twet"] = "s";
 
-	XModel.OutputVarMap["K_gw"] = XModel.gw.K;
+	XModel.OutputVarMap["K_gw"] = XModel.K_gw;
 	XModel.Outvarlongname["K_gw"] = "Groundwater hydraulic conductivity";
 	XModel.Outvarunits["K_gw"] = "m s-1";
 
-	XModel.OutputVarMap["fs_gw"] = XModel.gw.fs;
+	XModel.OutputVarMap["fs_gw"] = XModel.fs_gw;
 	XModel.Outvarlongname["fs_gw"] = "Saturated infiltration rate";
 	XModel.Outvarunits["fs_gw"] = "m s-1";
 
-	XModel.OutputVarMap["Sy_gw"] = XModel.gw.Sy;
+	XModel.OutputVarMap["Sy_gw"] = XModel.Sy_gw;
 	XModel.Outvarlongname["Sy_gw"] = "Specific yield";
 	XModel.Outvarunits["Sy_gw"] = "dimensionless";
 
-	XModel.OutputVarMap["zb_gw"] = XModel.gw.zb;
-	XModel.Outvarlongname["zb_gw"] = "Aquifer bed elevation above datum ";
-	XModel.Outvarunits["zb_gw"] = "m";
+	XModel.OutputVarMap["Aquifer_Depth"] = XModel.Aquifer_Depth;
+	XModel.Outvarlongname["Aquifer_Depth"] = "Aquifer depth to bed";
+	XModel.Outvarunits["Aquifer_Depth"] = "m";
 
-	XModel.OutputVarMap["zs_gw"] = XModel.gw.zs;
-	XModel.Outvarlongname["zs_gw"] = "Aquifer water surface elevation above datum ";
-	XModel.Outvarunits["zs_gw"] = "m";
+	XModel.OutputVarMap["Qx"] = XModel.Qx;
+	XModel.Outvarlongname["Qx"] = "Groundwater Darcy flux in x-direction";
+	XModel.Outvarunits["Qx"] = "m2 s-1";
 
-	XModel.OutputVarMap["h_gw"] = XModel.gw.h;
-	XModel.Outvarlongname["h_gw"] = "Aquifer thickness ";
-	XModel.Outvarunits["h_gw"] = "m";
+	XModel.OutputVarMap["Qy"] = XModel.Qy;
+	XModel.Outvarlongname["Qy"] = "Groundwater Darcy flux in y-direction";
+	XModel.Outvarunits["Qy"] = "m2 s-1";
 
 	//XModel.OutputVarMap["vort"] = XModel.vort;
 }

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -145,7 +145,7 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk , XParam.blksize, XModel.hgw, XModel.zb);
+			Copy2CartCPU(XParam.nblk * XParam.blksize, 1, XModel.hgw, XModel.zb);
 		}
 
 		// Initialise fluxes to 0

--- a/src/InitialConditions.cu
+++ b/src/InitialConditions.cu
@@ -119,47 +119,45 @@ template <class T> void InitialConditions(Param &XParam, Forcing<float> &XForcin
 	{
 		log("\tInitializing groundwater parameters");
 		if (!XForcing.K_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.gw.K);
+			interp2BUQ(XParam, XModel.blocks, XForcing.K_gw, XModel.K_gw);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.gw.K);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.K_gw, XModel.K_gw);
 
 		if (!XForcing.fs_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.gw.fs);
+			interp2BUQ(XParam, XModel.blocks, XForcing.fs_gw, XModel.fs_gw);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.gw.fs);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.fs_gw, XModel.fs_gw);
 
 		if (!XForcing.Sy_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.gw.Sy);
+			interp2BUQ(XParam, XModel.blocks, XForcing.Sy_gw, XModel.Sy_gw);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.gw.Sy);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Sy_gw, XModel.Sy_gw);
 
-		if (!XForcing.zb_gw.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.zb_gw, XModel.gw.zb);
+		if (!XForcing.Aquifer_Depth.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.Aquifer_Depth, XModel.Aquifer_Depth);
 		else
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.gw.zb);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.Aquifer_Depth, XModel.Aquifer_Depth);
 
-		if (!XForcing.zs_gw_init.inputfile.empty())
-			interp2BUQ(XParam, XModel.blocks, XForcing.zs_gw_init, XModel.gw.zs);
+		if (!XForcing.hgw_init.inputfile.empty())
+			interp2BUQ(XParam, XModel.blocks, XForcing.hgw_init, XModel.hgw);
 		else if (!std::isnan(XParam.hgw_init))
-			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.gw.zs);
+			InitArrayBUQ(XParam, XModel.blocks, (T)XParam.hgw_init, XModel.hgw);
 		else
 		{
 			// Default: hgw = zb (saturated to the surface)
-			Copy2CartCPU(XParam.nblk, XParam.blksize, XModel.gw.zs, XModel.zb);
+			Copy2CartCPU(XParam.nblk * XParam.blksize, 1, XModel.hgw, XModel.zb);
 		}
 
-		Inith(XParam, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb);
-
 		// Initialise fluxes to 0
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qx);
-		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.gw.Qy);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qx);
+		InitArrayBUQ(XParam, XModel.blocks, T(0.0), XModel.Qy);
 
 		// Set edges for all groundwater parameters
-		setedges(XParam, XModel.blocks, XModel.gw.K);
-		setedges(XParam, XModel.blocks, XModel.gw.fs);
-		setedges(XParam, XModel.blocks, XModel.gw.Sy);
-		setedges(XParam, XModel.blocks, XModel.gw.zb);
-		setedges(XParam, XModel.blocks, XModel.gw.h);
+		setedges(XParam, XModel.blocks, XModel.K_gw);
+		setedges(XParam, XModel.blocks, XModel.fs_gw);
+		setedges(XParam, XModel.blocks, XModel.Sy_gw);
+		setedges(XParam, XModel.blocks, XModel.Aquifer_Depth);
+		setedges(XParam, XModel.blocks, XModel.hgw);
 	}
 
 	//=====================================
@@ -941,29 +939,29 @@ template<class T> void Initmaparray(Model<T>& XModel)
 	XModel.Outvarlongname["twet"] = "time since the cell has been wet";
 	XModel.Outvarunits["twet"] = "s";
 
-	XModel.OutputVarMap["K_gw"] = XModel.gw.K;
+	XModel.OutputVarMap["K_gw"] = XModel.K_gw;
 	XModel.Outvarlongname["K_gw"] = "Groundwater hydraulic conductivity";
 	XModel.Outvarunits["K_gw"] = "m s-1";
 
-	XModel.OutputVarMap["fs_gw"] = XModel.gw.fs;
+	XModel.OutputVarMap["fs_gw"] = XModel.fs_gw;
 	XModel.Outvarlongname["fs_gw"] = "Saturated infiltration rate";
 	XModel.Outvarunits["fs_gw"] = "m s-1";
 
-	XModel.OutputVarMap["Sy_gw"] = XModel.gw.Sy;
+	XModel.OutputVarMap["Sy_gw"] = XModel.Sy_gw;
 	XModel.Outvarlongname["Sy_gw"] = "Specific yield";
 	XModel.Outvarunits["Sy_gw"] = "dimensionless";
 
-	XModel.OutputVarMap["zb_gw"] = XModel.gw.zb;
-	XModel.Outvarlongname["zb_gw"] = "Aquifer bed elevation above datum ";
-	XModel.Outvarunits["zb_gw"] = "m";
+	XModel.OutputVarMap["Aquifer_Depth"] = XModel.Aquifer_Depth;
+	XModel.Outvarlongname["Aquifer_Depth"] = "Aquifer depth to bed";
+	XModel.Outvarunits["Aquifer_Depth"] = "m";
 
-	XModel.OutputVarMap["zs_gw"] = XModel.gw.zs;
-	XModel.Outvarlongname["zs_gw"] = "Aquifer water surface elevation above datum ";
-	XModel.Outvarunits["zs_gw"] = "m";
+	XModel.OutputVarMap["Qx"] = XModel.Qx;
+	XModel.Outvarlongname["Qx"] = "Groundwater Darcy flux in x-direction";
+	XModel.Outvarunits["Qx"] = "m2 s-1";
 
-	XModel.OutputVarMap["h_gw"] = XModel.gw.h;
-	XModel.Outvarlongname["h_gw"] = "Aquifer thickness ";
-	XModel.Outvarunits["h_gw"] = "m";
+	XModel.OutputVarMap["Qy"] = XModel.Qy;
+	XModel.Outvarlongname["Qy"] = "Groundwater Darcy flux in y-direction";
+	XModel.Outvarunits["Qy"] = "m2 s-1";
 
 	//XModel.OutputVarMap["vort"] = XModel.vort;
 }

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -296,14 +296,12 @@ void AllocateCPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	if (XParam.groundwater)
 	{
-		AllocateCPU(nblk, blksize, XModel.gw.h);
-		AllocateCPU(nblk, blksize, XModel.gw.zs);
-		AllocateCPU(nblk, blksize, XModel.gw.K);
-		AllocateCPU(nblk, blksize, XModel.gw.fs);
-		AllocateCPU(nblk, blksize, XModel.gw.Sy);
-		AllocateCPU(nblk, blksize, XModel.gw.zb);
-		AllocateCPU(nblk, blksize, XModel.gw.Qx);
-		AllocateCPU(nblk, blksize, XModel.gw.Qy);
+		AllocateCPU(nblk, blksize, XModel.K_gw);
+		AllocateCPU(nblk, blksize, XModel.fs_gw);
+		AllocateCPU(nblk, blksize, XModel.Sy_gw);
+		AllocateCPU(nblk, blksize, XModel.Aquifer_Depth);
+		AllocateCPU(nblk, blksize, XModel.Qx);
+		AllocateCPU(nblk, blksize, XModel.Qy);
 	}
 
 	if (XParam.outmax)
@@ -556,14 +554,12 @@ void ReallocArray(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	if (XParam.groundwater)
 	{
-		ReallocArray(nblk, blksize, XModel.gw.K);
-		ReallocArray(nblk, blksize, XModel.gw.fs);
-		ReallocArray(nblk, blksize, XModel.gw.Sy);
-		ReallocArray(nblk, blksize, XModel.gw.zb);
-		ReallocArray(nblk, blksize, XModel.gw.zs);
-		ReallocArray(nblk, blksize, XModel.gw.h);
-		ReallocArray(nblk, blksize, XModel.gw.Qx);
-		ReallocArray(nblk, blksize, XModel.gw.Qy);
+		ReallocArray(nblk, blksize, XModel.K_gw);
+		ReallocArray(nblk, blksize, XModel.fs_gw);
+		ReallocArray(nblk, blksize, XModel.Sy_gw);
+		ReallocArray(nblk, blksize, XModel.Aquifer_Depth);
+		ReallocArray(nblk, blksize, XModel.Qx);
+		ReallocArray(nblk, blksize, XModel.Qy);
 	}
 
 	if (XParam.outmax)
@@ -885,14 +881,12 @@ void AllocateGPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	if (XParam.groundwater)
 	{
-		AllocateGPU(nblk, blksize, XModel.gw.h);
-		AllocateGPU(nblk, blksize, XModel.gw.zs);
-		AllocateGPU(nblk, blksize, XModel.gw.K);
-		AllocateGPU(nblk, blksize, XModel.gw.fs);
-		AllocateGPU(nblk, blksize, XModel.gw.Sy);
-		AllocateGPU(nblk, blksize, XModel.gw.zb);
-		AllocateGPU(nblk, blksize, XModel.gw.Qx);
-		AllocateGPU(nblk, blksize, XModel.gw.Qy);
+		AllocateGPU(nblk, blksize, XModel.K_gw);
+		AllocateGPU(nblk, blksize, XModel.fs_gw);
+		AllocateGPU(nblk, blksize, XModel.Sy_gw);
+		AllocateGPU(nblk, blksize, XModel.Aquifer_Depth);
+		AllocateGPU(nblk, blksize, XModel.Qx);
+		AllocateGPU(nblk, blksize, XModel.Qy);
 	}
 
 	if (XParam.outmax)

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -296,12 +296,14 @@ void AllocateCPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	if (XParam.groundwater)
 	{
-		AllocateCPU(nblk, blksize, XModel.K_gw);
-		AllocateCPU(nblk, blksize, XModel.fs_gw);
-		AllocateCPU(nblk, blksize, XModel.Sy_gw);
-		AllocateCPU(nblk, blksize, XModel.Aquifer_Depth);
-		AllocateCPU(nblk, blksize, XModel.Qx);
-		AllocateCPU(nblk, blksize, XModel.Qy);
+		AllocateCPU(nblk, blksize, XModel.gw.h);
+		AllocateCPU(nblk, blksize, XModel.gw.zs);
+		AllocateCPU(nblk, blksize, XModel.gw.K);
+		AllocateCPU(nblk, blksize, XModel.gw.fs);
+		AllocateCPU(nblk, blksize, XModel.gw.Sy);
+		AllocateCPU(nblk, blksize, XModel.gw.zb);
+		AllocateCPU(nblk, blksize, XModel.gw.Qx);
+		AllocateCPU(nblk, blksize, XModel.gw.Qy);
 	}
 
 	if (XParam.outmax)
@@ -554,12 +556,14 @@ void ReallocArray(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	if (XParam.groundwater)
 	{
-		ReallocArray(nblk, blksize, XModel.K_gw);
-		ReallocArray(nblk, blksize, XModel.fs_gw);
-		ReallocArray(nblk, blksize, XModel.Sy_gw);
-		ReallocArray(nblk, blksize, XModel.Aquifer_Depth);
-		ReallocArray(nblk, blksize, XModel.Qx);
-		ReallocArray(nblk, blksize, XModel.Qy);
+		ReallocArray(nblk, blksize, XModel.gw.K);
+		ReallocArray(nblk, blksize, XModel.gw.fs);
+		ReallocArray(nblk, blksize, XModel.gw.Sy);
+		ReallocArray(nblk, blksize, XModel.gw.zb);
+		ReallocArray(nblk, blksize, XModel.gw.zs);
+		ReallocArray(nblk, blksize, XModel.gw.h);
+		ReallocArray(nblk, blksize, XModel.gw.Qx);
+		ReallocArray(nblk, blksize, XModel.gw.Qy);
 	}
 
 	if (XParam.outmax)
@@ -881,12 +885,14 @@ void AllocateGPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 
 	if (XParam.groundwater)
 	{
-		AllocateGPU(nblk, blksize, XModel.K_gw);
-		AllocateGPU(nblk, blksize, XModel.fs_gw);
-		AllocateGPU(nblk, blksize, XModel.Sy_gw);
-		AllocateGPU(nblk, blksize, XModel.Aquifer_Depth);
-		AllocateGPU(nblk, blksize, XModel.Qx);
-		AllocateGPU(nblk, blksize, XModel.Qy);
+		AllocateGPU(nblk, blksize, XModel.gw.h);
+		AllocateGPU(nblk, blksize, XModel.gw.zs);
+		AllocateGPU(nblk, blksize, XModel.gw.K);
+		AllocateGPU(nblk, blksize, XModel.gw.fs);
+		AllocateGPU(nblk, blksize, XModel.gw.Sy);
+		AllocateGPU(nblk, blksize, XModel.gw.zb);
+		AllocateGPU(nblk, blksize, XModel.gw.Qx);
+		AllocateGPU(nblk, blksize, XModel.gw.Qy);
 	}
 
 	if (XParam.outmax)

--- a/src/MemManagement.cu
+++ b/src/MemManagement.cu
@@ -294,6 +294,16 @@ void AllocateCPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 		AllocateCPU(nblk, blksize, XModel.hgw);
 	}
 
+	if (XParam.groundwater)
+	{
+		AllocateCPU(nblk, blksize, XModel.K_gw);
+		AllocateCPU(nblk, blksize, XModel.fs_gw);
+		AllocateCPU(nblk, blksize, XModel.Sy_gw);
+		AllocateCPU(nblk, blksize, XModel.Aquifer_Depth);
+		AllocateCPU(nblk, blksize, XModel.Qx);
+		AllocateCPU(nblk, blksize, XModel.Qy);
+	}
+
 	if (XParam.outmax)
 	{
 		AllocateCPU(nblk, blksize, XModel.evmax);
@@ -540,7 +550,16 @@ void ReallocArray(int nblk, int blksize, Param XParam, Model<T>& XModel)
 		ReallocArray(nblk, blksize, XModel.il);
 		ReallocArray(nblk, blksize, XModel.cl);
 		ReallocArray(nblk, blksize, XModel.hgw);
+	}
 
+	if (XParam.groundwater)
+	{
+		ReallocArray(nblk, blksize, XModel.K_gw);
+		ReallocArray(nblk, blksize, XModel.fs_gw);
+		ReallocArray(nblk, blksize, XModel.Sy_gw);
+		ReallocArray(nblk, blksize, XModel.Aquifer_Depth);
+		ReallocArray(nblk, blksize, XModel.Qx);
+		ReallocArray(nblk, blksize, XModel.Qy);
 	}
 
 	if (XParam.outmax)
@@ -858,6 +877,16 @@ void AllocateGPU(int nblk, int blksize, Param XParam, Model<T>& XModel)
 		AllocateGPU(nblk, blksize, XModel.il);
 		AllocateGPU(nblk, blksize, XModel.cl);
 		AllocateGPU(nblk, blksize, XModel.hgw);
+	}
+
+	if (XParam.groundwater)
+	{
+		AllocateGPU(nblk, blksize, XModel.K_gw);
+		AllocateGPU(nblk, blksize, XModel.fs_gw);
+		AllocateGPU(nblk, blksize, XModel.Sy_gw);
+		AllocateGPU(nblk, blksize, XModel.Aquifer_Depth);
+		AllocateGPU(nblk, blksize, XModel.Qx);
+		AllocateGPU(nblk, blksize, XModel.Qy);
 	}
 
 	if (XParam.outmax)

--- a/src/Param.h
+++ b/src/Param.h
@@ -24,10 +24,17 @@ public:
 	double Cd = 0.002; // Wind drag coefficient
 	double il = 0.0; //Initial Loss value (if constant)
 	double cl = 0.0; //Continuous Loss value (if constant)
+
+	double K_gw = 0.0; // Hydraulic conductivity (m/s)
+	double fs_gw = 0.0; // Saturated infiltration rate (m/s)
+	double Sy_gw = 0.05; // Specific yield
+	double Aquifer_Depth = 10.0; // Aquifer depth (m)
+	double hgw_init = nan(""); // Initial groundwater elevation (m)
 	bool windforcing = false; //not working yet
 	bool atmpforcing = false;
 	bool rainforcing = false;
 	bool infiltration = false;
+	bool groundwater = false;
 
 	bool conserveElevation = false; //Switch to force the conservation of zs instead of h at the interface between coarse and fine blocks
 	bool wetdryfix = true; // Switch to remove wet/dry instability (i.e. true reoves instability and false leaves the model as is)

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,32 +382,6 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
-	// groundwater file
-
-	if (XParam.groundwater)
-	{
-		//XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.K_gw.denanval = 0.0;
-		readstaticforcing(XForcing.K_gw);
-
-		XForcing.fs_gw.denanval = 0.0;
-		readstaticforcing(XForcing.fs_gw);
-
-		XForcing.Sy_gw.denanval = 0.0;
-		readstaticforcing(XForcing.Sy_gw);
-
-		XForcing.zb_gw.denanval = 0.0;
-		readstaticforcing(XForcing.zb_gw);
-
-		XForcing.zs_gw_init.denanval = 0.0;
-		readstaticforcing(XForcing.zs_gw_init);
-		//XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		//XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		//XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		//XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
-	}
-
-	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -479,6 +453,15 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 	}
 
+	if (XParam.groundwater)
+	{
+		XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		XForcing.zb_gw = readforcinghead(XForcing.zb_gw);
+		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
 	else
 	{
 		//Error message

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,6 +382,17 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
+	// Groundwater
+	if (XParam.groundwater)
+	{
+		XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
+
+	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -451,15 +462,6 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 		denan(Sforcing.nx, Sforcing.ny, float(Sforcing.denanval), Sforcing.val);
 
-	}
-
-	if (XParam.groundwater)
-	{
-		XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
 	}
 	else
 	{

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -452,6 +452,15 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 		denan(Sforcing.nx, Sforcing.ny, float(Sforcing.denanval), Sforcing.val);
 
 	}
+
+	if (XParam.groundwater)
+	{
+		XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
 	else
 	{
 		//Error message

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,6 +382,32 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
+	// groundwater file
+
+	if (XParam.groundwater)
+	{
+		//XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.K_gw.denanval = 0.0;
+		readstaticforcing(XForcing.K_gw);
+
+		XForcing.fs_gw.denanval = 0.0;
+		readstaticforcing(XForcing.fs_gw);
+
+		XForcing.Sy_gw.denanval = 0.0;
+		readstaticforcing(XForcing.Sy_gw);
+
+		XForcing.Aquifer_Depth.denanval = 0.0;
+		readstaticforcing(XForcing.Aquifer_Depth);
+
+		XForcing.hgw_init.denanval = 0.0;
+		readstaticforcing(XForcing.hgw_init);
+		//XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		//XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		//XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		//XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
+
+	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -453,14 +479,6 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 	}
 
-	if (XParam.groundwater)
-	{
-		XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
-	}
 	else
 	{
 		//Error message

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,32 +382,6 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
-	// groundwater file
-
-	if (XParam.groundwater)
-	{
-		//XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.K_gw.denanval = 0.0;
-		readstaticforcing(XForcing.K_gw);
-
-		XForcing.fs_gw.denanval = 0.0;
-		readstaticforcing(XForcing.fs_gw);
-
-		XForcing.Sy_gw.denanval = 0.0;
-		readstaticforcing(XForcing.Sy_gw);
-
-		XForcing.zb_gw.denanval = 0.0;
-		readstaticforcing(XForcing.zb_gw);
-
-		XForcing.zs_gw_init.denanval = 0.0;
-		readstaticforcing(XForcing.zs_gw_init);
-		//XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		//XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		//XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		//XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
-	}
-
-	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -479,6 +453,14 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 	}
 
+	if (XParam.groundwater)
+	{
+		XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
 	else
 	{
 		//Error message

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,17 +382,6 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
-	// Groundwater
-	if (XParam.groundwater)
-	{
-		XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
-	}
-
-	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -462,6 +451,15 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 		denan(Sforcing.nx, Sforcing.ny, float(Sforcing.denanval), Sforcing.val);
 
+	}
+
+	if (XParam.groundwater)
+	{
+		XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
 	}
 	else
 	{

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,6 +382,32 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
+	// groundwater file
+
+	if (XParam.groundwater)
+	{
+		//XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.K_gw.denanval = 0.0;
+		readstaticforcing(XForcing.K_gw);
+
+		XForcing.fs_gw.denanval = 0.0;
+		readstaticforcing(XForcing.fs_gw);
+
+		XForcing.Sy_gw.denanval = 0.0;
+		readstaticforcing(XForcing.Sy_gw);
+
+		XForcing.zb_gw.denanval = 0.0;
+		readstaticforcing(XForcing.zb_gw);
+
+		XForcing.zs_gw_init.denanval = 0.0;
+		readstaticforcing(XForcing.zs_gw_init);
+		//XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		//XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		//XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		//XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
+
+	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -453,14 +479,6 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 	}
 
-	if (XParam.groundwater)
-	{
-		XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
-	}
 	else
 	{
 		//Error message

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -382,6 +382,32 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 	}
 
 	//======================
+	// groundwater file
+
+	if (XParam.groundwater)
+	{
+		//XForcing.K_gw = readforcinghead(XForcing.K_gw);
+		XForcing.K_gw.denanval = 0.0;
+		readstaticforcing(XForcing.K_gw);
+
+		XForcing.fs_gw.denanval = 0.0;
+		readstaticforcing(XForcing.fs_gw);
+
+		XForcing.Sy_gw.denanval = 0.0;
+		readstaticforcing(XForcing.Sy_gw);
+
+		XForcing.zb_gw.denanval = 0.0;
+		readstaticforcing(XForcing.zb_gw);
+
+		XForcing.zs_gw_init.denanval = 0.0;
+		readstaticforcing(XForcing.zs_gw_init);
+		//XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
+		//XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
+		//XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
+		//XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
+	}
+
+	//======================
 	// Polygon data
 	if (!XForcing.AOI.file.empty())
 	{
@@ -453,15 +479,6 @@ template <class T> void readstaticforcing(int step,T& Sforcing)
 
 	}
 
-	if (XParam.groundwater)
-	{
-		XForcing.K_gw = readforcinghead(XForcing.K_gw);
-		XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
-		XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
-		XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);
-		XForcing.zb_gw = readforcinghead(XForcing.zb_gw);
-		XForcing.hgw_init = readforcinghead(XForcing.hgw_init);
-	}
 	else
 	{
 		//Error message

--- a/src/ReadForcing.cu
+++ b/src/ReadForcing.cu
@@ -396,11 +396,11 @@ void readforcing(Param & XParam, Forcing<T> & XForcing)
 		XForcing.Sy_gw.denanval = 0.0;
 		readstaticforcing(XForcing.Sy_gw);
 
-		XForcing.Aquifer_Depth.denanval = 0.0;
-		readstaticforcing(XForcing.Aquifer_Depth);
+		XForcing.zb_gw.denanval = 0.0;
+		readstaticforcing(XForcing.zb_gw);
 
-		XForcing.hgw_init.denanval = 0.0;
-		readstaticforcing(XForcing.hgw_init);
+		XForcing.zs_gw_init.denanval = 0.0;
+		readstaticforcing(XForcing.zs_gw_init);
 		//XForcing.fs_gw = readforcinghead(XForcing.fs_gw);
 		//XForcing.Sy_gw = readforcinghead(XForcing.Sy_gw);
 		//XForcing.Aquifer_Depth = readforcinghead(XForcing.Aquifer_Depth);

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -305,7 +305,7 @@ Param readparamstr(std::string line, Param param)
 		param.groundwater = readparambool(parametervalue, param.groundwater);
 		if (param.groundwater) param.infiltration = true;
 	}
-
+	
 	parameterstr = "K_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -346,8 +346,8 @@ Param readparamstr(std::string line, Param param)
 		}
 	}
 
-	paramvec = { "hgw_init","zs_gw_init" };
-	parametervalue = findparameter(paramvec, line);
+	parameterstr = "hgw_init";
+	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
@@ -355,7 +355,7 @@ Param readparamstr(std::string line, Param param)
 			param.hgw_init = std::stod(parametervalue);
 		}
 	}
-
+	
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -574,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 			//Need to add more here
 
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","Aquifer_Depth" };
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","zb_gw","zs_gw","h_gw"};
 
 
 			std::string vvar = trim(vars[nv], " ");
@@ -1171,26 +1171,6 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		}
 	}
 
-	parameterstr = "Aquifer_Depth";
-	parametervalue = findparameter(parameterstr, line);
-	if (!parametervalue.empty())
-	{
-		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
-		{
-			forcing.Aquifer_Depth = readfileinfo(parametervalue, forcing.Aquifer_Depth);
-		}
-	}
-
-	paramvec = { "hgw_init","zs_gw_init" };
-	parametervalue = findparameter(paramvec, line);
-	if (!parametervalue.empty())
-	{
-		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
-		{
-			forcing.hgw_init = readfileinfo(parametervalue, forcing.hgw_init);
-		}
-	}
-
 	parameterstr = "zb_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -1198,6 +1178,16 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
 			forcing.zb_gw = readfileinfo(parametervalue, forcing.zb_gw);
+		}
+	}
+
+	parameterstr = "zs_gw_init";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.zs_gw_init = readfileinfo(parametervalue, forcing.zs_gw_init);
 		}
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -305,7 +305,7 @@ Param readparamstr(std::string line, Param param)
 		param.groundwater = readparambool(parametervalue, param.groundwater);
 		if (param.groundwater) param.infiltration = true;
 	}
-	/*
+	
 	parameterstr = "K_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -355,7 +355,7 @@ Param readparamstr(std::string line, Param param)
 			param.hgw_init = std::stod(parametervalue);
 		}
 	}
-	*/
+	
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -574,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 			//Need to add more here
 
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","Aquifer_Depth" };
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","zb_gw","zs_gw","h_gw"};
 
 
 			std::string vvar = trim(vars[nv], " ");
@@ -1171,23 +1171,23 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		}
 	}
 
-	parameterstr = "Aquifer_Depth";
+	parameterstr = "zb_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
-			forcing.Aquifer_Depth = readfileinfo(parametervalue, forcing.Aquifer_Depth);
+			forcing.zb_gw = readfileinfo(parametervalue, forcing.zb_gw);
 		}
 	}
 
-	parameterstr = "hgw_init";
+	parameterstr = "zs_gw_init";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
-			forcing.hgw_init = readfileinfo(parametervalue, forcing.hgw_init);
+			forcing.zs_gw_init = readfileinfo(parametervalue, forcing.zs_gw_init);
 		}
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -305,7 +305,7 @@ Param readparamstr(std::string line, Param param)
 		param.groundwater = readparambool(parametervalue, param.groundwater);
 		if (param.groundwater) param.infiltration = true;
 	}
-	
+
 	parameterstr = "K_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -355,7 +355,7 @@ Param readparamstr(std::string line, Param param)
 			param.hgw_init = std::stod(parametervalue);
 		}
 	}
-	
+
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -574,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 			//Need to add more here
 
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","zb_gw","zs_gw","h_gw"};
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","Aquifer_Depth","Qx","Qy" };
 
 
 			std::string vvar = trim(vars[nv], " ");
@@ -1171,23 +1171,23 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		}
 	}
 
-	parameterstr = "zb_gw";
+	parameterstr = "Aquifer_Depth";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
-			forcing.zb_gw = readfileinfo(parametervalue, forcing.zb_gw);
+			forcing.Aquifer_Depth = readfileinfo(parametervalue, forcing.Aquifer_Depth);
 		}
 	}
 
-	parameterstr = "zs_gw_init";
+	parameterstr = "hgw_init";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
-			forcing.zs_gw_init = readfileinfo(parametervalue, forcing.zs_gw_init);
+			forcing.hgw_init = readfileinfo(parametervalue, forcing.hgw_init);
 		}
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -305,7 +305,7 @@ Param readparamstr(std::string line, Param param)
 		param.groundwater = readparambool(parametervalue, param.groundwater);
 		if (param.groundwater) param.infiltration = true;
 	}
-
+	/*
 	parameterstr = "K_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -355,7 +355,7 @@ Param readparamstr(std::string line, Param param)
 			param.hgw_init = std::stod(parametervalue);
 		}
 	}
-
+	*/
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -298,6 +298,64 @@ Param readparamstr(std::string line, Param param)
 		}
 	}
 
+	parameterstr = "groundwater";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		param.groundwater = readparambool(parametervalue, param.groundwater);
+		if (param.groundwater) param.infiltration = true;
+	}
+
+	parameterstr = "K_gw";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
+		{
+			param.K_gw = std::stod(parametervalue);
+		}
+	}
+
+	parameterstr = "fs_gw";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
+		{
+			param.fs_gw = std::stod(parametervalue);
+		}
+	}
+
+	parameterstr = "Sy_gw";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
+		{
+			param.Sy_gw = std::stod(parametervalue);
+		}
+	}
+
+	parameterstr = "Aquifer_Depth";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
+		{
+			param.Aquifer_Depth = std::stod(parametervalue);
+		}
+	}
+
+	parameterstr = "hgw_init";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
+		{
+			param.hgw_init = std::stod(parametervalue);
+		}
+	}
+
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -516,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 			//Need to add more here
 
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy" };
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","Aquifer_Depth" };
 
 
 			std::string vvar = trim(vars[nv], " ");
@@ -1080,6 +1138,56 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha)) //(std::isdigit(parametervalue[0]) == false)
 		{
 			forcing.cl = readfileinfo(parametervalue, forcing.cl);
+		}
+	}
+
+	parameterstr = "K_gw";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.K_gw = readfileinfo(parametervalue, forcing.K_gw);
+		}
+	}
+
+	parameterstr = "fs_gw";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.fs_gw = readfileinfo(parametervalue, forcing.fs_gw);
+		}
+	}
+
+	parameterstr = "Sy_gw";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.Sy_gw = readfileinfo(parametervalue, forcing.Sy_gw);
+		}
+	}
+
+	parameterstr = "Aquifer_Depth";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.Aquifer_Depth = readfileinfo(parametervalue, forcing.Aquifer_Depth);
+		}
+	}
+
+	parameterstr = "hgw_init";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.hgw_init = readfileinfo(parametervalue, forcing.hgw_init);
 		}
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -305,7 +305,7 @@ Param readparamstr(std::string line, Param param)
 		param.groundwater = readparambool(parametervalue, param.groundwater);
 		if (param.groundwater) param.infiltration = true;
 	}
-	
+
 	parameterstr = "K_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -346,8 +346,8 @@ Param readparamstr(std::string line, Param param)
 		}
 	}
 
-	parameterstr = "hgw_init";
-	parametervalue = findparameter(parameterstr, line);
+	paramvec = { "hgw_init","zs_gw_init" };
+	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha) == false)
@@ -355,7 +355,7 @@ Param readparamstr(std::string line, Param param)
 			param.hgw_init = std::stod(parametervalue);
 		}
 	}
-	
+
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -574,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 			//Need to add more here
 
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","zb_gw","zs_gw","h_gw"};
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","Aquifer_Depth" };
 
 
 			std::string vvar = trim(vars[nv], " ");
@@ -1171,6 +1171,26 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		}
 	}
 
+	parameterstr = "Aquifer_Depth";
+	parametervalue = findparameter(parameterstr, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.Aquifer_Depth = readfileinfo(parametervalue, forcing.Aquifer_Depth);
+		}
+	}
+
+	paramvec = { "hgw_init","zs_gw_init" };
+	parametervalue = findparameter(paramvec, line);
+	if (!parametervalue.empty())
+	{
+		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
+		{
+			forcing.hgw_init = readfileinfo(parametervalue, forcing.hgw_init);
+		}
+	}
+
 	parameterstr = "zb_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -1178,16 +1198,6 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
 			forcing.zb_gw = readfileinfo(parametervalue, forcing.zb_gw);
-		}
-	}
-
-	parameterstr = "zs_gw_init";
-	parametervalue = findparameter(parameterstr, line);
-	if (!parametervalue.empty())
-	{
-		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
-		{
-			forcing.zs_gw_init = readfileinfo(parametervalue, forcing.zs_gw_init);
 		}
 	}
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -305,7 +305,7 @@ Param readparamstr(std::string line, Param param)
 		param.groundwater = readparambool(parametervalue, param.groundwater);
 		if (param.groundwater) param.infiltration = true;
 	}
-
+	
 	parameterstr = "K_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
@@ -355,7 +355,7 @@ Param readparamstr(std::string line, Param param)
 			param.hgw_init = std::stod(parametervalue);
 		}
 	}
-
+	
 	paramvec = { "cl","Rain_cl","continuousloss" };
 	parametervalue = findparameter(paramvec, line);
 	if (!parametervalue.empty())
@@ -574,7 +574,7 @@ Param readparamstr(std::string line, Param param)
 			//Need to add more here
 
 
-			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","Aquifer_Depth","Qx","Qy" };
+			std::vector<std::string> SupportedVarNames = { "zb","zs","u","v","h","hmean","zsmean","umean","vmean","hUmean","Umean","hmax","zsmax","umax","vmax","hUmax","Umax","twet","dhdx","dhdy","dzsdx","dzsdy","dzbdx","dzbdy","dudx","dudy","dvdx","dvdy","Fhu","Fhv","Fqux","Fqvy","Fquy","Fqvx","Su","Sv","dh","dhu","dhv","cf","Patm","datmpdx","datmpdy","il","cl","hgw","hu","hv","hfu" ,"hfv","hau","hav","Fux","Fvx","Fuy","Fvy","K_gw","fs_gw","Sy_gw","zb_gw","zs_gw","h_gw"};
 
 
 			std::string vvar = trim(vars[nv], " ");
@@ -1171,23 +1171,23 @@ Forcing<T> readparamstr(std::string line, Forcing<T> forcing)
 		}
 	}
 
-	parameterstr = "Aquifer_Depth";
+	parameterstr = "zb_gw";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
-			forcing.Aquifer_Depth = readfileinfo(parametervalue, forcing.Aquifer_Depth);
+			forcing.zb_gw = readfileinfo(parametervalue, forcing.zb_gw);
 		}
 	}
 
-	parameterstr = "hgw_init";
+	parameterstr = "zs_gw_init";
 	parametervalue = findparameter(parameterstr, line);
 	if (!parametervalue.empty())
 	{
 		if (std::any_of(parametervalue.begin(), parametervalue.end(), ::isalpha))
 		{
-			forcing.hgw_init = readfileinfo(parametervalue, forcing.hgw_init);
+			forcing.zs_gw_init = readfileinfo(parametervalue, forcing.zs_gw_init);
 		}
 	}
 

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -349,12 +349,19 @@ template <class T> void CopytoGPU(int nblk, int blksize, Param XParam, Model<T> 
 
 	if (XParam.groundwater)
 	{
-		CopytoGPU(nblk, blksize, XModel_cpu.K_gw, XModel_gpu.K_gw);
-		CopytoGPU(nblk, blksize, XModel_cpu.fs_gw, XModel_gpu.fs_gw);
-		CopytoGPU(nblk, blksize, XModel_cpu.Sy_gw, XModel_gpu.Sy_gw);
-		CopytoGPU(nblk, blksize, XModel_cpu.Aquifer_Depth, XModel_gpu.Aquifer_Depth);
-		CopytoGPU(nblk, blksize, XModel_cpu.Qx, XModel_gpu.Qx);
-		CopytoGPU(nblk, blksize, XModel_cpu.Qy, XModel_gpu.Qy);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.K, XModel_gpu.gw.K);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.fs, XModel_gpu.gw.fs);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.zb, XModel_gpu.gw.zb);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.Sy, XModel_gpu.gw.Sy);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.zs, XModel_gpu.gw.zs);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.h, XModel_gpu.gw.h);
+
+		/*AllocateCPU(nblk, blksize, XModel.K_gw);
+		AllocateCPU(nblk, blksize, XModel.fs_gw);
+		AllocateCPU(nblk, blksize, XModel.Sy_gw);
+		AllocateCPU(nblk, blksize, XModel.Aquifer_Depth);
+		AllocateCPU(nblk, blksize, XModel.Qx);
+		AllocateCPU(nblk, blksize, XModel.Qy);*/
 	}
 
 	if (XParam.outmax)

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -349,19 +349,12 @@ template <class T> void CopytoGPU(int nblk, int blksize, Param XParam, Model<T> 
 
 	if (XParam.groundwater)
 	{
-		CopytoGPU(nblk, blksize, XModel_cpu.gw.K, XModel_gpu.gw.K);
-		CopytoGPU(nblk, blksize, XModel_cpu.gw.fs, XModel_gpu.gw.fs);
-		CopytoGPU(nblk, blksize, XModel_cpu.gw.zb, XModel_gpu.gw.zb);
-		CopytoGPU(nblk, blksize, XModel_cpu.gw.Sy, XModel_gpu.gw.Sy);
-		CopytoGPU(nblk, blksize, XModel_cpu.gw.zs, XModel_gpu.gw.zs);
-		CopytoGPU(nblk, blksize, XModel_cpu.gw.h, XModel_gpu.gw.h);
-
-		/*AllocateCPU(nblk, blksize, XModel.K_gw);
-		AllocateCPU(nblk, blksize, XModel.fs_gw);
-		AllocateCPU(nblk, blksize, XModel.Sy_gw);
-		AllocateCPU(nblk, blksize, XModel.Aquifer_Depth);
-		AllocateCPU(nblk, blksize, XModel.Qx);
-		AllocateCPU(nblk, blksize, XModel.Qy);*/
+		CopytoGPU(nblk, blksize, XModel_cpu.K_gw, XModel_gpu.K_gw);
+		CopytoGPU(nblk, blksize, XModel_cpu.fs_gw, XModel_gpu.fs_gw);
+		CopytoGPU(nblk, blksize, XModel_cpu.Sy_gw, XModel_gpu.Sy_gw);
+		CopytoGPU(nblk, blksize, XModel_cpu.Aquifer_Depth, XModel_gpu.Aquifer_Depth);
+		CopytoGPU(nblk, blksize, XModel_cpu.Qx, XModel_gpu.Qx);
+		CopytoGPU(nblk, blksize, XModel_cpu.Qy, XModel_gpu.Qy);
 	}
 
 	if (XParam.outmax)

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -349,10 +349,12 @@ template <class T> void CopytoGPU(int nblk, int blksize, Param XParam, Model<T> 
 
 	if (XParam.groundwater)
 	{
-		CopytoGPU(nblk, blksize, XModel_cpu.K_gw, XModel_gpu.K_gw);
-		CopytoGPU(nblk, blksize, XModel_cpu.fs_gw, XModel_gpu.fs_gw);
-		CopytoGPU(nblk, blksize, XModel_cpu.Aquifer_Depth, XModel_gpu.Aquifer_Depth);
-		CopytoGPU(nblk, blksize, XModel_cpu.Sy_gw, XModel_gpu.Sy_gw);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.K, XModel_gpu.gw.K);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.fs, XModel_gpu.gw.fs);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.zb, XModel_gpu.gw.zb);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.Sy, XModel_gpu.gw.Sy);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.zs, XModel_gpu.gw.zs);
+		CopytoGPU(nblk, blksize, XModel_cpu.gw.h, XModel_gpu.gw.h);
 
 		/*AllocateCPU(nblk, blksize, XModel.K_gw);
 		AllocateCPU(nblk, blksize, XModel.fs_gw);

--- a/src/Setup_GPU.cu
+++ b/src/Setup_GPU.cu
@@ -347,6 +347,21 @@ template <class T> void CopytoGPU(int nblk, int blksize, Param XParam, Model<T> 
 		CopytoGPU(nblk, blksize, XModel_cpu.hgw, XModel_gpu.hgw);
 	}
 
+	if (XParam.groundwater)
+	{
+		CopytoGPU(nblk, blksize, XModel_cpu.K_gw, XModel_gpu.K_gw);
+		CopytoGPU(nblk, blksize, XModel_cpu.fs_gw, XModel_gpu.fs_gw);
+		CopytoGPU(nblk, blksize, XModel_cpu.Aquifer_Depth, XModel_gpu.Aquifer_Depth);
+		CopytoGPU(nblk, blksize, XModel_cpu.Sy_gw, XModel_gpu.Sy_gw);
+
+		/*AllocateCPU(nblk, blksize, XModel.K_gw);
+		AllocateCPU(nblk, blksize, XModel.fs_gw);
+		AllocateCPU(nblk, blksize, XModel.Sy_gw);
+		AllocateCPU(nblk, blksize, XModel.Aquifer_Depth);
+		AllocateCPU(nblk, blksize, XModel.Qx);
+		AllocateCPU(nblk, blksize, XModel.Qy);*/
+	}
+
 	if (XParam.outmax)
 	{
 		CopytoGPU(nblk, blksize, XModel_cpu.evmax, XModel_gpu.evmax);

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -5187,7 +5187,7 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 	return modelgood;
 }
 
-template <class T> int TestGWmodel(T zs)
+template <class T> bool TestGWmodel(T zs)
 {
 	//
 	Param XParam;

--- a/src/Testing.cu
+++ b/src/Testing.cu
@@ -341,6 +341,17 @@ template <class T> bool Testing(Param XParam, Forcing<float> XForcing, Model<T> 
 			isfailed = (!FlexibleOutTime || isfailed) ? true : false;
 
 		}
+		if (mytest == 16)
+			/* Test 16 is to test the groundwater model egainst values computed using an analytical model
+			*/
+		{
+			bool gwtest=TestGWmodel(-10.0);
+			result = gwtest ? "successful" : "failed";
+			log("\t\t ##### \n");
+			log("\t\t ##### Groundwater test : " + result + "\n");
+			log("\t\t ##### \n");
+			isfailed = (!gwtest || isfailed) ? true : false;
+		}
 
 
 
@@ -5174,6 +5185,228 @@ template <class T> int TestAIObnd(Param XParam, Model<T> XModel, Model<T> XModel
 
 	//log("#####");
 	return modelgood;
+}
+
+template <class T> int TestGWmodel(T zs)
+{
+	//
+	Param XParam;
+	
+	log("#####");
+	
+	XParam.zsinit = -10.0;
+	XParam.zsoffset = 0.0;
+
+	//Output times for comparisons
+	XParam.endtime = 7200.0;
+	XParam.outputtimestep = 600.0;
+
+	XParam.smallnc = 0;
+
+	XParam.groundwater = true;
+
+	XParam.cf = 0.001;
+	XParam.frictionmodel = 0;
+
+	XParam.aoibnd = 0;
+
+	// Enforce GPU/CPU
+	XParam.GPUDEVICE = 1;
+	std::vector<std::string> outv = { "zb","zs","u","v","h","h_gw","K_gw","fs_gw","Sy_gw","zs_gw","zb_gw" }; //
+
+	XParam.outvars = outv;
+	// create Model setup
+	Model<T> XModel;
+	Model<T> XModel_g;
+
+	Forcing<float> XForcing;
+
+	StaticForcingP<float> bathy;
+
+	XForcing.Bathy.push_back(bathy);
+
+	// initialise forcing bathymetry to 0
+	XForcing.Bathy[0].xo = 0;
+	XForcing.Bathy[0].yo = 0;
+
+	XForcing.Bathy[0].xmax = 250.0;
+	XForcing.Bathy[0].ymax = 250.0;
+	XForcing.Bathy[0].nx = 250;
+	XForcing.Bathy[0].ny = 250;
+
+	XForcing.Bathy[0].dx = 1.0;
+	XForcing.Bathy[0].dy = XForcing.Bathy[0].dx;
+	AllocateCPU(1, 1, XForcing.left.blks, XForcing.right.blks, XForcing.top.blks, XForcing.bot.blks);
+
+	AllocateCPU(XForcing.Bathy[0].nx, XForcing.Bathy[0].ny, XForcing.Bathy[0].val);
+
+	for (int j = 0; j < XForcing.Bathy[0].ny; j++)
+	{
+		for (int i = 0; i < XForcing.Bathy[0].nx; i++)
+		{
+			XForcing.Bathy[0].val[i + j * XForcing.Bathy[0].nx] = T(-10.0);
+		}
+	}
+	//
+	//
+
+	XForcing.fs_gw.dx = 1.0;
+	XForcing.K_gw.dx = 1.0;
+	XForcing.zs_gw_init.dx = 1.0;
+	XForcing.zb_gw.dx = 1.0;
+	XForcing.Sy_gw.dx = 1.0;
+
+	XForcing.fs_gw.nx = 250;
+	XForcing.K_gw.nx = 250;
+	XForcing.zs_gw_init.nx = 250;
+	XForcing.zb_gw.nx = 250;
+	XForcing.Sy_gw.nx = 250;
+
+	XForcing.fs_gw.ny = 250;
+	XForcing.K_gw.ny = 250;
+	XForcing.zs_gw_init.ny = 250;
+	XForcing.zb_gw.ny = 250;
+	XForcing.Sy_gw.ny = 250;
+
+	XForcing.fs_gw.dy = 1.0;
+	XForcing.K_gw.dy = 1.0;
+	XForcing.zs_gw_init.dy = 1.0;
+	XForcing.zb_gw.dy = 1.0;
+	XForcing.Sy_gw.dy = 1.0;
+
+	XForcing.fs_gw.xo = 0;
+	XForcing.K_gw.xo = 0;
+	XForcing.zs_gw_init.xo = 0;
+	XForcing.zb_gw.xo = 0;
+	XForcing.Sy_gw.xo = 0;
+
+	XForcing.fs_gw.yo = 0;
+	XForcing.K_gw.yo = 0;
+	XForcing.zs_gw_init.yo = 0;
+	XForcing.zb_gw.yo = 0;
+	XForcing.Sy_gw.yo = 0;
+
+	XForcing.fs_gw.xmax = 250;
+	XForcing.K_gw.xmax = 250;
+	XForcing.zs_gw_init.xmax = 250;
+	XForcing.zb_gw.xmax = 250;
+	XForcing.Sy_gw.xmax = 250;
+
+	XForcing.fs_gw.ymax = 250;
+	XForcing.K_gw.ymax = 250;
+	XForcing.zs_gw_init.ymax = 250;
+	XForcing.zb_gw.ymax = 250;
+	XForcing.Sy_gw.ymax = 250;
+
+	AllocateCPU(XForcing.fs_gw.nx, XForcing.fs_gw.ny, XForcing.fs_gw.val);
+	AllocateCPU(XForcing.K_gw.nx, XForcing.K_gw.ny, XForcing.K_gw.val);
+	AllocateCPU(XForcing.zs_gw_init.nx, XForcing.zs_gw_init.ny, XForcing.zs_gw_init.val);
+	AllocateCPU(XForcing.zb_gw.nx, XForcing.zb_gw.ny, XForcing.zb_gw.val);
+	AllocateCPU(XForcing.Sy_gw.nx, XForcing.Sy_gw.ny, XForcing.Sy_gw.val);
+
+	for (int j = 0; j < XForcing.fs_gw.ny; j++)
+	{
+		for (int i = 0; i < XForcing.fs_gw.nx; i++)
+		{
+			XForcing.fs_gw.val[i + j * XForcing.fs_gw.nx] = T(50.0);
+			XForcing.K_gw.val[i + j * XForcing.K_gw.nx] = T(500.0/(24.0*60.0*60.0));// 500m/day in m/s
+			XForcing.zs_gw_init.val[i + j * XForcing.zs_gw_init.nx] = T(-13.0);
+			XForcing.zb_gw.val[i + j * XForcing.zb_gw.nx] = T(-15.0);
+			XForcing.Sy_gw.val[i + j * XForcing.Sy_gw.nx] = T(0.3);
+
+		}
+	}
+	double Q = 0.034720;
+
+	std::ofstream river_file(
+		"testriver.tmp", std::ios_base::out | std::ios_base::trunc);
+	river_file << "0.0 " + std::to_string(Q) << std::endl;
+	river_file << "3600.0 " + std::to_string(Q) << std::endl;
+	river_file << "3600.1 " + std::to_string(0.0) << std::endl;
+	river_file << "36000.0 " + std::to_string(0.0) << std::endl;
+	river_file.close(); //destructor implicitly does it
+
+	River thisriver;
+	thisriver.Riverflowfile = "testriver.tmp";
+	thisriver.xstart =100;
+	thisriver.xend = 150;
+	thisriver.ystart = 100;
+	thisriver.yend = 150;
+
+	XForcing.rivers.push_back(thisriver);
+
+
+	XForcing.rivers[0].flowinput = readFlowfile(XForcing.rivers[0].Riverflowfile, XParam.reftime);
+
+
+	checkparamsanity(XParam, XForcing);
+
+	InitMesh(XParam, XForcing, XModel);
+
+	InitialConditions(XParam, XForcing, XModel);
+
+	InitialAdaptation(XParam, XForcing, XModel);
+
+	SetupGPU(XParam, XModel, XForcing, XModel_g);
+
+	Loop<T> XLoop;
+
+	XLoop.hugenegval = std::numeric_limits<T>::min();
+
+	XLoop.hugeposval = std::numeric_limits<T>::max();
+	XLoop.epsilon = std::numeric_limits<T>::epsilon();
+
+	XLoop.totaltime = 0.0;
+
+	MainLoop(XParam, XForcing, XModel, XModel_g);
+
+
+
+	double xx_Verif[8] = { -60.0,-50.0,-40.0,-30.0,-20.0,-10.0,-5.0,0. };
+	double ZsGW_Verif[8] = { 2.00551,2.01393,2.02929,2.05114,2.0748,2.09302,2.09809,2.09983 };
+
+	bool modelgood = true;
+
+	int xxmodel[8] = {66,76,86,96,106,116,121,126};
+
+	for (int iv = 0; iv < 8; iv++)
+	{
+
+		int ix, iy, ib, ii, jj, ibx, iby, nbx;
+		jj = 127;
+		ii = xxmodel[iv]-1;
+
+		// Theoretical size is 255x255
+		nbx = 256 / 16;
+
+
+		ibx = ftoi(floor(ii / XParam.blkwidth));
+		iby = ftoi(floor(jj / XParam.blkwidth));
+
+		ib = (iby)*nbx + ibx;
+
+		ix = ii - ibx * XParam.blkwidth;
+		iy = jj - iby * XParam.blkwidth;
+
+		int n = memloc(XParam, ix, iy, ib);
+
+		double diff = abs(T(XModel.gw.h[n]) - ZsGW_Verif[iv]);
+		if (diff > 2e-3)//Tolerance is 2e-3 against analytical solution
+		{
+
+			printf("ib=%d, ix=%d, iy=%d; simulated=%f; expected=%f; diff=%e\n", ib, ix, iy, XModel.gw.h[n], ZsGW_Verif[iv], diff);
+			modelgood = false;
+			
+		}
+
+
+
+	}
+
+	
+
+	return modelgood;
+
 }
 
 /**

--- a/src/Testing.h
+++ b/src/Testing.h
@@ -42,6 +42,7 @@ template <class T> bool ZoneOutputTest(int nzones, T zsinit);
 template <class T> bool Rainlossestest(T zsnit, int gpu, float alpha);
 template <class T> bool TestMultiBathyRough(int gpu, T ref, int secnario);
 template <class T> bool TestFlexibleOutputTimes(int gpu, T ref, int scenario);
+template <class T> bool TestGWmodel(T zs);
 
 // End of global definition
 #endif

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -32,8 +32,8 @@ template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBl
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    T bed = zb[idx] - Aquifer_Depth[idx];
-    T thick = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed);
+    T maxbed = zb[idx] - Aquifer_Depth[idx];
+    T thick = utils::max(T(0.0), utils::min(hgw[idx],maxbed));
 
     T diffusion = (K_gw[idx] * thick) / utils::max(Sy_gw[idx], T(1e-6));
 
@@ -46,6 +46,23 @@ template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBl
 }
 template __global__ void GroundwaterCFLGPU<float>(Param XParam, BlockP<float> XBlock, float* hgw, float* zb, float* K_gw, float* Sy_gw, float* Aquifer_Depth, float* dtmax);
 template __global__ void GroundwaterCFLGPU<double>(Param XParam, BlockP<double> XBlock, double* hgw, double* zb, double* K_gw, double* Sy_gw, double* Aquifer_Depth, double* dtmax);
+
+template <class T> __global__ void Updatehgw(Param XParam, BlockP<T> XBlock, T* hgw, T* zbgw, T* zsgw)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    hgw[idx] = max(T(0.0), zsgw[idx] - zbgw[idx]);
+
+}
 
 
 template <class T> __host__ T CalctimestepGWGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime,T dtmax_surf)
@@ -133,7 +150,7 @@ template <class T> __host__ T CalctimestepGWGPU(Param XParam, Loop<T> XLoop, Blo
  * @param Aquifer_Depth Aquifer depth array
  * @param Qx Output Darcy flux array (x-direction)
  */
-template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx)
+template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* z_aqb, T* Qx)
 {
     int halowidth = XParam.halowidth;
     int blkmemwidth = blockDim.x + halowidth * 2;
@@ -147,13 +164,13 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    // Z_bed = Topo - Aquifer_Depth
-    T bed_L = zb[idx] - Aquifer_Depth[idx];
-    T bed_R = zb[idx_r] - Aquifer_Depth[idx_r];
+    // max gw thickness
+    T bed_L = zb[idx] - z_aqb[idx];
+    T bed_R = zb[idx_r] - z_aqb[idx_r];
 
     // Saturated thickness (D) = max(0, min(H_gw, Topo) - Z_bed)
-    T thick_L = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed_L);
-    T thick_R = utils::max(T(0.0), utils::min(hgw[idx_r], zb[idx_r]) - bed_R);
+    T thick_L = utils::max(T(0.0), utils::min(hgw[idx], bed_L));
+    T thick_R = utils::max(T(0.0), utils::min(hgw[idx_r], bed_R));
     T avg_thick = T(0.5) * (thick_L + thick_R);
 
     // Qx = -K * avg_thick * ((h_gw[idx+1] + h_sw[idx+1]) - (h_gw[idx] + h_sw[idx])) / dx
@@ -172,14 +189,14 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
  * @tparam T Data type (float or double)
  * @param XParam Simulation parameters
  * @param XBlock Block data structure
- * @param hgw Groundwater elevation array
+ * @param hgw Groundwater depth array
  * @param hsw Surface water depth array
  * @param zb Topography elevation array
  * @param K_gw Hydraulic conductivity array
- * @param Aquifer_Depth Aquifer depth array
+ * @param z_aqb Aquifer bed elevation array
  * @param Qy Output Darcy flux array (y-direction)
  */
-template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy)
+template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* z_aqb, T* Qy)
 {
     int halowidth = XParam.halowidth;
     int blkmemwidth = blockDim.x + halowidth * 2;
@@ -193,15 +210,15 @@ template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock,
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    T bed_B = zb[idx] - Aquifer_Depth[idx];
-    T bed_T = zb[idx_t] - Aquifer_Depth[idx_t];
+    T bed_B = zb[idx] - z_aqb[idx];
+    T bed_T = zb[idx_t] - z_aqb[idx_t];
 
-    T thick_B = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed_B);
-    T thick_T = utils::max(T(0.0), utils::min(hgw[idx_t], zb[idx_t]) - bed_T);
+    T thick_B = utils::max(T(0.0), utils::min(hgw[idx], bed_B));
+    T thick_T = utils::max(T(0.0), utils::min(hgw[idx_t], bed_T));
     T avg_thick = T(0.5) * (thick_B + thick_T);
 
     T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_t]);
-    T H_eff_B = hgw[idx] + hsw[idx];
+    T H_eff_B = hgw[idx] + hsw[idx]; // Should be calculated with z!
     T H_eff_T = hgw[idx_t] + hsw[idx_t];
 
     Qy[idx] = -K_avg * avg_thick * (H_eff_T - H_eff_B) / levdx;
@@ -223,7 +240,7 @@ template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock,
  * @param Qx Darcy flux array (x-direction)
  * @param Qy Darcy flux array (y-direction)
  */
-template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
+template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw,T* zs_gw,T* zb_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
 {
     int halowidth = XParam.halowidth;
     int blkmemwidth = blockDim.x + halowidth * 2;
@@ -239,10 +256,12 @@ template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt,
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
     // net_lateral = -(dQx/dx + dQy/dy)
-    T net_lateral = -( (Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx );
+    T net_lateral =  -((Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx);
+
+    T fsfac = T(1.0) / 1000 / 3600;
 
     // actual_inf = min(h_sw, fs * dt)
-    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * dt);
+    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * fsfac * dt);
 
     // Update surface water depth
     h_sw[idx] -= actual_inf;
@@ -251,14 +270,18 @@ template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt,
     T new_h_gw = h_gw[idx] + (net_lateral * dt / Sy_gw[idx]) + (actual_inf / Sy_gw[idx]);
 
     // If H_gw > Topo, transfer volume to surface water (seepage)
-    if (new_h_gw > topo[idx]) {
-        T seepage = (new_h_gw - topo[idx]) * Sy_gw[idx];
+    if ((new_h_gw + zb_gw[idx]) > topo[idx]) {
+        T seepage = (new_h_gw + zb_gw[idx] - topo[idx]) * Sy_gw[idx];
         h_sw[idx] += seepage;
-        new_h_gw = topo[idx];
+        new_h_gw = topo[idx] - zb_gw[idx];
     }
 
     h_gw[idx] = new_h_gw;
     zs[idx] = topo[idx] + h_sw[idx];
+
+    zs_gw[idx] = min(topo[idx], zb_gw[idx] + h_gw[idx]);
+
+
 }
 
 /**
@@ -272,11 +295,15 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
     dim3 blockDimKX(XParam.blkwidth + XParam.halowidth, XParam.blkwidth, 1);
     dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + XParam.halowidth, 1);
 
+    fillHaloGPU(XParam, XModel.blocks, XModel.gw.zb);
+    fillHaloGPU(XParam, XModel.blocks, XModel.gw.K);
+
+
     
     // It is likely that the GW timestep is smaller then surface water the GW model is simple so we run only the GW model n time to keep up with surface water. 
     // We hope that the CFL condition don't change too drastically during this calculation. the CFL of 0.5 should help with that
-
-    GroundwaterCFLGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.hgw, XModel.zb, XModel.K_gw, XModel.Sy_gw, XModel.Aquifer_Depth, XModel.time.dtmax);
+    
+    GroundwaterCFLGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.zb, XModel.gw.K, XModel.gw.Sy, XModel.gw.zb, XModel.time.dtmax);
     CUDA_CHECK(cudaDeviceSynchronize());
 
     int n_substeps = CalctimestepGWGPU(XParam, XLoop, XModel.blocks, XModel.time, T(XLoop.dtmax));
@@ -285,24 +312,27 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
 
     for (int i = 0; i < n_substeps; i++) 
     {
-
-
+        Updatehgw << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.gw.zb, XModel.gw.zs);
+        CUDA_CHECK(cudaDeviceSynchronize());
+        
         // Fill halo for groundwater head
-        fillHaloGPU(XParam, XModel.blocks, XModel.hgw);
-
+        fillHaloGPU(XParam, XModel.blocks, XModel.gw.h);
+        
         // Calculate Darcy Fluxes
-        DarcyFluxXGPU << <gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
-        DarcyFluxYGPU << <gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
+        DarcyFluxXGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.evolv.h, XModel.zb, XModel.gw.K, XModel.gw.zb, XModel.gw.Qx);
+        DarcyFluxYGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.evolv.h, XModel.zb, XModel.gw.K, XModel.gw.zb, XModel.gw.Qy);
         CUDA_CHECK(cudaDeviceSynchronize());
 
         // Fill halo for groundwater fluxes
-        fillHaloGPU(XParam, XModel.blocks, XModel.Qx);
-        fillHaloGPU(XParam, XModel.blocks, XModel.Qy);
-
+        fillHaloGPU(XParam, XModel.blocks, XModel.gw.Qx);
+        fillHaloGPU(XParam, XModel.blocks, XModel.gw.Qy);
+        
         // Update Mass Balance and Seepage
-        GroundwaterMassBalanceGPU << <gridDim, blockDim, 0 >> > (XParam, dtgw, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);
+        GroundwaterMassBalanceGPU << <gridDim, blockDim, 0 >> > (XParam, dtgw, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.gw.fs, XModel.gw.Sy, XModel.gw.Qx, XModel.gw.Qy);
         CUDA_CHECK(cudaDeviceSynchronize());
+        
     }
+    
 }
 
 template void GroundwaterStepGPU<float>(Param XParam, Loop<float>& XLoop, Model<float> XModel);

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -1,23 +1,82 @@
 
 #include "groundwater.h"
-
-
+#include "MemManagement.h"
+#include "Setup_GPU.h"
+#include "Util_CPU.h"
+#include "Halo.h"
 
 /**
- * @brief CUDA kernel to calculate groundwater CFL condition.
- *
- * Stability for diffusion: dt < 0.5 * dx^2 / (K * D / Sy)
- * where D is saturated thickness.
- *
- * @tparam T Data type (float or double)
- * @param XParam Simulation parameters
- * @param XBlock Block data structure
- * @param hgw Groundwater elevation array
- * @param zb Topography elevation array
- * @param K_gw Hydraulic conductivity array
- * @param Sy_gw Specific yield array
- * @param Aquifer_Depth Aquifer depth array
- * @param dtmax Maximum time step array
+ * @brief CUDA kernel to calculate Darcy flux in the x-direction.
+ */
+template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    // Using Darcy flux at the interface between idx_L and idx_R
+    // The kernel is launched with blockDimKX (blkwidth + 1)
+    if (ix < XParam.blkwidth + 1) {
+        int idx_L = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
+        int idx_R = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+        T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+        T bed_L = zb[idx_L] - Aquifer_Depth[idx_L];
+        T bed_R = zb[idx_R] - Aquifer_Depth[idx_R];
+
+        T thick_L = utils::max(T(0.0), utils::min(hgw[idx_L], zb[idx_L]) - bed_L);
+        T thick_R = utils::max(T(0.0), utils::min(hgw[idx_R], zb[idx_R]) - bed_R);
+        T avg_thick = T(0.5) * (thick_L + thick_R);
+
+        T K_avg = T(0.5) * (K_gw[idx_L] + K_gw[idx_R]);
+        T H_eff_L = hgw[idx_L] + hsw[idx_L];
+        T H_eff_R = hgw[idx_R] + hsw[idx_R];
+
+        // Qx[idx_R] is the flux at the left face of cell idx_R
+        Qx[idx_R] = -K_avg * avg_thick * (H_eff_R - H_eff_L) / levdx;
+    }
+}
+
+/**
+ * @brief CUDA kernel to calculate Darcy flux in the y-direction.
+ */
+template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    if (iy < XParam.blkwidth + 1) {
+        int idx_B = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
+        int idx_T = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+        T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+        T bed_B = zb[idx_B] - Aquifer_Depth[idx_B];
+        T bed_T = zb[idx_T] - Aquifer_Depth[idx_T];
+
+        T thick_B = utils::max(T(0.0), utils::min(hgw[idx_B], zb[idx_B]) - bed_B);
+        T thick_T = utils::max(T(0.0), utils::min(hgw[idx_T], zb[idx_T]) - bed_T);
+        T avg_thick = T(0.5) * (thick_B + thick_T);
+
+        T K_avg = T(0.5) * (K_gw[idx_B] + K_gw[idx_T]);
+        T H_eff_B = hgw[idx_B] + hsw[idx_B];
+        T H_eff_T = hgw[idx_T] + hsw[idx_T];
+
+        // Qy[idx_T] is the flux at the bottom face of cell idx_T
+        Qy[idx_T] = -K_avg * avg_thick * (H_eff_T - H_eff_B) / levdx;
+    }
+}
+
+/**
+ * @brief CUDA kernel for groundwater CFL condition.
  */
 template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* zb, T* K_gw, T* Sy_gw, T* Aquifer_Depth, T* dtmax)
 {
@@ -32,8 +91,8 @@ template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBl
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    T maxbed = zb[idx] - Aquifer_Depth[idx];
-    T thick = utils::max(T(0.0), utils::min(hgw[idx],maxbed));
+    T bed = zb[idx] - Aquifer_Depth[idx];
+    T thick = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed);
 
     T diffusion = (K_gw[idx] * thick) / utils::max(Sy_gw[idx], T(1e-6));
 
@@ -44,113 +103,11 @@ template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBl
         }
     }
 }
-template __global__ void GroundwaterCFLGPU<float>(Param XParam, BlockP<float> XBlock, float* hgw, float* zb, float* K_gw, float* Sy_gw, float* Aquifer_Depth, float* dtmax);
-template __global__ void GroundwaterCFLGPU<double>(Param XParam, BlockP<double> XBlock, double* hgw, double* zb, double* K_gw, double* Sy_gw, double* Aquifer_Depth, double* dtmax);
-
-template <class T> __global__ void Updatehgw(Param XParam, BlockP<T> XBlock, T* hgw, T* zbgw, T* zsgw)
-{
-    int halowidth = XParam.halowidth;
-    int blkmemwidth = blockDim.x + halowidth * 2;
-    int ix = threadIdx.x;
-    int iy = threadIdx.y;
-    int ibl = blockIdx.x;
-    int ib = XBlock.active[ibl];
-
-    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
-
-    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
-
-    hgw[idx] = max(T(0.0), zsgw[idx] - zbgw[idx]);
-
-}
-
-
-template <class T> __host__ T CalctimestepGWGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime,T dtmax_surf)
-{
-    T* dummy;
-    AllocateCPU(32, 1, dummy);
-
-    // densify dtmax (i.e. remove empty block and halo that may sit in the middle of the memory structure)
-    int s = XParam.nblk * (XParam.blkwidth * XParam.blkwidth); // Not blksize wich includes Halo
-
-    dim3 blockDim(XParam.blkwidth, XParam.blkwidth, 1);
-    dim3 gridDim(XParam.nblk, 1, 1);
-
-    densify << < gridDim, blockDim, 0 >> > (XParam, XBlock, XTime.dtmax, XTime.arrmin);
-    CUDA_CHECK(cudaDeviceSynchronize());
-
-
-    CUDA_CHECK(cudaMemcpy(XTime.dtmax, XTime.arrmin, s * sizeof(T), cudaMemcpyDeviceToDevice));
-
-
-    //GPU Harris reduction #3. 8.3x reduction #0  Note #7 if a lot faster
-    // This was successfully tested with a range of grid size
-    //reducemax3 <<<gridDimLine, blockDimLine, 64*sizeof(float) >>>(dtmax_g, arrmax_g, nx*ny)
-
-    int maxThreads = 256;
-    int threads = (s < maxThreads * 2) ? nextPow2((s + 1) / 2) : maxThreads;
-    int blocks = (s + (threads * 2 - 1)) / (threads * 2);
-    int smemSize = (threads <= 32) ? 2 * threads * sizeof(T) : threads * sizeof(T);
-    dim3 blockDimLine(threads, 1, 1);
-    dim3 gridDimLine(blocks, 1, 1);
-
-
-    reducemin3 << <gridDimLine, blockDimLine, smemSize >> > (XTime.dtmax, XTime.arrmin, s);
-    CUDA_CHECK(cudaDeviceSynchronize());
-
-
-
-    s = gridDimLine.x;
-    while (s > 1)//cpuFinalThreshold
-    {
-        threads = (s < maxThreads * 2) ? nextPow2((s + 1) / 2) : maxThreads;
-        blocks = (s + (threads * 2 - 1)) / (threads * 2);
-
-        smemSize = (threads <= 32) ? 2 * threads * sizeof(T) : threads * sizeof(T);
-
-        dim3 blockDimLineS(threads, 1, 1);
-        dim3 gridDimLineS(blocks, 1, 1);
-
-        CUDA_CHECK(cudaMemcpy(XTime.dtmax, XTime.arrmin, s * sizeof(T), cudaMemcpyDeviceToDevice));
-
-        reducemin3 << <gridDimLineS, blockDimLineS, smemSize >> > (XTime.dtmax, XTime.arrmin, s);
-        CUDA_CHECK(cudaDeviceSynchronize());
-
-        s = (s + (threads * 2 - 1)) / (threads * 2);
-    }
-
-
-    CUDA_CHECK(cudaMemcpy(dummy, XTime.arrmin, 32 * sizeof(T), cudaMemcpyDeviceToHost)); // replace 32 by word here?
-
-    T dtmaxgw = dummy[0];
-
-
-    int n_substeps = ceil(dtmax_surf / dtmaxgw);
-    //float dt_gw = dtmax_surf / n_substeps
-    free(dummy);
-
-
-
-    return n_substeps;
-
-    
-}
-
 
 /**
- * @brief CUDA kernel to calculate Darcy flux in the x-direction.
- *
- * @tparam T Data type (float or double)
- * @param XParam Simulation parameters
- * @param XBlock Block data structure
- * @param hgw Groundwater elevation array
- * @param hsw Surface water depth array
- * @param zb Topography elevation array
- * @param K_gw Hydraulic conductivity array
- * @param Aquifer_Depth Aquifer depth array
- * @param Qx Output Darcy flux array (x-direction)
+ * @brief CUDA kernel for Groundwater Mass Balance and Seepage.
  */
-template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* z_aqb, T* Qx)
+template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
 {
     int halowidth = XParam.halowidth;
     int blkmemwidth = blockDim.x + halowidth * 2;
@@ -161,127 +118,29 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
 
     int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
     int idx_r = memloc(halowidth, blkmemwidth, ix + 1, iy, ib);
-
-    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
-
-    // max gw thickness
-    T bed_L = zb[idx] - z_aqb[idx];
-    T bed_R = zb[idx_r] - z_aqb[idx_r];
-
-    // Saturated thickness (D) = max(0, min(H_gw, Topo) - Z_bed)
-    T thick_L = utils::max(T(0.0), utils::min(hgw[idx], bed_L));
-    T thick_R = utils::max(T(0.0), utils::min(hgw[idx_r], bed_R));
-    T avg_thick = T(0.5) * (thick_L + thick_R);
-
-    // Qx = -K * avg_thick * ((h_gw[idx+1] + h_sw[idx+1]) - (h_gw[idx] + h_sw[idx])) / dx
-    T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_r]);
-    T H_eff_L = hgw[idx] + hsw[idx];
-    T H_eff_R = hgw[idx_r] + hsw[idx_r];
-
-    Qx[idx] = -K_avg * avg_thick * (H_eff_R - H_eff_L) / levdx;
-}
-
-
-
-/**
- * @brief CUDA kernel to calculate Darcy flux in the y-direction.
- *
- * @tparam T Data type (float or double)
- * @param XParam Simulation parameters
- * @param XBlock Block data structure
- * @param hgw Groundwater depth array
- * @param hsw Surface water depth array
- * @param zb Topography elevation array
- * @param K_gw Hydraulic conductivity array
- * @param z_aqb Aquifer bed elevation array
- * @param Qy Output Darcy flux array (y-direction)
- */
-template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* z_aqb, T* Qy)
-{
-    int halowidth = XParam.halowidth;
-    int blkmemwidth = blockDim.x + halowidth * 2;
-    int ix = threadIdx.x;
-    int iy = threadIdx.y;
-    int ibl = blockIdx.x;
-    int ib = XBlock.active[ibl];
-
-    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
     int idx_t = memloc(halowidth, blkmemwidth, ix, iy + 1, ib);
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    T bed_B = zb[idx] - z_aqb[idx];
-    T bed_T = zb[idx_t] - z_aqb[idx_t];
+    // Qx[idx] is flux at the left face, Qx[idx_r] is flux at the right face
+    // Qy[idx] is flux at the bottom face, Qy[idx_t] is flux at the top face
+    // net_lateral = -(dQx/dx + dQy/dy) = (Qx_in - Qx_out)/dx + (Qy_in - Qy_out)/dy
+    T net_lateral = (Qx[idx] - Qx[idx_r]) / levdx + (Qy[idx] - Qy[idx_t]) / levdx;
 
-    T thick_B = utils::max(T(0.0), utils::min(hgw[idx], bed_B));
-    T thick_T = utils::max(T(0.0), utils::min(hgw[idx_t], bed_T));
-    T avg_thick = T(0.5) * (thick_B + thick_T);
+    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * dt);
 
-    T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_t]);
-    T H_eff_B = hgw[idx] + hsw[idx]; // Should be calculated with z!
-    T H_eff_T = hgw[idx_t] + hsw[idx_t];
-
-    Qy[idx] = -K_avg * avg_thick * (H_eff_T - H_eff_B) / levdx;
-}
-
-/**
- * @brief CUDA kernel for Groundwater Mass Balance and Seepage.
- *
- * @tparam T Data type (float or double)
- * @param XParam Simulation parameters
- * @param dt Time step
- * @param XBlock Block data structure
- * @param h_gw Groundwater elevation array
- * @param h_sw Surface water depth array
- * @param zs Surface water elevation array
- * @param topo Topography elevation array
- * @param fs_gw Saturated infiltration rate array
- * @param Sy_gw Specific yield array
- * @param Qx Darcy flux array (x-direction)
- * @param Qy Darcy flux array (y-direction)
- */
-template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw,T* zs_gw,T* zb_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
-{
-    int halowidth = XParam.halowidth;
-    int blkmemwidth = blockDim.x + halowidth * 2;
-    int ix = threadIdx.x;
-    int iy = threadIdx.y;
-    int ibl = blockIdx.x;
-    int ib = XBlock.active[ibl];
-
-    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
-    int idx_l = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
-    int idx_b = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
-
-    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
-
-    // net_lateral = -(dQx/dx + dQy/dy)
-    T net_lateral =  -((Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx);
-
-    T fsfac = T(1.0) / 1000 / 3600;
-
-    // actual_inf = min(h_sw, fs * dt)
-    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * fsfac * dt);
-
-    // Update surface water depth
     h_sw[idx] -= actual_inf;
 
-    // new_h_gw = h_gw[idx] + (net_lateral * dt / Sy) + (actual_inf / Sy);
     T new_h_gw = h_gw[idx] + (net_lateral * dt / Sy_gw[idx]) + (actual_inf / Sy_gw[idx]);
 
-    // If H_gw > Topo, transfer volume to surface water (seepage)
-    if ((new_h_gw + zb_gw[idx]) > topo[idx]) {
-        T seepage = (new_h_gw + zb_gw[idx] - topo[idx]) * Sy_gw[idx];
+    if (new_h_gw > topo[idx]) {
+        T seepage = (new_h_gw - topo[idx]) * Sy_gw[idx];
         h_sw[idx] += seepage;
-        new_h_gw = topo[idx] - zb_gw[idx];
+        new_h_gw = topo[idx];
     }
 
     h_gw[idx] = new_h_gw;
     zs[idx] = topo[idx] + h_sw[idx];
-
-    zs_gw[idx] = min(topo[idx], zb_gw[idx] + h_gw[idx]);
-
-
 }
 
 /**
@@ -292,47 +151,22 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
     dim3 blockDim(XParam.blkwidth, XParam.blkwidth, 1);
     dim3 gridDim(XParam.nblk, 1, 1);
 
-    dim3 blockDimKX(XParam.blkwidth + XParam.halowidth, XParam.blkwidth, 1);
-    dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + XParam.halowidth, 1);
+    dim3 blockDimKX(XParam.blkwidth + 1, XParam.blkwidth, 1);
+    dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + 1, 1);
 
-    fillHaloGPU(XParam, XModel.blocks, XModel.gw.zb);
-    fillHaloGPU(XParam, XModel.blocks, XModel.gw.K);
-
-
-    
-    // It is likely that the GW timestep is smaller then surface water the GW model is simple so we run only the GW model n time to keep up with surface water. 
-    // We hope that the CFL condition don't change too drastically during this calculation. the CFL of 0.5 should help with that
-    
-    GroundwaterCFLGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.zb, XModel.gw.K, XModel.gw.Sy, XModel.gw.zb, XModel.time.dtmax);
+    fillHaloGPU(XParam, XModel.blocks, XModel.hgw);
     CUDA_CHECK(cudaDeviceSynchronize());
 
-    int n_substeps = CalctimestepGWGPU(XParam, XLoop, XModel.blocks, XModel.time, T(XLoop.dtmax));
+    DarcyFluxXGPU<<<gridDim, blockDimKX, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
+    DarcyFluxYGPU<<<gridDim, blockDimKY, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
+    CUDA_CHECK(cudaDeviceSynchronize());
 
-    T dtgw = XLoop.dtmax / n_substeps;
+    fillHaloGPU(XParam, XModel.blocks, XModel.Qx);
+    fillHaloGPU(XParam, XModel.blocks, XModel.Qy);
+    CUDA_CHECK(cudaDeviceSynchronize());
 
-    for (int i = 0; i < n_substeps; i++) 
-    {
-        Updatehgw << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.gw.zb, XModel.gw.zs);
-        CUDA_CHECK(cudaDeviceSynchronize());
-        
-        // Fill halo for groundwater head
-        fillHaloGPU(XParam, XModel.blocks, XModel.gw.h);
-        
-        // Calculate Darcy Fluxes
-        DarcyFluxXGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.evolv.h, XModel.zb, XModel.gw.K, XModel.gw.zb, XModel.gw.Qx);
-        DarcyFluxYGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.evolv.h, XModel.zb, XModel.gw.K, XModel.gw.zb, XModel.gw.Qy);
-        CUDA_CHECK(cudaDeviceSynchronize());
-
-        // Fill halo for groundwater fluxes
-        fillHaloGPU(XParam, XModel.blocks, XModel.gw.Qx);
-        fillHaloGPU(XParam, XModel.blocks, XModel.gw.Qy);
-        
-        // Update Mass Balance and Seepage
-        GroundwaterMassBalanceGPU << <gridDim, blockDim, 0 >> > (XParam, dtgw, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.gw.fs, XModel.gw.Sy, XModel.gw.Qx, XModel.gw.Qy);
-        CUDA_CHECK(cudaDeviceSynchronize());
-        
-    }
-    
+    GroundwaterMassBalanceGPU<<<gridDim, blockDim, 0>>>(XParam, T(XLoop.dt), XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);
+    CUDA_CHECK(cudaDeviceSynchronize());
 }
 
 template void GroundwaterStepGPU<float>(Param XParam, Loop<float>& XLoop, Model<float> XModel);

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -1,0 +1,166 @@
+
+#include "groundwater.h"
+#include "MemManagement.h"
+
+/**
+ * @brief CUDA kernel to calculate Darcy flux in the x-direction.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater elevation array
+ * @param hsw Surface water depth array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param Aquifer_Depth Aquifer depth array
+ * @param Qx Output Darcy flux array (x-direction)
+ */
+template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+    int idx_r = memloc(halowidth, blkmemwidth, ix + 1, iy, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    // Z_bed = Topo - Aquifer_Depth
+    T bed_L = zb[idx] - Aquifer_Depth[idx];
+    T bed_R = zb[idx_r] - Aquifer_Depth[idx_r];
+
+    // Saturated thickness (D) = max(0, min(H_gw, Topo) - Z_bed)
+    T thick_L = fmaxf(T(0.0), fminf(hgw[idx], zb[idx]) - bed_L);
+    T thick_R = fmaxf(T(0.0), fminf(hgw[idx_r], zb[idx_r]) - bed_R);
+    T avg_thick = T(0.5) * (thick_L + thick_R);
+
+    // Qx = -K * avg_thick * ((h_gw[idx+1] + h_sw[idx+1]) - (h_gw[idx] + h_sw[idx])) / dx
+    T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_r]);
+    T H_eff_L = hgw[idx] + hsw[idx];
+    T H_eff_R = hgw[idx_r] + hsw[idx_r];
+
+    Qx[idx] = -K_avg * avg_thick * (H_eff_R - H_eff_L) / levdx;
+}
+
+/**
+ * @brief CUDA kernel to calculate Darcy flux in the y-direction.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater elevation array
+ * @param hsw Surface water depth array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param Aquifer_Depth Aquifer depth array
+ * @param Qy Output Darcy flux array (y-direction)
+ */
+template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+    int idx_t = memloc(halowidth, blkmemwidth, ix, iy + 1, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    T bed_B = zb[idx] - Aquifer_Depth[idx];
+    T bed_T = zb[idx_t] - Aquifer_Depth[idx_t];
+
+    T thick_B = fmaxf(T(0.0), fminf(hgw[idx], zb[idx]) - bed_B);
+    T thick_T = fmaxf(T(0.0), fminf(hgw[idx_t], zb[idx_t]) - bed_T);
+    T avg_thick = T(0.5) * (thick_B + thick_T);
+
+    T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_t]);
+    T H_eff_B = hgw[idx] + hsw[idx];
+    T H_eff_T = hgw[idx_t] + hsw[idx_t];
+
+    Qy[idx] = -K_avg * avg_thick * (H_eff_T - H_eff_B) / levdx;
+}
+
+/**
+ * @brief CUDA kernel for Groundwater Mass Balance and Seepage.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param dt Time step
+ * @param XBlock Block data structure
+ * @param h_gw Groundwater elevation array
+ * @param h_sw Surface water depth array
+ * @param zs Surface water elevation array
+ * @param topo Topography elevation array
+ * @param fs_gw Saturated infiltration rate array
+ * @param Sy_gw Specific yield array
+ * @param Qx Darcy flux array (x-direction)
+ * @param Qy Darcy flux array (y-direction)
+ */
+template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+    int idx_l = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
+    int idx_b = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    // net_lateral = -(dQx/dx + dQy/dy)
+    T net_lateral = -( (Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx );
+
+    // actual_inf = min(h_sw, fs * dt)
+    T actual_inf = fminf(h_sw[idx], fs_gw[idx] * dt);
+
+    // Update surface water depth
+    h_sw[idx] -= actual_inf;
+
+    // new_h_gw = h_gw[idx] + (net_lateral * dt / Sy) + (actual_inf / Sy);
+    T new_h_gw = h_gw[idx] + (net_lateral * dt / Sy_gw[idx]) + (actual_inf / Sy_gw[idx]);
+
+    // If H_gw > Topo, transfer volume to surface water (seepage)
+    if (new_h_gw > topo[idx]) {
+        T seepage = (new_h_gw - topo[idx]) * Sy_gw[idx];
+        h_sw[idx] += seepage;
+        new_h_gw = topo[idx];
+    }
+
+    h_gw[idx] = new_h_gw;
+    zs[idx] = topo[idx] + h_sw[idx];
+}
+
+/**
+ * @brief Host routine to orchestrate groundwater kernels.
+ */
+template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T> XModel)
+{
+    dim3 blockDim(XParam.blkwidth, XParam.blkwidth, 1);
+    dim3 gridDim(XParam.nblk, 1, 1);
+
+    dim3 blockDimKX(XParam.blkwidth + XParam.halowidth, XParam.blkwidth, 1);
+    dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + XParam.halowidth, 1);
+
+    // Calculate Darcy Fluxes
+    DarcyFluxXGPU<<<gridDim, blockDimKX, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
+    DarcyFluxYGPU<<<gridDim, blockDimKY, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    // Update Mass Balance and Seepage
+    GroundwaterMassBalanceGPU<<<gridDim, blockDim, 0>>>(XParam, T(XLoop.dt), XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);
+    CUDA_CHECK(cudaDeviceSynchronize());
+}
+
+template void GroundwaterStepGPU<float>(Param XParam, Loop<float>& XLoop, Model<float> XModel);
+template void GroundwaterStepGPU<double>(Param XParam, Loop<double>& XLoop, Model<double> XModel);

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -1,6 +1,6 @@
 
 #include "groundwater.h"
-#include "MemManagement.h"
+
 
 /**
  * @brief CUDA kernel to calculate Darcy flux in the x-direction.
@@ -34,8 +34,8 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
     T bed_R = zb[idx_r] - Aquifer_Depth[idx_r];
 
     // Saturated thickness (D) = max(0, min(H_gw, Topo) - Z_bed)
-    T thick_L = fmaxf(T(0.0), fminf(hgw[idx], zb[idx]) - bed_L);
-    T thick_R = fmaxf(T(0.0), fminf(hgw[idx_r], zb[idx_r]) - bed_R);
+    T thick_L = max(T(0.0), min(hgw[idx], zb[idx]) - bed_L);
+    T thick_R = max(T(0.0), min(hgw[idx_r], zb[idx_r]) - bed_R);
     T avg_thick = T(0.5) * (thick_L + thick_R);
 
     // Qx = -K * avg_thick * ((h_gw[idx+1] + h_sw[idx+1]) - (h_gw[idx] + h_sw[idx])) / dx
@@ -76,8 +76,8 @@ template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock,
     T bed_B = zb[idx] - Aquifer_Depth[idx];
     T bed_T = zb[idx_t] - Aquifer_Depth[idx_t];
 
-    T thick_B = fmaxf(T(0.0), fminf(hgw[idx], zb[idx]) - bed_B);
-    T thick_T = fmaxf(T(0.0), fminf(hgw[idx_t], zb[idx_t]) - bed_T);
+    T thick_B = max(T(0.0), min(hgw[idx], zb[idx]) - bed_B);
+    T thick_T = max(T(0.0), min(hgw[idx_t], zb[idx_t]) - bed_T);
     T avg_thick = T(0.5) * (thick_B + thick_T);
 
     T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_t]);
@@ -122,7 +122,7 @@ template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt,
     T net_lateral = -( (Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx );
 
     // actual_inf = min(h_sw, fs * dt)
-    T actual_inf = fminf(h_sw[idx], fs_gw[idx] * dt);
+    T actual_inf = min(h_sw[idx], fs_gw[idx]/1000/3600 * dt);
 
     // Update surface water depth
     h_sw[idx] -= actual_inf;

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -1,6 +1,9 @@
 
 #include "groundwater.h"
-
+#include "MemManagement.h"
+#include "Setup_GPU.h"
+#include "Util_CPU.h"
+#include "Halo.h"
 
 /**
  * @brief CUDA kernel to calculate Darcy flux in the x-direction.
@@ -34,8 +37,8 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
     T bed_R = zb[idx_r] - Aquifer_Depth[idx_r];
 
     // Saturated thickness (D) = max(0, min(H_gw, Topo) - Z_bed)
-    T thick_L = max(T(0.0), min(hgw[idx], zb[idx]) - bed_L);
-    T thick_R = max(T(0.0), min(hgw[idx_r], zb[idx_r]) - bed_R);
+    T thick_L = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed_L);
+    T thick_R = utils::max(T(0.0), utils::min(hgw[idx_r], zb[idx_r]) - bed_R);
     T avg_thick = T(0.5) * (thick_L + thick_R);
 
     // Qx = -K * avg_thick * ((h_gw[idx+1] + h_sw[idx+1]) - (h_gw[idx] + h_sw[idx])) / dx
@@ -76,8 +79,8 @@ template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock,
     T bed_B = zb[idx] - Aquifer_Depth[idx];
     T bed_T = zb[idx_t] - Aquifer_Depth[idx_t];
 
-    T thick_B = max(T(0.0), min(hgw[idx], zb[idx]) - bed_B);
-    T thick_T = max(T(0.0), min(hgw[idx_t], zb[idx_t]) - bed_T);
+    T thick_B = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed_B);
+    T thick_T = utils::max(T(0.0), utils::min(hgw[idx_t], zb[idx_t]) - bed_T);
     T avg_thick = T(0.5) * (thick_B + thick_T);
 
     T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_t]);
@@ -122,7 +125,7 @@ template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt,
     T net_lateral = -( (Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx );
 
     // actual_inf = min(h_sw, fs * dt)
-    T actual_inf = min(h_sw[idx], fs_gw[idx]/1000/3600 * dt);
+    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * dt);
 
     // Update surface water depth
     h_sw[idx] -= actual_inf;
@@ -152,10 +155,17 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
     dim3 blockDimKX(XParam.blkwidth + XParam.halowidth, XParam.blkwidth, 1);
     dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + XParam.halowidth, 1);
 
+    // Fill halo for groundwater head
+    fillHaloGPU(XParam, XModel.blocks, XModel.hgw);
+
     // Calculate Darcy Fluxes
     DarcyFluxXGPU<<<gridDim, blockDimKX, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
     DarcyFluxYGPU<<<gridDim, blockDimKY, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
     CUDA_CHECK(cudaDeviceSynchronize());
+
+    // Fill halo for groundwater fluxes
+    fillHaloGPU(XParam, XModel.blocks, XModel.Qx);
+    fillHaloGPU(XParam, XModel.blocks, XModel.Qy);
 
     // Update Mass Balance and Seepage
     GroundwaterMassBalanceGPU<<<gridDim, blockDim, 0>>>(XParam, T(XLoop.dt), XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -1,9 +1,124 @@
 
 #include "groundwater.h"
-#include "MemManagement.h"
-#include "Setup_GPU.h"
-#include "Util_CPU.h"
-#include "Halo.h"
+
+
+
+/**
+ * @brief CUDA kernel to calculate groundwater CFL condition.
+ *
+ * Stability for diffusion: dt < 0.5 * dx^2 / (K * D / Sy)
+ * where D is saturated thickness.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater elevation array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param Sy_gw Specific yield array
+ * @param Aquifer_Depth Aquifer depth array
+ * @param dtmax Maximum time step array
+ */
+template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* zb, T* K_gw, T* Sy_gw, T* Aquifer_Depth, T* dtmax)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    T bed = zb[idx] - Aquifer_Depth[idx];
+    T thick = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed);
+
+    T diffusion = (K_gw[idx] * thick) / utils::max(Sy_gw[idx], T(1e-6));
+
+    if (diffusion > T(1e-10)) {
+        T dt_gw = T(0.5) * T(XParam.CFL) * levdx * levdx / diffusion;
+        if (dt_gw < dtmax[idx]) {
+            dtmax[idx] = dt_gw;
+        }
+    }
+}
+template __global__ void GroundwaterCFLGPU<float>(Param XParam, BlockP<float> XBlock, float* hgw, float* zb, float* K_gw, float* Sy_gw, float* Aquifer_Depth, float* dtmax);
+template __global__ void GroundwaterCFLGPU<double>(Param XParam, BlockP<double> XBlock, double* hgw, double* zb, double* K_gw, double* Sy_gw, double* Aquifer_Depth, double* dtmax);
+
+
+template <class T> __host__ T CalctimestepGWGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime,T dtmax_surf)
+{
+    T* dummy;
+    AllocateCPU(32, 1, dummy);
+
+    // densify dtmax (i.e. remove empty block and halo that may sit in the middle of the memory structure)
+    int s = XParam.nblk * (XParam.blkwidth * XParam.blkwidth); // Not blksize wich includes Halo
+
+    dim3 blockDim(XParam.blkwidth, XParam.blkwidth, 1);
+    dim3 gridDim(XParam.nblk, 1, 1);
+
+    densify << < gridDim, blockDim, 0 >> > (XParam, XBlock, XTime.dtmax, XTime.arrmin);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+
+    CUDA_CHECK(cudaMemcpy(XTime.dtmax, XTime.arrmin, s * sizeof(T), cudaMemcpyDeviceToDevice));
+
+
+    //GPU Harris reduction #3. 8.3x reduction #0  Note #7 if a lot faster
+    // This was successfully tested with a range of grid size
+    //reducemax3 <<<gridDimLine, blockDimLine, 64*sizeof(float) >>>(dtmax_g, arrmax_g, nx*ny)
+
+    int maxThreads = 256;
+    int threads = (s < maxThreads * 2) ? nextPow2((s + 1) / 2) : maxThreads;
+    int blocks = (s + (threads * 2 - 1)) / (threads * 2);
+    int smemSize = (threads <= 32) ? 2 * threads * sizeof(T) : threads * sizeof(T);
+    dim3 blockDimLine(threads, 1, 1);
+    dim3 gridDimLine(blocks, 1, 1);
+
+
+    reducemin3 << <gridDimLine, blockDimLine, smemSize >> > (XTime.dtmax, XTime.arrmin, s);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+
+
+    s = gridDimLine.x;
+    while (s > 1)//cpuFinalThreshold
+    {
+        threads = (s < maxThreads * 2) ? nextPow2((s + 1) / 2) : maxThreads;
+        blocks = (s + (threads * 2 - 1)) / (threads * 2);
+
+        smemSize = (threads <= 32) ? 2 * threads * sizeof(T) : threads * sizeof(T);
+
+        dim3 blockDimLineS(threads, 1, 1);
+        dim3 gridDimLineS(blocks, 1, 1);
+
+        CUDA_CHECK(cudaMemcpy(XTime.dtmax, XTime.arrmin, s * sizeof(T), cudaMemcpyDeviceToDevice));
+
+        reducemin3 << <gridDimLineS, blockDimLineS, smemSize >> > (XTime.dtmax, XTime.arrmin, s);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        s = (s + (threads * 2 - 1)) / (threads * 2);
+    }
+
+
+    CUDA_CHECK(cudaMemcpy(dummy, XTime.arrmin, 32 * sizeof(T), cudaMemcpyDeviceToHost)); // replace 32 by word here?
+
+    T dtmaxgw = dummy[0];
+
+
+    int n_substeps = ceil(dtmax_surf / dtmaxgw);
+    //float dt_gw = dtmax_surf / n_substeps
+    free(dummy);
+
+
+
+    return n_substeps;
+
+    
+}
+
 
 /**
  * @brief CUDA kernel to calculate Darcy flux in the x-direction.
@@ -49,47 +164,7 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
     Qx[idx] = -K_avg * avg_thick * (H_eff_R - H_eff_L) / levdx;
 }
 
-/**
- * @brief CUDA kernel to calculate groundwater CFL condition.
- *
- * Stability for diffusion: dt < 0.5 * dx^2 / (K * D / Sy)
- * where D is saturated thickness.
- *
- * @tparam T Data type (float or double)
- * @param XParam Simulation parameters
- * @param XBlock Block data structure
- * @param hgw Groundwater elevation array
- * @param zb Topography elevation array
- * @param K_gw Hydraulic conductivity array
- * @param Sy_gw Specific yield array
- * @param Aquifer_Depth Aquifer depth array
- * @param dtmax Maximum time step array
- */
-template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* zb, T* K_gw, T* Sy_gw, T* Aquifer_Depth, T* dtmax)
-{
-    int halowidth = XParam.halowidth;
-    int blkmemwidth = blockDim.x + halowidth * 2;
-    int ix = threadIdx.x;
-    int iy = threadIdx.y;
-    int ibl = blockIdx.x;
-    int ib = XBlock.active[ibl];
 
-    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
-
-    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
-
-    T bed = zb[idx] - Aquifer_Depth[idx];
-    T thick = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed);
-
-    T diffusion = (K_gw[idx] * thick) / utils::max(Sy_gw[idx], T(1e-6));
-
-    if (diffusion > T(1e-10)) {
-        T dt_gw = T(0.5) * T(XParam.CFL) * levdx * levdx / diffusion;
-        if (dt_gw < dtmax[idx]) {
-            dtmax[idx] = dt_gw;
-        }
-    }
-}
 
 /**
  * @brief CUDA kernel to calculate Darcy flux in the y-direction.
@@ -197,21 +272,37 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
     dim3 blockDimKX(XParam.blkwidth + XParam.halowidth, XParam.blkwidth, 1);
     dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + XParam.halowidth, 1);
 
-    // Fill halo for groundwater head
-    fillHaloGPU(XParam, XModel.blocks, XModel.hgw);
+    
+    // It is likely that the GW timestep is smaller then surface water the GW model is simple so we run only the GW model n time to keep up with surface water. 
+    // We hope that the CFL condition don't change too drastically during this calculation. the CFL of 0.5 should help with that
 
-    // Calculate Darcy Fluxes
-    DarcyFluxXGPU<<<gridDim, blockDimKX, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
-    DarcyFluxYGPU<<<gridDim, blockDimKY, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
+    GroundwaterCFLGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.hgw, XModel.zb, XModel.K_gw, XModel.Sy_gw, XModel.Aquifer_Depth, XModel.time.dtmax);
     CUDA_CHECK(cudaDeviceSynchronize());
 
-    // Fill halo for groundwater fluxes
-    fillHaloGPU(XParam, XModel.blocks, XModel.Qx);
-    fillHaloGPU(XParam, XModel.blocks, XModel.Qy);
+    int n_substeps = CalctimestepGWGPU(XParam, XLoop, XModel.blocks, XModel.time, T(XLoop.dtmax));
 
-    // Update Mass Balance and Seepage
-    GroundwaterMassBalanceGPU<<<gridDim, blockDim, 0>>>(XParam, T(XLoop.dt), XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);
-    CUDA_CHECK(cudaDeviceSynchronize());
+    T dtgw = XLoop.dtmax / n_substeps;
+
+    for (int i = 0; i < n_substeps; i++) 
+    {
+
+
+        // Fill halo for groundwater head
+        fillHaloGPU(XParam, XModel.blocks, XModel.hgw);
+
+        // Calculate Darcy Fluxes
+        DarcyFluxXGPU << <gridDim, blockDimKX, 0 >> > (XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
+        DarcyFluxYGPU << <gridDim, blockDimKY, 0 >> > (XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        // Fill halo for groundwater fluxes
+        fillHaloGPU(XParam, XModel.blocks, XModel.Qx);
+        fillHaloGPU(XParam, XModel.blocks, XModel.Qy);
+
+        // Update Mass Balance and Seepage
+        GroundwaterMassBalanceGPU << <gridDim, blockDim, 0 >> > (XParam, dtgw, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
 }
 
 template void GroundwaterStepGPU<float>(Param XParam, Loop<float>& XLoop, Model<float> XModel);

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -50,6 +50,48 @@ template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock,
 }
 
 /**
+ * @brief CUDA kernel to calculate groundwater CFL condition.
+ *
+ * Stability for diffusion: dt < 0.5 * dx^2 / (K * D / Sy)
+ * where D is saturated thickness.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater elevation array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param Sy_gw Specific yield array
+ * @param Aquifer_Depth Aquifer depth array
+ * @param dtmax Maximum time step array
+ */
+template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* zb, T* K_gw, T* Sy_gw, T* Aquifer_Depth, T* dtmax)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    T bed = zb[idx] - Aquifer_Depth[idx];
+    T thick = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed);
+
+    T diffusion = (K_gw[idx] * thick) / utils::max(Sy_gw[idx], T(1e-6));
+
+    if (diffusion > T(1e-10)) {
+        T dt_gw = T(0.5) * T(XParam.CFL) * levdx * levdx / diffusion;
+        if (dt_gw < dtmax[idx]) {
+            dtmax[idx] = dt_gw;
+        }
+    }
+}
+
+/**
  * @brief CUDA kernel to calculate Darcy flux in the y-direction.
  *
  * @tparam T Data type (float or double)

--- a/src/groundwater.cu
+++ b/src/groundwater.cu
@@ -1,82 +1,23 @@
 
 #include "groundwater.h"
-#include "MemManagement.h"
-#include "Setup_GPU.h"
-#include "Util_CPU.h"
-#include "Halo.h"
+
+
 
 /**
- * @brief CUDA kernel to calculate Darcy flux in the x-direction.
- */
-template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx)
-{
-    int halowidth = XParam.halowidth;
-    int blkmemwidth = blockDim.x + halowidth * 2;
-    int ix = threadIdx.x;
-    int iy = threadIdx.y;
-    int ibl = blockIdx.x;
-    int ib = XBlock.active[ibl];
-
-    // Using Darcy flux at the interface between idx_L and idx_R
-    // The kernel is launched with blockDimKX (blkwidth + 1)
-    if (ix < XParam.blkwidth + 1) {
-        int idx_L = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
-        int idx_R = memloc(halowidth, blkmemwidth, ix, iy, ib);
-
-        T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
-
-        T bed_L = zb[idx_L] - Aquifer_Depth[idx_L];
-        T bed_R = zb[idx_R] - Aquifer_Depth[idx_R];
-
-        T thick_L = utils::max(T(0.0), utils::min(hgw[idx_L], zb[idx_L]) - bed_L);
-        T thick_R = utils::max(T(0.0), utils::min(hgw[idx_R], zb[idx_R]) - bed_R);
-        T avg_thick = T(0.5) * (thick_L + thick_R);
-
-        T K_avg = T(0.5) * (K_gw[idx_L] + K_gw[idx_R]);
-        T H_eff_L = hgw[idx_L] + hsw[idx_L];
-        T H_eff_R = hgw[idx_R] + hsw[idx_R];
-
-        // Qx[idx_R] is the flux at the left face of cell idx_R
-        Qx[idx_R] = -K_avg * avg_thick * (H_eff_R - H_eff_L) / levdx;
-    }
-}
-
-/**
- * @brief CUDA kernel to calculate Darcy flux in the y-direction.
- */
-template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy)
-{
-    int halowidth = XParam.halowidth;
-    int blkmemwidth = blockDim.x + halowidth * 2;
-    int ix = threadIdx.x;
-    int iy = threadIdx.y;
-    int ibl = blockIdx.x;
-    int ib = XBlock.active[ibl];
-
-    if (iy < XParam.blkwidth + 1) {
-        int idx_B = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
-        int idx_T = memloc(halowidth, blkmemwidth, ix, iy, ib);
-
-        T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
-
-        T bed_B = zb[idx_B] - Aquifer_Depth[idx_B];
-        T bed_T = zb[idx_T] - Aquifer_Depth[idx_T];
-
-        T thick_B = utils::max(T(0.0), utils::min(hgw[idx_B], zb[idx_B]) - bed_B);
-        T thick_T = utils::max(T(0.0), utils::min(hgw[idx_T], zb[idx_T]) - bed_T);
-        T avg_thick = T(0.5) * (thick_B + thick_T);
-
-        T K_avg = T(0.5) * (K_gw[idx_B] + K_gw[idx_T]);
-        T H_eff_B = hgw[idx_B] + hsw[idx_B];
-        T H_eff_T = hgw[idx_T] + hsw[idx_T];
-
-        // Qy[idx_T] is the flux at the bottom face of cell idx_T
-        Qy[idx_T] = -K_avg * avg_thick * (H_eff_T - H_eff_B) / levdx;
-    }
-}
-
-/**
- * @brief CUDA kernel for groundwater CFL condition.
+ * @brief CUDA kernel to calculate groundwater CFL condition.
+ *
+ * Stability for diffusion: dt < 0.5 * dx^2 / (K * D / Sy)
+ * where D is saturated thickness.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater elevation array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param Sy_gw Specific yield array
+ * @param Aquifer_Depth Aquifer depth array
+ * @param dtmax Maximum time step array
  */
 template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* zb, T* K_gw, T* Sy_gw, T* Aquifer_Depth, T* dtmax)
 {
@@ -91,8 +32,8 @@ template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBl
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    T bed = zb[idx] - Aquifer_Depth[idx];
-    T thick = utils::max(T(0.0), utils::min(hgw[idx], zb[idx]) - bed);
+    T maxbed = zb[idx] - Aquifer_Depth[idx];
+    T thick = utils::max(T(0.0), utils::min(hgw[idx],maxbed));
 
     T diffusion = (K_gw[idx] * thick) / utils::max(Sy_gw[idx], T(1e-6));
 
@@ -103,11 +44,113 @@ template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBl
         }
     }
 }
+template __global__ void GroundwaterCFLGPU<float>(Param XParam, BlockP<float> XBlock, float* hgw, float* zb, float* K_gw, float* Sy_gw, float* Aquifer_Depth, float* dtmax);
+template __global__ void GroundwaterCFLGPU<double>(Param XParam, BlockP<double> XBlock, double* hgw, double* zb, double* K_gw, double* Sy_gw, double* Aquifer_Depth, double* dtmax);
+
+template <class T> __global__ void Updatehgw(Param XParam, BlockP<T> XBlock, T* hgw, T* zbgw, T* zsgw)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    hgw[idx] = max(T(0.0), zsgw[idx] - zbgw[idx]);
+
+}
+
+
+template <class T> __host__ T CalctimestepGWGPU(Param XParam, Loop<T> XLoop, BlockP<T> XBlock, TimeP<T> XTime,T dtmax_surf)
+{
+    T* dummy;
+    AllocateCPU(32, 1, dummy);
+
+    // densify dtmax (i.e. remove empty block and halo that may sit in the middle of the memory structure)
+    int s = XParam.nblk * (XParam.blkwidth * XParam.blkwidth); // Not blksize wich includes Halo
+
+    dim3 blockDim(XParam.blkwidth, XParam.blkwidth, 1);
+    dim3 gridDim(XParam.nblk, 1, 1);
+
+    densify << < gridDim, blockDim, 0 >> > (XParam, XBlock, XTime.dtmax, XTime.arrmin);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+
+    CUDA_CHECK(cudaMemcpy(XTime.dtmax, XTime.arrmin, s * sizeof(T), cudaMemcpyDeviceToDevice));
+
+
+    //GPU Harris reduction #3. 8.3x reduction #0  Note #7 if a lot faster
+    // This was successfully tested with a range of grid size
+    //reducemax3 <<<gridDimLine, blockDimLine, 64*sizeof(float) >>>(dtmax_g, arrmax_g, nx*ny)
+
+    int maxThreads = 256;
+    int threads = (s < maxThreads * 2) ? nextPow2((s + 1) / 2) : maxThreads;
+    int blocks = (s + (threads * 2 - 1)) / (threads * 2);
+    int smemSize = (threads <= 32) ? 2 * threads * sizeof(T) : threads * sizeof(T);
+    dim3 blockDimLine(threads, 1, 1);
+    dim3 gridDimLine(blocks, 1, 1);
+
+
+    reducemin3 << <gridDimLine, blockDimLine, smemSize >> > (XTime.dtmax, XTime.arrmin, s);
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+
+
+    s = gridDimLine.x;
+    while (s > 1)//cpuFinalThreshold
+    {
+        threads = (s < maxThreads * 2) ? nextPow2((s + 1) / 2) : maxThreads;
+        blocks = (s + (threads * 2 - 1)) / (threads * 2);
+
+        smemSize = (threads <= 32) ? 2 * threads * sizeof(T) : threads * sizeof(T);
+
+        dim3 blockDimLineS(threads, 1, 1);
+        dim3 gridDimLineS(blocks, 1, 1);
+
+        CUDA_CHECK(cudaMemcpy(XTime.dtmax, XTime.arrmin, s * sizeof(T), cudaMemcpyDeviceToDevice));
+
+        reducemin3 << <gridDimLineS, blockDimLineS, smemSize >> > (XTime.dtmax, XTime.arrmin, s);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        s = (s + (threads * 2 - 1)) / (threads * 2);
+    }
+
+
+    CUDA_CHECK(cudaMemcpy(dummy, XTime.arrmin, 32 * sizeof(T), cudaMemcpyDeviceToHost)); // replace 32 by word here?
+
+    T dtmaxgw = dummy[0];
+
+
+    int n_substeps = ceil(dtmax_surf / dtmaxgw);
+    //float dt_gw = dtmax_surf / n_substeps
+    free(dummy);
+
+
+
+    return n_substeps;
+
+    
+}
+
 
 /**
- * @brief CUDA kernel for Groundwater Mass Balance and Seepage.
+ * @brief CUDA kernel to calculate Darcy flux in the x-direction.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater elevation array
+ * @param hsw Surface water depth array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param Aquifer_Depth Aquifer depth array
+ * @param Qx Output Darcy flux array (x-direction)
  */
-template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
+template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* z_aqb, T* Qx)
 {
     int halowidth = XParam.halowidth;
     int blkmemwidth = blockDim.x + halowidth * 2;
@@ -118,29 +161,127 @@ template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt,
 
     int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
     int idx_r = memloc(halowidth, blkmemwidth, ix + 1, iy, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    // max gw thickness
+    T bed_L = zb[idx] - z_aqb[idx];
+    T bed_R = zb[idx_r] - z_aqb[idx_r];
+
+    // Saturated thickness (D) = max(0, min(H_gw, Topo) - Z_bed)
+    T thick_L = utils::max(T(0.0), utils::min(hgw[idx], bed_L));
+    T thick_R = utils::max(T(0.0), utils::min(hgw[idx_r], bed_R));
+    T avg_thick = T(0.5) * (thick_L + thick_R);
+
+    // Qx = -K * avg_thick * ((h_gw[idx+1] + h_sw[idx+1]) - (h_gw[idx] + h_sw[idx])) / dx
+    T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_r]);
+    T H_eff_L = hgw[idx] + hsw[idx];
+    T H_eff_R = hgw[idx_r] + hsw[idx_r];
+
+    Qx[idx] = -K_avg * avg_thick * (H_eff_R - H_eff_L) / levdx;
+}
+
+
+
+/**
+ * @brief CUDA kernel to calculate Darcy flux in the y-direction.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param XBlock Block data structure
+ * @param hgw Groundwater depth array
+ * @param hsw Surface water depth array
+ * @param zb Topography elevation array
+ * @param K_gw Hydraulic conductivity array
+ * @param z_aqb Aquifer bed elevation array
+ * @param Qy Output Darcy flux array (y-direction)
+ */
+template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* z_aqb, T* Qy)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
     int idx_t = memloc(halowidth, blkmemwidth, ix, iy + 1, ib);
 
     T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
 
-    // Qx[idx] is flux at the left face, Qx[idx_r] is flux at the right face
-    // Qy[idx] is flux at the bottom face, Qy[idx_t] is flux at the top face
-    // net_lateral = -(dQx/dx + dQy/dy) = (Qx_in - Qx_out)/dx + (Qy_in - Qy_out)/dy
-    T net_lateral = (Qx[idx] - Qx[idx_r]) / levdx + (Qy[idx] - Qy[idx_t]) / levdx;
+    T bed_B = zb[idx] - z_aqb[idx];
+    T bed_T = zb[idx_t] - z_aqb[idx_t];
 
-    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * dt);
+    T thick_B = utils::max(T(0.0), utils::min(hgw[idx], bed_B));
+    T thick_T = utils::max(T(0.0), utils::min(hgw[idx_t], bed_T));
+    T avg_thick = T(0.5) * (thick_B + thick_T);
 
+    T K_avg = T(0.5) * (K_gw[idx] + K_gw[idx_t]);
+    T H_eff_B = hgw[idx] + hsw[idx]; // Should be calculated with z!
+    T H_eff_T = hgw[idx_t] + hsw[idx_t];
+
+    Qy[idx] = -K_avg * avg_thick * (H_eff_T - H_eff_B) / levdx;
+}
+
+/**
+ * @brief CUDA kernel for Groundwater Mass Balance and Seepage.
+ *
+ * @tparam T Data type (float or double)
+ * @param XParam Simulation parameters
+ * @param dt Time step
+ * @param XBlock Block data structure
+ * @param h_gw Groundwater elevation array
+ * @param h_sw Surface water depth array
+ * @param zs Surface water elevation array
+ * @param topo Topography elevation array
+ * @param fs_gw Saturated infiltration rate array
+ * @param Sy_gw Specific yield array
+ * @param Qx Darcy flux array (x-direction)
+ * @param Qy Darcy flux array (y-direction)
+ */
+template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* h_gw,T* zs_gw,T* zb_gw, T* h_sw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy)
+{
+    int halowidth = XParam.halowidth;
+    int blkmemwidth = blockDim.x + halowidth * 2;
+    int ix = threadIdx.x;
+    int iy = threadIdx.y;
+    int ibl = blockIdx.x;
+    int ib = XBlock.active[ibl];
+
+    int idx = memloc(halowidth, blkmemwidth, ix, iy, ib);
+    int idx_l = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
+    int idx_b = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
+
+    T levdx = calcres(T(XParam.dx), XBlock.level[ib]);
+
+    // net_lateral = -(dQx/dx + dQy/dy)
+    T net_lateral =  -((Qx[idx] - Qx[idx_l]) / levdx + (Qy[idx] - Qy[idx_b]) / levdx);
+
+    T fsfac = T(1.0) / 1000 / 3600;
+
+    // actual_inf = min(h_sw, fs * dt)
+    T actual_inf = utils::min(h_sw[idx], fs_gw[idx] * fsfac * dt);
+
+    // Update surface water depth
     h_sw[idx] -= actual_inf;
 
+    // new_h_gw = h_gw[idx] + (net_lateral * dt / Sy) + (actual_inf / Sy);
     T new_h_gw = h_gw[idx] + (net_lateral * dt / Sy_gw[idx]) + (actual_inf / Sy_gw[idx]);
 
-    if (new_h_gw > topo[idx]) {
-        T seepage = (new_h_gw - topo[idx]) * Sy_gw[idx];
+    // If H_gw > Topo, transfer volume to surface water (seepage)
+    if ((new_h_gw + zb_gw[idx]) > topo[idx]) {
+        T seepage = (new_h_gw + zb_gw[idx] - topo[idx]) * Sy_gw[idx];
         h_sw[idx] += seepage;
-        new_h_gw = topo[idx];
+        new_h_gw = topo[idx] - zb_gw[idx];
     }
 
     h_gw[idx] = new_h_gw;
     zs[idx] = topo[idx] + h_sw[idx];
+
+    zs_gw[idx] = min(topo[idx], zb_gw[idx] + h_gw[idx]);
+
+
 }
 
 /**
@@ -151,22 +292,47 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
     dim3 blockDim(XParam.blkwidth, XParam.blkwidth, 1);
     dim3 gridDim(XParam.nblk, 1, 1);
 
-    dim3 blockDimKX(XParam.blkwidth + 1, XParam.blkwidth, 1);
-    dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + 1, 1);
+    dim3 blockDimKX(XParam.blkwidth + XParam.halowidth, XParam.blkwidth, 1);
+    dim3 blockDimKY(XParam.blkwidth, XParam.blkwidth + XParam.halowidth, 1);
 
-    fillHaloGPU(XParam, XModel.blocks, XModel.hgw);
+    fillHaloGPU(XParam, XModel.blocks, XModel.gw.zb);
+    fillHaloGPU(XParam, XModel.blocks, XModel.gw.K);
+
+
+    
+    // It is likely that the GW timestep is smaller then surface water the GW model is simple so we run only the GW model n time to keep up with surface water. 
+    // We hope that the CFL condition don't change too drastically during this calculation. the CFL of 0.5 should help with that
+    
+    GroundwaterCFLGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.zb, XModel.gw.K, XModel.gw.Sy, XModel.gw.zb, XModel.time.dtmax);
     CUDA_CHECK(cudaDeviceSynchronize());
 
-    DarcyFluxXGPU<<<gridDim, blockDimKX, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qx);
-    DarcyFluxYGPU<<<gridDim, blockDimKY, 0>>>(XParam, XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.zb, XModel.K_gw, XModel.Aquifer_Depth, XModel.Qy);
-    CUDA_CHECK(cudaDeviceSynchronize());
+    int n_substeps = CalctimestepGWGPU(XParam, XLoop, XModel.blocks, XModel.time, T(XLoop.dtmax));
 
-    fillHaloGPU(XParam, XModel.blocks, XModel.Qx);
-    fillHaloGPU(XParam, XModel.blocks, XModel.Qy);
-    CUDA_CHECK(cudaDeviceSynchronize());
+    T dtgw = XLoop.dtmax / n_substeps;
 
-    GroundwaterMassBalanceGPU<<<gridDim, blockDim, 0>>>(XParam, T(XLoop.dt), XModel.blocks, XModel.hgw, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.fs_gw, XModel.Sy_gw, XModel.Qx, XModel.Qy);
-    CUDA_CHECK(cudaDeviceSynchronize());
+    for (int i = 0; i < n_substeps; i++) 
+    {
+        Updatehgw << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.gw.zb, XModel.gw.zs);
+        CUDA_CHECK(cudaDeviceSynchronize());
+        
+        // Fill halo for groundwater head
+        fillHaloGPU(XParam, XModel.blocks, XModel.gw.h);
+        
+        // Calculate Darcy Fluxes
+        DarcyFluxXGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.evolv.h, XModel.zb, XModel.gw.K, XModel.gw.zb, XModel.gw.Qx);
+        DarcyFluxYGPU << <gridDim, blockDim, 0 >> > (XParam, XModel.blocks, XModel.gw.h, XModel.evolv.h, XModel.zb, XModel.gw.K, XModel.gw.zb, XModel.gw.Qy);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        // Fill halo for groundwater fluxes
+        fillHaloGPU(XParam, XModel.blocks, XModel.gw.Qx);
+        fillHaloGPU(XParam, XModel.blocks, XModel.gw.Qy);
+        
+        // Update Mass Balance and Seepage
+        GroundwaterMassBalanceGPU << <gridDim, blockDim, 0 >> > (XParam, dtgw, XModel.blocks, XModel.gw.h, XModel.gw.zs, XModel.gw.zb, XModel.evolv.h, XModel.evolv.zs, XModel.zb, XModel.gw.fs, XModel.gw.Sy, XModel.gw.Qx, XModel.gw.Qy);
+        CUDA_CHECK(cudaDeviceSynchronize());
+        
+    }
+    
 }
 
 template void GroundwaterStepGPU<float>(Param XParam, Loop<float>& XLoop, Model<float> XModel);

--- a/src/groundwater.h
+++ b/src/groundwater.h
@@ -5,6 +5,12 @@
 #include "General.h"
 #include "Param.h"
 #include "Arrays.h"
+#include "MemManagement.h"
+#include "Setup_GPU.h"
+#include "Util_CPU.h"
+#include "Halo.h"
+#include "Advection.h"
+
 
 template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T> XModel);
 

--- a/src/groundwater.h
+++ b/src/groundwater.h
@@ -10,6 +10,7 @@ template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T
 
 template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx);
 template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy);
+template <class T> __global__ void GroundwaterCFLGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* zb, T* K_gw, T* Sy_gw, T* Aquifer_Depth, T* dtmax);
 template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* hgw, T* hsw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy);
 
 #endif

--- a/src/groundwater.h
+++ b/src/groundwater.h
@@ -1,0 +1,15 @@
+
+#ifndef GROUNDWATER_H
+#define GROUNDWATER_H
+
+#include "General.h"
+#include "Param.h"
+#include "Arrays.h"
+
+template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T> XModel);
+
+template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx);
+template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy);
+template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* hgw, T* hsw, T* zs, T* zb, T* fs_gw, T* Sy_gw, T* Qx, T* Qy);
+
+#endif

--- a/src/groundwater.h
+++ b/src/groundwater.h
@@ -5,12 +5,11 @@
 #include "General.h"
 #include "Param.h"
 #include "Arrays.h"
-#include "MemManagement.h"
 
 template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T> XModel);
 
 template <class T> __global__ void DarcyFluxXGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qx);
 template <class T> __global__ void DarcyFluxYGPU(Param XParam, BlockP<T> XBlock, T* hgw, T* hsw, T* zb, T* K_gw, T* Aquifer_Depth, T* Qy);
-template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* hgw, T* hsw, T* zs, T* zb, T* fs_gw, T* Sy_gw, T* Qx, T* Qy);
+template <class T> __global__ void GroundwaterMassBalanceGPU(Param XParam, T dt, BlockP<T> XBlock, T* hgw, T* hsw, T* zs, T* topo, T* fs_gw, T* Sy_gw, T* Qx, T* Qy);
 
 #endif

--- a/src/groundwater.h
+++ b/src/groundwater.h
@@ -5,12 +5,6 @@
 #include "General.h"
 #include "Param.h"
 #include "Arrays.h"
-#include "MemManagement.h"
-#include "Setup_GPU.h"
-#include "Util_CPU.h"
-#include "Halo.h"
-#include "Advection.h"
-
 
 template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T> XModel);
 

--- a/src/groundwater.h
+++ b/src/groundwater.h
@@ -5,6 +5,7 @@
 #include "General.h"
 #include "Param.h"
 #include "Arrays.h"
+#include "MemManagement.h"
 
 template <class T> void GroundwaterStepGPU(Param XParam, Loop<T>& XLoop, Model<T> XModel);
 

--- a/tools/Validation/Analytical_GW_test.jl
+++ b/tools/Validation/Analytical_GW_test.jl
@@ -1,0 +1,487 @@
+### A Pluto.jl notebook ###
+# v0.20.3
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 546f34d0-5125-11f1-1dce-c79ac1688d87
+using Pkg
+
+# ╔═╡ 64553d93-ad06-42bd-ab2c-b1aaa7231189
+Pkg.activate()
+
+# ╔═╡ 78ddbf7b-31a7-4232-9173-eb6fdf799189
+using GMT
+
+# ╔═╡ 9804ea50-575d-471e-a3a9-86eeb08a8bec
+using SpecialFunctions  # For the erf() function
+
+
+# ╔═╡ 952f9644-540e-4e66-b6e7-dcae8abaf18b
+
+using QuadGK            # For numerical integration of the S* function
+
+# ╔═╡ 1558fa3e-d026-4475-881c-ac9899fa9878
+using NetCDF
+
+# ╔═╡ 4e1d57f1-cb04-4a63-ab20-b205f9055e98
+"""
+    boussinesq_mound_1d(x, t, h0, Hm, L, K, Sy, h_bar; max_n=151)
+
+Calculates the analytical linearized Boussinesq solution for a decaying groundwater mound.
+
+# Arguments
+- `x`: Position vector or scalar (m)
+- `t`: Time since release (s)
+- `h0`: Background water table height (m)
+- `Hm`: Initial mound height above h0 (m)
+- `L`: Total width of the domain (m)
+- `K`: Hydraulic conductivity (m/s)
+- `Sy`: Specific yield (dimensionless)
+- `h_bar`: Average saturated thickness (m), typically h0 + Hm/2
+- `max_n`: Maximum harmonic term to compute (must be an odd integer)
+"""
+function boussinesq_mound_1d(x, t, h0, Hm, L, K, Sy, h_bar; max_n=51)
+    # Initialize the sum matching the type of x (handles scalars or vectors)
+    sum_terms = zeros(eltype(x), size(x))
+    
+    # Pre-calculate constant groups for performance
+    spatial_factor = 4.0 * Hm / pi
+    temporal_factor = (pi^2 * K * h_bar) / (Sy * L^2)
+    
+    # Loop over odd harmonics only
+    for n in 1:2:max_n
+        # Spatial component: sin(n * pi * x / L) / n
+        spatial = sin.((n * pi .* x) ./ L) ./ n
+        
+        # Temporal component: exp(-n^2 * factor * t)
+        decay = exp(-n^2 * temporal_factor * t)
+        
+        # Accumulate the term
+        sum_terms .+= spatial .* decay
+	end
+    
+    # Scale the accumulated terms and add background head
+    return h0 .+ (spatial_factor .* sum_terms)
+end
+
+# ╔═╡ 97a74f48-b83f-420e-bc0e-7f408cab31c0
+function boussinesq_mound_1d_b(x, t, h0, Hm, L, K, Sy, h_bar; max_n=51)
+    # Initialize the sum matching the type of x (handles scalars or vectors)
+    sum_terms = zeros(eltype(x), size(x))
+    
+    # Pre-calculate constant groups
+    spatial_factor = 4.0 * Hm / pi
+    temporal_factor = (pi^2 * K * h_bar) / (Sy * L^2)
+    
+    # Corrected loop structure
+    for n in 1:2:max_n
+        # Spatial component
+        spatial = sin.((n * pi .* x) ./ L) ./ n
+        
+        # Temporal decay component
+        decay = exp(-n^2 * temporal_factor * t)
+        
+        # Accumulate
+        sum_terms .+= spatial .* decay
+    end # <--- Corrected: was a stray '}'
+
+    # Final result: h0 + (4*Hm/pi) * Sum
+    return h0 .+ (spatial_factor .* sum_terms)
+end
+
+# ╔═╡ b9652acf-58fa-4b58-873f-886b22f448a6
+L  = 256.0                # Domain length (m)
+
+# ╔═╡ a691b620-ce52-443f-afc0-e55540a97d15
+
+h0 = 5.0                  # Background head (m)
+
+
+# ╔═╡ e96bd7af-495c-45da-bbdb-c8652c4fdb22
+Hm = 0.06                  # Mound height (m)
+
+# ╔═╡ 94dcd744-d774-4963-9fbf-d4cbb3c1f5cf
+K  = 1500.0 / 86400.0       # Convert 10 m/day to m/s
+
+
+# ╔═╡ 2e694e54-1958-4180-a664-7c957c110713
+Sy = 0.2                  # Specific yield
+
+# ╔═╡ dc49fe58-e9ff-45fa-a3b1-69a136bb0860
+h_bar = h0 + (Hm / 2.0)   # Average thickness
+
+# ╔═╡ 6a3232d9-6520-4cf7-8d33-71b4e04c323e
+x_cells = collect(0.5:1.0:150)
+
+# ╔═╡ 1a86a8ff-b74d-405b-a95a-86052025758f
+ y10h = boussinesq_mound_1d(x_cells, 100, h0, Hm, L, K, Sy, h_bar)
+
+# ╔═╡ 2aaba249-ea9c-43cd-aafb-8a8aaba7a9bd
+plot(x_cells,y10h,show=true)
+
+# ╔═╡ 55939618-bb99-413f-9636-62fbe5bf6fef
+
+
+"""
+    hantush_mound_cell(x, y, t, h0, w, K, Sy, h_bar, a, b)
+
+Calculates the hydraulic head at a single coordinate (x,y) at time t 
+using the Hantush (1967) unconfined rectangular mounding equation.
+Assumes x and y are measured from the center of the rectangular basin.
+"""
+function hantush_mound_cell(x, y, t, h0, w, K, Sy, h_bar, a, b)
+    if t <= 0.0
+        return h0
+    end
+    
+    nu = (K * h_bar) / Sy  # Diffusivity parameter
+    
+    # Define the integrand for Hantush's S* function
+    integrand = tau -> begin
+        if tau == 0.0
+            return 0.0
+        end
+        sqrt_tau = sqrt(tau)
+        
+        # X-direction error functions
+        term_x = erf((a + x) / (sqrt(4 * nu * t) * sqrt_tau)) + 
+                 erf((a - x) / (sqrt(4 * nu * t) * sqrt_tau))
+                 
+        # Y-direction error functions
+        term_y = erf((b + y) / (sqrt(4 * nu * t) * sqrt_tau)) + 
+                 erf((b - y) / (sqrt(4 * nu * t) * sqrt_tau))
+                 
+        return term_x * term_y
+    end
+    
+    # Integrate from 0 to 1 using Gauss-Kronrod quadrature
+    S_star, _ = quadgk(integrand, 0.0, 1.0, rtol=1e-8)
+    
+    # Calculate head squared
+    h2 = h0^2 + (w / K) * nu * t * S_star
+    return sqrt(h2)
+end
+
+
+# ╔═╡ 02f5cb39-8c69-4131-a450-530099572583
+
+"""
+    hantush_mound_2d(x_vec, y_vec, t, h0, w, K, Sy, h_bar, a, b)
+
+Generates a full 2D grid matrix of heads matching the coordinates in x_vec and y_vec.
+"""
+function hantush_mound_2d(x_vec, y_vec, t, h0, w, K, Sy, h_bar, a, b)
+    h_matrix = zeros(length(x_vec), length(y_vec))
+    for i in 1:length(x_vec)
+        for j in 1:length(y_vec)
+            # x_vec and y_vec are absolute coordinates, 
+            # so we assume center of domain is the center of the mound
+            x_rel = x_vec[i] - (maximum(x_vec)/2.0)
+            y_rel = y_vec[j] - (maximum(y_vec)/2.0)
+            
+            h_matrix[i, j] = hantush_mound_cell(x_rel, y_rel, t, h0, w, K, Sy, h_bar, a, b)
+        end
+    end
+    return h_matrix
+end
+
+# ╔═╡ d01f55ce-dc51-4f7a-ab7e-0b1170097af9
+hantush_mound_cell(0,0, 3600, 2, 1.4e-5, 500/24, 0.2, 2, 10, 10)
+
+# ╔═╡ 9bd30b8b-6cf1-4f8d-aaaa-7ecb923ddc08
+"""
+    hantush_mound_cell(x, y, t, h0, w, K, Sy, h_bar, a, b, t_off)
+
+Calculates the hydraulic head at a single coordinate (x,y) at time t.
+Handles both the growth phase (t <= t_off) and decay phase (t > t_off).
+"""
+function hantush_mound_cell_to(x, y, t, h0, w, K, Sy, h_bar, a, b, t_off)
+    if t <= 0.0
+        return h0
+    end
+    
+    nu = (K * h_bar) / Sy  # Aquifer diffusivity
+    
+    # Helper function to compute the S* integral for a given time duration
+    function compute_S_star(time_duration)
+        if time_duration <= 0.0
+            return 0.0
+        end
+        
+        integrand = tau -> begin
+            if tau == 0.0; return 0.0; end
+            sqrt_tau = sqrt(tau)
+            
+            term_x = erf((a + x) / (sqrt(4 * nu * time_duration) * sqrt_tau)) + 
+                     erf((a - x) / (sqrt(4 * nu * time_duration) * sqrt_tau))
+                     
+            term_y = erf((b + y) / (sqrt(4 * nu * time_duration) * sqrt_tau)) + 
+                     erf((b - y) / (sqrt(4 * nu * time_duration) * sqrt_tau))
+                     
+            return term_x * term_y
+        end
+        
+        S_star, _ = quadgk(integrand, 0.0, 1.0, rtol=1e-8)
+        return S_star
+    end
+
+    # Phase 1: Mound is actively growing (Rain is still on)
+    if t <= t_off
+        S_star_1 = compute_S_star(t)
+        h2 = h0^2 + (0.5*w / K) * nu * t * S_star_1
+        
+    # Phase 2: Mound is decaying (Rain stopped at t_off)
+    else
+        S_star_1 = compute_S_star(t)
+        S_star_2 = compute_S_star(t - t_off)
+        
+        # Superposition: Positive rain since t=0 MINUS negative rain since t_off
+        term1 = t * S_star_1
+        term2 = (t - t_off) * S_star_2
+        
+        h2 = h0^2 + (0.5*w / K) * nu * (term1 - term2)
+    end
+    
+    return sqrt(max(0.0, h2)) # Guard against minor negative floating-point issues
+end
+
+# ╔═╡ 0566ebda-133d-4a3f-a647-519174e327a5
+"""
+    hantush_mound_2d(x_vec, y_vec, t, h0, w, K, Sy, h_bar, a, b)
+
+Generates a full 2D grid matrix of heads matching the coordinates in x_vec and y_vec.
+"""
+function hantush_mound_2d_to(x_vec, y_vec, t, h0, w, K, Sy, h_bar, a, b,toff)
+    h_matrix = zeros(length(x_vec), length(y_vec))
+    for i in 1:length(x_vec)
+        for j in 1:length(y_vec)
+            # x_vec and y_vec are absolute coordinates, 
+            # so we assume center of domain is the center of the mound
+            x_rel = x_vec[i]# - (maximum(x_vec)/2.0)
+            y_rel = y_vec[j]# - (maximum(y_vec)/2.0)
+            
+            h_matrix[i, j] = hantush_mound_cell_to(x_rel, y_rel, t, h0, w, K, Sy, h_bar, a, b,toff)
+        end
+    end
+    return h_matrix
+end
+
+# ╔═╡ c5a95c3a-277d-4cec-b130-6b1eb8d4e9d5
+tvec=collect(0:600:36000)
+
+# ╔═╡ 51d60340-e4c1-4df0-9032-8295b727d8d7
+hcent=hantush_mound_cell_to.(126 .- 125, 0, tvec, 2.0, 1.3888e-5, 500/24/3600, 0.3, 2.0, 25, 25, 3600)
+
+# ╔═╡ 215c0e9c-d212-441f-ac42-6fca77d32479
+riverrate=(50/1000/3600)*50*50
+
+
+# ╔═╡ 932821ea-a771-49a9-9f92-848583902a64
+w=riverrate/(50*50)
+
+# ╔═╡ 76de7206-6eea-4739-9a7d-e454df6b29d5
+
+
+# ╔═╡ a43906ae-9c04-49f3-a2d2-8dabc5a5d3fa
+BGff="groundwatertest_40.nc"
+
+# ╔═╡ 50072ad0-8b44-49ad-945f-141899313176
+Tscentre=dropdims(ncread(BGff,"h_gw_P0",start=[126,125,1],count=[1,1,-1]),dims=(1,2))
+
+# ╔═╡ 05d674af-b56e-4d45-a09b-929b14c099f6
+tttmodel=ncread(BGff,"time")
+
+# ╔═╡ a63a6737-cffd-42dd-8232-24a6b0abcd81
+begin
+	plot(tvec,hcent,label="Hantush (1967) ", title="BG_Flood vs analytical solution at the center of the recharge", xlabel="time [s]",ylabel="hgw [m] ")
+	plot!(tttmodel,Tscentre,lc=:red,label="BG_Flood",show=true)
+end
+
+# ╔═╡ 15dcd1de-0a68-46ca-a73a-b27d53c2ab68
+xvecAS=collect(-100:1:100)
+
+# ╔═╡ c8aa04a1-2dcb-47c7-90b4-0d6fea64257b
+xvecASB=collect(-200:5:200)
+
+# ╔═╡ 2e8fcab2-824c-4c9d-a9ee-3be24f3117db
+hxs=hantush_mound_cell_to.(xvecAS, 0, 12*600, 2.0, 1.388e-5, 500/24/3600, 0.3, 2.0, 25, 25, 3600)
+
+# ╔═╡ 237aa5f4-e94e-42d0-a9f9-8dec89eb56fa
+modelxs=dropdims(ncread(BGff,"h_gw_P0",start=[1,125,13],count=[-1,1,1]),dims=(2,3))
+
+# ╔═╡ f7689747-2208-4491-897f-f122d1bfd512
+xxsmod=ncread(BGff,"xx_P0")
+
+# ╔═╡ e74447c1-8fb5-4375-b3db-edd7d3ace23a
+hallAS=hantush_mound_2d_to(xvecASB, xvecASB, 12*600, 2.0, 1.388e-5*.5, 1500/24/3600, 0.3, 2.0, 25, 25, 3600)
+
+# ╔═╡ d129ceab-f1ca-4fa3-9b60-5a6350374379
+grdimage(hallAS,show=true)
+
+# ╔═╡ 3e0ba7c3-3204-4c85-b2cb-563341f21de5
+totalVolAS=sum(hallAS.-2.0)*0.3
+
+# ╔═╡ f7eb1299-134d-4a97-b28b-e2192f955db0
+modelhw=dropdims(ncread(BGff,"h_gw_P0",start=[1,1,13],count=[-1,-1,1]),dims=(3))
+
+# ╔═╡ 50adec77-dbf6-4f18-b487-9a10bf1cb594
+modelwaterVol=sum(modelhw.-2.0)*0.3
+
+# ╔═╡ 258346fa-461a-48e7-a6ee-f6ca676d635f
+
+
+# ╔═╡ 05b20dfa-e506-4da3-ae31-7ed4e2f737b6
+injectVol=0.03472*3600
+
+# ╔═╡ be541022-c138-4a98-b679-968442b24d58
+begin
+	plot(xvecAS,hxs,label="Hantush (1967)",title="BG_Flood vs analytical solution X-Section through the center at t=6600s",xlabel="x [m]",ylabel="hgw [m] ")
+	plot!(xxsmod.-125.0,modelxs,lc=:red,label="BG_Flood",show=true)
+end
+
+# ╔═╡ e3214624-b2e1-4223-ace6-b645be23ac88
+500/24/3600
+
+
+# ╔═╡ 2576223d-d890-4db0-bede-054718087ac0
+md"""
+# Groundwater infiltration and exfiltration
+"""
+
+# ╔═╡ 3c838a69-4c07-44e9-805b-a6fa9e117f59
+test1BG="C:\\Project\\BG_Flood\\Investigation\\Groundwater_Test1\\groundwatertest1_2.nc"
+
+# ╔═╡ 9557ca3f-4c27-465f-bd02-97cf3df593a1
+
+
+# ╔═╡ 38a939e6-e234-40f9-a0c3-a1c69da53598
+
+
+# ╔═╡ 50a28e8f-3ef8-4d04-b8cd-efa2e85c1fca
+function plotgwnh(step)
+	test1x=ncread(test1BG,"xx_P0")
+	Test1zb=dropdims(ncread(test1BG,"zb_P0",start=[1,1,step],count=[-1,-1,1]),dims=(3))
+	Test1zs=dropdims(ncread(test1BG,"zs_P0",start=[1,1,step],count=[-1,-1,1]),dims=(3))
+	Test1zgw=dropdims(ncread(test1BG,"zs_gw_P0",start=[1,1,step],count=[-1,-1,1]),dims=(3))
+	region=(0,250,0,1.1)
+	plot(test1x,Test1zgw[:,115],region=region,lc=:green,label="groundwater")
+	plot!(test1x,Test1zs[:,115],label="surface",lc=:blue)
+	plot!(test1x,Test1zb[:,115],label="land",show=true)
+end
+
+# ╔═╡ 02b93d46-4b97-4b5d-bc3e-2690459a7953
+plotgwnh(1)
+
+# ╔═╡ 0b3ac4c7-e3f1-42ef-a529-eae4ec031742
+plotgwnh(4)
+
+# ╔═╡ b4a72f9f-48df-416c-bfba-5dbd843c9632
+plotgwnh(8)
+
+# ╔═╡ 2723f1c0-4237-4058-8cd4-30c4fd3a9209
+plotgwnh(12)
+
+# ╔═╡ 1b212431-d7c5-4567-9cf3-69ee4e720ca9
+plotgwnh(16)
+
+# ╔═╡ d5b1ab8a-9f05-40fd-a3e3-c3dfc8deb013
+plotgwnh(20)
+
+# ╔═╡ 424a4cbd-46ec-433b-b280-6a98b884c18d
+plotgwnh(24)
+
+# ╔═╡ 7c74c3f0-fed2-4b97-b7db-05865d792339
+plotgwnh(28)
+
+# ╔═╡ 65c62260-eb64-47f7-980a-446b25071d11
+plotgwnh(32)
+
+# ╔═╡ 72ecb147-3e51-49cb-875a-2de99f386229
+plotgwnh(36)
+
+# ╔═╡ 6b97c49f-f4ae-4531-9e65-de5d09e4affc
+plotgwnh(40)
+
+# ╔═╡ f3fde2a3-820a-49f1-bc52-448dbab103cd
+plotgwnh(44)
+
+# ╔═╡ c57cfbd3-7c48-4894-9056-d8063180ff34
+plotgwnh(48)
+
+# ╔═╡ b6422ade-e6a1-4989-8c61-74b591c8b8cc
+plotgwnh(52)
+
+# ╔═╡ b48d6f9d-54bf-4fce-aa0a-e4a95ad762cc
+plotgwnh(56)
+
+# ╔═╡ 841172f9-05c8-43ac-86c3-286207749adc
+plotgwnh(60)
+
+# ╔═╡ Cell order:
+# ╠═546f34d0-5125-11f1-1dce-c79ac1688d87
+# ╠═64553d93-ad06-42bd-ab2c-b1aaa7231189
+# ╠═78ddbf7b-31a7-4232-9173-eb6fdf799189
+# ╠═4e1d57f1-cb04-4a63-ab20-b205f9055e98
+# ╠═97a74f48-b83f-420e-bc0e-7f408cab31c0
+# ╠═b9652acf-58fa-4b58-873f-886b22f448a6
+# ╠═a691b620-ce52-443f-afc0-e55540a97d15
+# ╠═e96bd7af-495c-45da-bbdb-c8652c4fdb22
+# ╠═94dcd744-d774-4963-9fbf-d4cbb3c1f5cf
+# ╠═2e694e54-1958-4180-a664-7c957c110713
+# ╠═dc49fe58-e9ff-45fa-a3b1-69a136bb0860
+# ╠═6a3232d9-6520-4cf7-8d33-71b4e04c323e
+# ╠═1a86a8ff-b74d-405b-a95a-86052025758f
+# ╠═2aaba249-ea9c-43cd-aafb-8a8aaba7a9bd
+# ╠═9804ea50-575d-471e-a3a9-86eeb08a8bec
+# ╠═952f9644-540e-4e66-b6e7-dcae8abaf18b
+# ╠═55939618-bb99-413f-9636-62fbe5bf6fef
+# ╠═02f5cb39-8c69-4131-a450-530099572583
+# ╠═d01f55ce-dc51-4f7a-ab7e-0b1170097af9
+# ╠═9bd30b8b-6cf1-4f8d-aaaa-7ecb923ddc08
+# ╠═0566ebda-133d-4a3f-a647-519174e327a5
+# ╠═c5a95c3a-277d-4cec-b130-6b1eb8d4e9d5
+# ╠═51d60340-e4c1-4df0-9032-8295b727d8d7
+# ╠═215c0e9c-d212-441f-ac42-6fca77d32479
+# ╠═932821ea-a771-49a9-9f92-848583902a64
+# ╠═76de7206-6eea-4739-9a7d-e454df6b29d5
+# ╠═1558fa3e-d026-4475-881c-ac9899fa9878
+# ╠═a43906ae-9c04-49f3-a2d2-8dabc5a5d3fa
+# ╠═50072ad0-8b44-49ad-945f-141899313176
+# ╠═05d674af-b56e-4d45-a09b-929b14c099f6
+# ╠═a63a6737-cffd-42dd-8232-24a6b0abcd81
+# ╠═15dcd1de-0a68-46ca-a73a-b27d53c2ab68
+# ╠═c8aa04a1-2dcb-47c7-90b4-0d6fea64257b
+# ╠═2e8fcab2-824c-4c9d-a9ee-3be24f3117db
+# ╠═237aa5f4-e94e-42d0-a9f9-8dec89eb56fa
+# ╠═f7689747-2208-4491-897f-f122d1bfd512
+# ╠═e74447c1-8fb5-4375-b3db-edd7d3ace23a
+# ╠═d129ceab-f1ca-4fa3-9b60-5a6350374379
+# ╠═3e0ba7c3-3204-4c85-b2cb-563341f21de5
+# ╠═f7eb1299-134d-4a97-b28b-e2192f955db0
+# ╠═50adec77-dbf6-4f18-b487-9a10bf1cb594
+# ╠═258346fa-461a-48e7-a6ee-f6ca676d635f
+# ╠═05b20dfa-e506-4da3-ae31-7ed4e2f737b6
+# ╠═be541022-c138-4a98-b679-968442b24d58
+# ╠═e3214624-b2e1-4223-ace6-b645be23ac88
+# ╟─2576223d-d890-4db0-bede-054718087ac0
+# ╠═3c838a69-4c07-44e9-805b-a6fa9e117f59
+# ╠═9557ca3f-4c27-465f-bd02-97cf3df593a1
+# ╠═38a939e6-e234-40f9-a0c3-a1c69da53598
+# ╠═50a28e8f-3ef8-4d04-b8cd-efa2e85c1fca
+# ╠═02b93d46-4b97-4b5d-bc3e-2690459a7953
+# ╠═0b3ac4c7-e3f1-42ef-a529-eae4ec031742
+# ╠═b4a72f9f-48df-416c-bfba-5dbd843c9632
+# ╠═2723f1c0-4237-4058-8cd4-30c4fd3a9209
+# ╠═1b212431-d7c5-4567-9cf3-69ee4e720ca9
+# ╠═d5b1ab8a-9f05-40fd-a3e3-c3dfc8deb013
+# ╠═424a4cbd-46ec-433b-b280-6a98b884c18d
+# ╠═7c74c3f0-fed2-4b97-b7db-05865d792339
+# ╠═65c62260-eb64-47f7-980a-446b25071d11
+# ╠═72ecb147-3e51-49cb-875a-2de99f386229
+# ╠═6b97c49f-f4ae-4531-9e65-de5d09e4affc
+# ╠═f3fde2a3-820a-49f1-bc52-448dbab103cd
+# ╠═c57cfbd3-7c48-4894-9056-d8063180ff34
+# ╠═b6422ade-e6a1-4989-8c61-74b591c8b8cc
+# ╠═b48d6f9d-54bf-4fce-aa0a-e4a95ad762cc
+# ╠═841172f9-05c8-43ac-86c3-286207749adc


### PR DESCRIPTION
I have implemented the Groundwater module for BG_Flood as specified. 

The implementation includes:
1. **Data Structures:** Updated `Param.h`, `Forcing.h`, and `Arrays.h` to include groundwater flags, constant parameters, and spatially variable maps for K_gw, fs_gw, Sy_gw, and Aquifer_Depth. Added a new groundwater head variable `hgw`.
2. **Input & Memory:** Updated `ReadInput.cu` and `ReadForcing.cu` to parse groundwater parameters from `BG_param.txt` and load parameter maps. Updated `MemManagement.cu` to handle allocation/reallocation of the new arrays on both CPU and GPU.
3. **Initialization:** Modified `InitialConditions.cu` to initialize groundwater parameters and the initial head `hgw` (defaulting to topography elevation if not specified).
4. **Kernels:** Created `groundwater.h` and `groundwater.cu` containing the CUDA kernels for Darcy flux calculation and groundwater mass balance/seepage.
5. **Integration:** Integrated the groundwater step into `FlowGPU.cu`, where it replaces the existing infiltration model when enabled.
6. **Output:** Added groundwater parameters to the NetCDF output mapping for verification.

The Darcy flux uses the effective head (H_gw + H_sw) and is calculated using the local cell size. The mass balance kernel handles lateral flux, infiltration (capped by surface water depth and saturated infiltration rate), and seepage (transferring volume back to the surface when `hgw > zb`).

---
*PR created automatically by Jules for task [15222133803072565313](https://jules.google.com/task/15222133803072565313) started by @CyprienBosserelle*