### PR TITLE
Buttinger ground elevation reconstruction correction - engine=4

### DIFF
--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -84,6 +84,15 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 		updateKurgYATMCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb, XModel.Patm, XModel.datmpdy);
 		//AddSlopeSourceYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 	}
+	if (XParam.engine == 4)
+	{
+			// To Update
+		// X- direction
+		UpdateButtingerXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+
+		// Y- direction
+		UpdateButtingerYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+	}
 	
 
 	//============================================

--- a/src/FlowCPU.cu
+++ b/src/FlowCPU.cu
@@ -84,9 +84,9 @@ template <class T> void FlowCPU(Param XParam, Loop<T>& XLoop,Forcing<float> XFor
 		updateKurgYATMCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb, XModel.Patm, XModel.datmpdy);
 		//AddSlopeSourceYCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 	}
-	if (XParam.engine == 4)
+	else if (XParam.engine == 4)
 	{
-			// To Update
+			// To Update when updated function implemented - For now uses standard Buttinger
 		// X- direction
 		UpdateButtingerXCPU(XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -258,12 +258,12 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 	else if (XParam.engine == 4)
 	{
 		// X- direction
-		UpdateButtingerWDXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		UpdateButtingerWDXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 		//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 		// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 		CUDA_CHECK(cudaDeviceSynchronize());
 		// Y- direction
-		UpdateButtingerWDYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		UpdateButtingerWDYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 		//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 		// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 		// //updateKurgY <<< XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >>> (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);

--- a/src/FlowGPU.cu
+++ b/src/FlowGPU.cu
@@ -136,6 +136,22 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 		CUDA_CHECK(cudaDeviceSynchronize());
 	}
+	else if (XParam.engine == 4)
+	{
+		//log(" /!\ DEBUG - engine = " + std::to_string(XParam.engine));
+		// X- direction
+		UpdateButtingerWDXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+		CUDA_CHECK(cudaDeviceSynchronize());
+		// Y- direction
+		UpdateButtingerWDYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+		// //updateKurgY <<< XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >>> (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);
+
+		CUDA_CHECK(cudaDeviceSynchronize());
+	}
 	//============================================
 	// Fill Halo for flux from fine to coarse
 	fillHaloGPU(XParam, XModel.blocks, XModel.flux);
@@ -237,6 +253,21 @@ template <class T> void FlowGPU(Param XParam, Loop<T>& XLoop, Forcing<float> XFo
 
 		// Y- direction
 		updateKurgYATMGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv_o, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb, XModel.Patm, XModel.datmpdy);
+		CUDA_CHECK(cudaDeviceSynchronize());
+	}
+	else if (XParam.engine == 4)
+	{
+		// X- direction
+		UpdateButtingerWDXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+		CUDA_CHECK(cudaDeviceSynchronize());
+		// Y- direction
+		UpdateButtingerWDYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+		// //updateKurgY <<< XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >>> (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);
+
 		CUDA_CHECK(cudaDeviceSynchronize());
 	}
 	//============================================
@@ -455,6 +486,21 @@ template <class T> void HalfStepGPU(Param XParam, Loop<T>& XLoop, Forcing<float>
 		CUDA_CHECK(cudaDeviceSynchronize());
 		// Y- direction
 		updateKurgYATMGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb, XModel.Patm, XModel.datmpdy);
+		// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+		// //updateKurgY <<< XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >>> (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);
+
+		CUDA_CHECK(cudaDeviceSynchronize());
+	}
+	else if (XParam.engine == 4)
+	{
+		// X- direction
+		UpdateButtingerWDXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		//updateKurgXGPU <<< gridDim, blockDimKX, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		// //AddSlopeSourceXGPU <<< gridDim, blockDimKX, 0, XLoop.streams[0] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
+		CUDA_CHECK(cudaDeviceSynchronize());
+		// Y- direction
+		UpdateButtingerWDYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
+		//updateKurgYGPU <<< gridDim, blockDimKY, 0 >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax, XModel.zb);
 		// //AddSlopeSourceYGPU <<< gridDim, blockDimKY, 0, XLoop.streams[1] >>> (XParam, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.zb);
 		// //updateKurgY <<< XLoop.gridDim, XLoop.blockDim, 0, XLoop.streams[0] >>> (XParam, XLoop.epsilon, XModel.blocks, XModel.evolv, XModel.grad, XModel.flux, XModel.time.dtmax);
 

--- a/src/Gradients.cu
+++ b/src/Gradients.cu
@@ -164,7 +164,7 @@ template <class T> void gradientGPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 				conserveElevationGradHaloGPU(XParam, XBlock, XEv.h, XEv.zs, zb, XGrad.dhdx, XGrad.dzsdx, XGrad.dhdy, XGrad.dzsdy);
 			}
 		}
-		if (XParam.engine == 1)
+		if ( (XParam.engine == 1) || (XParam.engine == 4) )
 		{
 			//  wet slope limiter
 			WetsloperesetXGPU <<< gridDim, blockDim, 0 >>> (XParam, XBlock, XEv, XGrad, zb);
@@ -373,7 +373,7 @@ template <class T> void gradientGPUnew(Param XParam, BlockP<T>XBlock, EvolvingP<
 			conserveElevationGradHaloGPU(XParam, XBlock, XEv.h, XEv.zs, zb, XGrad.dhdx, XGrad.dzsdx, XGrad.dhdy, XGrad.dzsdy);
 		}
 	}
-	if (XParam.engine == 1)
+	if ( (XParam.engine == 1) || (XParam.engine == 4) )
 	{
 		//  wet slope limiter
 		WetsloperesetXGPU <<< gridDim, blockDim, 0 >>> (XParam, XBlock, XEv, XGrad, zb);
@@ -1207,7 +1207,7 @@ template <class T> void gradientCPU(Param XParam, BlockP<T>XBlock, EvolvingP<T> 
 
 	}
 	
-	if (XParam.engine == 1)
+	if ( (XParam.engine == 1) || (XParam.engine == 4) )
 	{
 		WetsloperesetCPU(XParam, XBlock, XEv, XGrad, zb);
 

--- a/src/ReadInput.cu
+++ b/src/ReadInput.cu
@@ -207,6 +207,20 @@ Param readparamstr(std::string line, Param param)
 			}
 
 		}
+		std::vector<std::string> buttingercorrstr = { "bc","buttcorr","buttingercorrected","4" };
+		if (!foo)
+		{
+			for (int ii = 0; ii < buttingercorrstr.size(); ii++)
+			{
+				found = case_insensitive_compare(parametervalue, buttingercorrstr[ii]);// it needs to strictly compare
+				if (found == 0)
+				{
+					param.engine = 4;
+					foo = true;
+				}
+
+			}
+		}
 		if (!foo)
 		{
 			param.engine = std::stoi(parametervalue);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -287,14 +287,16 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 		//}
 		
 		// Condition on z, eta and zf
-		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
-			zA = zr;
-		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
-			zA = zl;
-		} else {
-			//define the Audusse terms
-			zA = max(zr, zl);
-		}
+		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// 	zA = zr;
+		// } else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		// 	zA = zl;
+		// } else {
+		// 	//define the Audusse terms
+		// 	zA = max(zr, zl);
+		// }
+
+		zA = max(zr, zl);
 
 		// Now the CN terms
 		zCN = min(zA, min(etal, etar));
@@ -874,14 +876,16 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 		//}
 
 		// Condition on z, eta and zf
-		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
-			zA = zr;
-		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
-			zA = zl;
-		} else {
-			//define the Audusse terms
-			zA = max(zr, zl);
-		}
+		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// 	zA = zr;
+		// } else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		// 	zA = zl;
+		// } else {
+		// 	//define the Audusse terms
+		// 	zA = max(zr, zl);
+		// }
+
+		zA = max(zr, zl);
 
 		// Now the CN terms
 		zCN = min(zA, min(etal, etar));

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -277,24 +277,24 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 
 		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
 		// Condition on z and zf
-		// if ( (zn < zi) && (zl > zr) ){
-		// 	zA = zr;
-		// } else if ( (zn > zi) && (zl < zr) ){
-		// 	zA = zl;
-		// } else {
-		// 	//define the Audusse terms
-		// 	zA = max(zr, zl);
-		// }
-		
-		// Condition on z, eta and zf
-		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		if ( (zn < zi) && (zl > zr) ){
 			zA = zr;
-		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		} else if ( (zn > zi) && (zl < zr) ){
 			zA = zl;
 		} else {
 			//define the Audusse terms
 			zA = max(zr, zl);
 		}
+		
+		// Condition on z, eta and zf
+		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// 	zA = zr;
+		// } else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		// 	zA = zl;
+		// } else {
+		// 	//define the Audusse terms
+		// 	zA = max(zr, zl);
+		// }
 
 		// zA = max(zr, zl);
 
@@ -866,24 +866,24 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 
 		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
 		// Condition on z and zf
-		// if ( (zn < zi) && (zl > zr) ){
-		// 	zA = zr;
-		// } else if ( (zn > zi) && (zl < zr) ){
-		// 	zA = zl;
-		// } else {
-		// 	//define the Audusse terms
-		// 	zA = max(zr, zl);
-		// }
-
-		// Condition on z, eta and zf
-		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		if ( (zn < zi) && (zl > zr) ){
 			zA = zr;
-		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		} else if ( (zn > zi) && (zl < zr) ){
 			zA = zl;
 		} else {
 			//define the Audusse terms
 			zA = max(zr, zl);
 		}
+
+		// Condition on z, eta and zf
+		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// 	zA = zr;
+		// } else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		// 	zA = zl;
+		// } else {
+		// 	//define the Audusse terms
+		// 	zA = max(zr, zl);
+		// }
 
 		// zA = max(zr, zl);
 

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -270,27 +270,26 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 		etar = etai - dx * XGrad.dzsdx[i];
 		etal = etan + dx * XGrad.dzsdx[ileft];
 
+		// ## Fallback to 2nd order central differencing where monotonicity is violated for eta and h.
+		if ( (hi - hn) * (hr - hl) < 0 ) {
+			hr = 0.5*(hi + hn);
+			hl = 0.5*(hi + hn);
+		}
+		if ( (etai - etan) * (etar - etal) < 0 ) {
+			etar = 0.5*(etai + etan);
+			etal = 0.5*(etai + etan);
+		}
+
 		//define the topography term at the interfaces
 		zr = etar - hr;// zi - dx * XGrad.dzbdx[i];
 		zl = etal - hl;// zn + dx * XGrad.dzbdx[ileft];
 
 
-		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
-		// Condition on z and zf
-		// if ( (zn < zi) && (zl > zr) ){
-		// 	zA = zr;
-		// } else if ( (zn > zi) && (zl < zr) ){
-		// 	zA = zl;
-		// } else {
-		// 	//define the Audusse terms
-		// 	zA = max(zr, zl);
-		// }
-		
-		// Condition on z, eta and zf
-		//if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// Targetted correction of zface where monotonicity is violated at the cell faces but the flow is downhill
+		// Condition on z, eta, h and zf
+			// If z, eta and h are increasing/decreasing at the same time, let flux conditions be described by the upper cell (where the flow comes from) 
 		if ( (zn < zi) && (etan < etai) && (hn < hi) && (zl > zr) ){
 			zA = zr;
-		//} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
 		} else if ( (zn > zi) && (etan > etai) && (hn > hi) && (zl < zr) ){
             zA = zl;
 		} else {
@@ -861,29 +860,27 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 		etar = etai - dx * XGrad.dzsdy[i];
 		etal = etan + dx * XGrad.dzsdy[ibot];
 
+		// ## Fallback to 2nd order central differencing where monotonicity is violated for eta and h.
+		if ( (hi - hn) * (hr - hl) < 0 ) {
+			hr = 0.5*(hi + hn);
+			hl = 0.5*(hi + hn);
+		}
+		if ( (etai - etan) * (etar - etal) < 0 ) {
+			etar = 0.5*(etai + etan);
+			etal = 0.5*(etai + etan);
+		}
+
 		//define the topography term at the interfaces
-		zr = etar - hr;// zi - dx * XGrad.dzbdy[i];
-		zl = etal - hl;// zn + dx * XGrad.dzbdy[ibot];
+		zr = etar - hr;// zi - dx * XGrad.dzbdx[i];
+		zl = etal - hl;// zn + dx * XGrad.dzbdx[ileft];
 
-
-		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
-		// Condition on z and zf
-		// if ( (zn < zi) && (zl > zr) ){
-		// 	zA = zr;
-		// } else if ( (zn > zi) && (zl < zr) ){
-		// 	zA = zl;
-		// } else {
-		// 	//define the Audusse terms
-		// 	zA = max(zr, zl);
-		// }
-
-		// Condition on z, eta and zf
-		//if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// Targetted correction of zface where monotonicity is violated at the cell faces but the flow is downhill
+		// Condition on z, eta, h and zf
+			// If z, eta and h are increasing/decreasing at the same time, let flux conditions be described by the upper cell (where the flow comes from) 
 		if ( (zn < zi) && (etan < etai) && (hn < hi) && (zl > zr) ){
 			zA = zr;
-		//} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
 		} else if ( (zn > zi) && (etan > etai) && (hn > hi) && (zl < zr) ){
-			zA = zl;
+            zA = zl;
 		} else {
 			//define the Audusse terms
 			zA = max(zr, zl);

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -75,12 +75,15 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 	{
 		T dx, zi, zn, hr, hl, etar, etal, zr, zl, zA, zCN, hCNr, hCNl;
 		T ui, vi, uli, vli, dhdxi, dhdxil, dudxi, dudxil, dvdxi,dvdxil;
+		T etai, etan;
 
 		T ga = g * T(0.5);
 		// along X
 		dx = delta * T(0.5);
 		zi = zb[i];
 		zn = zb[ileft];
+		etai = XEv.zs[i];
+		etan = XEv.zs[ileft];
 
 		ui = XEv.u[i];
 		vi = XEv.v[i];
@@ -97,8 +100,8 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 
 		hr = hi - dx * dhdxi;
 		hl = hn + dx * dhdxil;
-		etar = XEv.zs[i] - dx * XGrad.dzsdx[i];
-		etal = XEv.zs[ileft] + dx * XGrad.dzsdx[ileft];
+		etar = etai - dx * XGrad.dzsdx[i];
+		etal = etan + dx * XGrad.dzsdx[ileft];
 
 		//define the topography term at the interfaces
 		zr = etar - hr;// zi - dx * XGrad.dzbdx[i];
@@ -192,6 +195,192 @@ template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> X
 }
 template __global__ void UpdateButtingerXGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
 template __global__ void UpdateButtingerXGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
+
+template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+{
+	unsigned int halowidth = XParam.halowidth;
+	unsigned int blkmemwidth = blockDim.y + halowidth * 2;
+	//unsigned int blksize = blkmemwidth * blkmemwidth;
+	int ix = threadIdx.x;
+	int iy = threadIdx.y;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int lev = XBlock.level[ib];
+	int RB, LBRB, LB, RBLB, levRB, levLB;
+	RB = XBlock.RightBot[ib];
+	levRB = XBlock.level[RB];
+	LBRB = XBlock.LeftBot[RB];
+
+	LB = XBlock.LeftBot[ib];
+	levLB = XBlock.level[LB];
+	RBLB = XBlock.RightBot[LB];
+
+	T epsi = nextafter(T(1.0), T(2.0)) - T(1.0);
+	T eps = T(XParam.eps) + epsi;
+	T delta = calcres(T(XParam.delta), lev);
+	T g = T(XParam.g);
+	T CFL = T(XParam.CFL);
+
+	int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
+	int ileft = memloc(halowidth, blkmemwidth, ix - 1, iy, ib);
+
+	T ybo = T(XParam.yo + XBlock.yo[ib]);
+
+
+	//T dhdxi = XGrad.dhdx[i];
+	//T dhdxmin = XGrad.dhdx[ileft];
+	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
+	T fmu = T(1.0);
+
+	T hi = XEv.h[i];
+
+	T hn = XEv.h[ileft];
+
+
+	if (hi > eps || hn > eps)
+	{
+		T dx, zi, zn, hr, hl, etar, etal, zr, zl, zA, zCN, hCNr, hCNl;
+		T ui, vi, uli, vli, dhdxi, dhdxil, dudxi, dudxil, dvdxi,dvdxil;
+		T etai, etan;
+
+		T ga = g * T(0.5);
+		// along X
+		dx = delta * T(0.5);
+		zi = zb[i];
+		zn = zb[ileft];
+		etai = XEv.zs[i];
+		etan = XEv.zs[ileft];
+
+		ui = XEv.u[i];
+		vi = XEv.v[i];
+		uli = XEv.u[ileft];
+		vli = XEv.v[ileft];
+
+		dhdxi = XGrad.dhdx[i];
+		dhdxil = XGrad.dhdx[ileft];
+		dudxi = XGrad.dudx[i];
+		dudxil = XGrad.dudx[ileft];
+		dvdxi = XGrad.dvdx[i];
+		dvdxil = XGrad.dvdx[ileft];
+
+
+		hr = hi - dx * dhdxi;
+		hl = hn + dx * dhdxil;
+		etar = etai - dx * XGrad.dzsdx[i];
+		etal = etan + dx * XGrad.dzsdx[ileft];
+
+		//define the topography term at the interfaces
+		zr = etar - hr;// zi - dx * XGrad.dzbdx[i];
+		zl = etal - hl;// zn + dx * XGrad.dzbdx[ileft];
+
+
+		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
+		// Condition on z and zf
+		//if ( (zn < zi) && (zl > zr) ){
+		//	zA = zr;
+		//} else if ( (zn > zi) && (zl < zr) ){
+		//	zA = zl;
+		//} else {
+		//	//define the Audusse terms
+		//	zA = max(zr, zl);
+		//}
+		
+		// Condition on z, eta and zf
+		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+			zA = zr;
+		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+			zA = zl;
+		} else {
+			//define the Audusse terms
+			zA = max(zr, zl);
+		}
+
+		// Now the CN terms
+		zCN = min(zA, min(etal, etar));
+		hCNr = max(T(0.0), min(etar - zCN, hr));
+		hCNl = max(T(0.0), min(etal - zCN, hl));
+		
+		//Velocity reconstruction
+		//To avoid high velocities near dry cells, we reconstruct velocities according to Bouchut.
+		T ul, ur, vl, vr,sl,sr;
+		if (hi > eps) {
+			ur = ui - (1. + dx * dhdxi / hi) * dx * dudxi;
+			vr = vi - (1. + dx * dhdxi / hi) * dx * dvdxi;
+		}
+		else {
+			ur = ui - dx * dudxi;
+			vr = vi - dx * dvdxi;
+		}
+		if (hn > eps) {
+			ul = uli + (T(1.0) - dx * dhdxil / hn) * dx * dudxil;
+			vl = vli + (T(1.0) - dx * dhdxil / hn) * dx * dvdxil;
+		}
+		else {
+			ul = uli + dx * dudxil;
+			vl = vli + dx * dvdxil;
+		}
+
+	
+
+
+		T fh, fu, fv, dt;
+
+
+		//solver below also modifies fh and fu
+		dt = hllc(g, delta, epsi, CFL, cm, fmu, hCNl, hCNr, ul, ur, fh, fu);
+		//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
+
+		if (dt < dtmax[i])
+		{
+			dtmax[i] = dt;
+		}
+		
+
+		fv = (fh > 0. ? vl : vr) * fh;
+
+	
+		// Topographic source term
+
+		// In the case of adaptive refinement, care must be taken to ensure
+		// well-balancing at coarse/fine faces (see [notes/balanced.tm]()). 
+		if ((ix == blockDim.y) && levRB < lev)//(ix==16) i.e. in the right halo
+		{
+			int jj = LBRB == ib ? floor(iy * (T)0.5) : floor(iy * (T)0.5) + blockDim.y / 2;
+			int iright = memloc(halowidth, blkmemwidth, 0, jj, RB);;
+			hi = XEv.h[iright];
+			zi = zb[iright];
+		}
+		if ((ix == 0) && levLB < lev)//(ix==16) i.e. in the right halo
+		{
+			int jj = RBLB == ib ? floor(iy * (T)0.5) : floor(iy * (T)0.5) + blockDim.y / 2;
+			int ilc = memloc(halowidth, blkmemwidth, blockDim.y - 1, jj, LB);
+			hn = XEv.h[ilc];
+			zn = zb[ilc];
+		}
+
+		sl = ga * (hi + hCNr) * (zi - zCN);
+		sr = ga * (hCNl + hn) * (zn - zCN);
+
+		////Flux update
+
+		XFlux.Fhu[i] = fmu * fh;
+		XFlux.Fqux[i] = fmu * (fu - sl);
+		XFlux.Su[i] = fmu * (fu - sr);
+		XFlux.Fqvx[i] = fmu * fv;
+	}
+	else
+	{
+		dtmax[i] = T(1.0) / epsi;
+		XFlux.Fhu[i] = T(0.0);
+		XFlux.Fqux[i] = T(0.0);
+		XFlux.Su[i] = T(0.0);
+		XFlux.Fqvx[i] = T(0.0);
+	}
+
+}
+template __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
+template __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
 
 
 /**
@@ -471,12 +660,16 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 	{
 		T dx, zi, zn, hr, hl, etar, etal, zr, zl, zA, zCN, hCNr, hCNl;
 		T ui, vi, uli, vli, dhdyi, dhdyil, dudyi, dudyil, dvdyi, dvdyil;
+		T etai, etan;
 
 		T ga = g * T(0.5);
 		// along X
 		dx = delta * T(0.5);
 		zi = zb[i];
 		zn = zb[ibot];
+
+		etai = XEv.zs[i];
+		etan = XEv.zs[ibot];
 
 		ui = XEv.u[i];
 		vi = XEv.v[i];
@@ -493,8 +686,8 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 
 		hr = hi - dx * dhdyi;
 		hl = hn + dx * dhdyil;
-		etar = XEv.zs[i] - dx * XGrad.dzsdy[i];
-		etal = XEv.zs[ibot] + dx * XGrad.dzsdy[ibot];
+		etar = etai - dx * XGrad.dzsdy[i];
+		etal = etan + dx * XGrad.dzsdy[ibot];
 
 		//define the topography term at the interfaces
 		zr = etar - hr;// zi - dx * XGrad.dzbdy[i];
@@ -588,6 +781,194 @@ template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> X
 }
 template __global__ void UpdateButtingerYGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
 template __global__ void UpdateButtingerYGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
+
+template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb)
+{
+	unsigned int halowidth = XParam.halowidth;
+	unsigned int blkmemwidth = blockDim.x + halowidth * 2;
+	//unsigned int blksize = blkmemwidth * blkmemwidth;
+	int ix = threadIdx.x;
+	int iy = threadIdx.y;
+	unsigned int ibl = blockIdx.x;
+	unsigned int ib = XBlock.active[ibl];
+
+	int lev = XBlock.level[ib];
+	int TL, BLTL, BL, TLBL, levTL, levBL;
+	TL = XBlock.TopLeft[ib];
+	levTL = XBlock.level[TL];
+	BLTL = XBlock.BotLeft[TL];
+
+	BL = XBlock.BotLeft[ib];
+	levBL = XBlock.level[BL];
+	TLBL = XBlock.TopLeft[BL];
+
+	T epsi = nextafter(T(1.0), T(2.0)) - T(1.0);
+	T eps = T(XParam.eps) + epsi;
+	T delta = calcres(T(XParam.delta), lev);
+	T g = T(XParam.g);
+	T CFL = T(XParam.CFL);
+
+	int i = memloc(halowidth, blkmemwidth, ix, iy, ib);
+	int ibot = memloc(halowidth, blkmemwidth, ix, iy - 1, ib);
+
+
+	T ybo = T(XParam.yo + XBlock.yo[ib]);
+
+	//T dhdyi = XGrad.dhdy[i];
+	//T dhdymin = XGrad.dhdy[ibot];
+	T cm = XParam.spherical ? calcCM(T(XParam.Radius), delta, ybo, iy) : T(1.0);
+	T fmv = XParam.spherical ? calcFM(T(XParam.Radius), delta, ybo, T(iy)) : T(1.0);
+
+	T hi = XEv.h[i];
+
+	T hn = XEv.h[ibot];
+
+
+	if (hi > eps || hn > eps)
+	{
+		T dx, zi, zn, hr, hl, etar, etal, zr, zl, zA, zCN, hCNr, hCNl;
+		T ui, vi, uli, vli, dhdyi, dhdyil, dudyi, dudyil, dvdyi, dvdyil;
+		T etai, etan;
+
+		T ga = g * T(0.5);
+		// along X
+		dx = delta * T(0.5);
+		zi = zb[i];
+		zn = zb[ibot];
+
+		etai = XEv.zs[i];
+		etan = XEv.zs[ibot];
+
+		ui = XEv.u[i];
+		vi = XEv.v[i];
+		uli = XEv.u[ibot];
+		vli = XEv.v[ibot];
+
+		dhdyi = XGrad.dhdy[i];
+		dhdyil = XGrad.dhdy[ibot];
+		dudyi = XGrad.dudy[i];
+		dudyil = XGrad.dudy[ibot];
+		dvdyi = XGrad.dvdy[i];
+		dvdyil = XGrad.dvdy[ibot];
+
+
+		hr = hi - dx * dhdyi;
+		hl = hn + dx * dhdyil;
+		etar = etai - dx * XGrad.dzsdy[i];
+		etal = etan + dx * XGrad.dzsdy[ibot];
+
+		//define the topography term at the interfaces
+		zr = etar - hr;// zi - dx * XGrad.dzbdy[i];
+		zl = etal - hl;// zn + dx * XGrad.dzbdy[ibot];
+
+
+		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
+		// Condition on z and zf
+		//if ( (zn < zi) && (zl > zr) ){
+		//	zA = zr;
+		//} else if ( (zn > zi) && (zl < zr) ){
+		//	zA = zl;
+		//} else {
+		//	//define the Audusse terms
+		//	zA = max(zr, zl);
+		//}
+
+		// Condition on z, eta and zf
+		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+			zA = zr;
+		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+			zA = zl;
+		} else {
+			//define the Audusse terms
+			zA = max(zr, zl);
+		}
+
+		// Now the CN terms
+		zCN = min(zA, min(etal, etar));
+		hCNr = max(T(0.0), min(etar - zCN, hr));
+		hCNl = max(T(0.0), min(etal - zCN, hl));
+
+		//Velocity reconstruction
+		//To avoid high velocities near dry cells, we reconstruct velocities according to Bouchut.
+		T ul, ur, vl, vr, sl, sr;
+		if (hi > eps) {
+			ur = ui - (1. + dx * dhdyi / hi) * dx * dudyi;
+			vr = vi - (1. + dx * dhdyi / hi) * dx * dvdyi;
+		}
+		else {
+			ur = ui - dx * dudyi;
+			vr = vi - dx * dvdyi;
+		}
+		if (hn > eps) {
+			ul = uli + (1. - dx * dhdyil / hn) * dx * dudyil;
+			vl = vli + (1. - dx * dhdyil / hn) * dx * dvdyil;
+		}
+		else {
+			ul = uli + dx * dudyil;
+			vl = vli + dx * dvdyil;
+		}
+
+
+
+
+		T fh, fu, fv, dt;
+
+
+		//solver below also modifies fh and fu
+		dt = hllc(g, delta, epsi, CFL, cm, fmv, hCNl, hCNr, vl, vr, fh, fu);
+		//hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T & fh, T & fq)
+
+		if (dt < dtmax[i])
+		{
+			dtmax[i] = dt;
+		}
+		
+
+		fv = (fh > 0. ? ul : ur) * fh;
+
+
+		// Topographic source term
+
+		// In the case of adaptive refinement, care must be taken to ensure
+		// well-balancing at coarse/fine faces (see [notes/balanced.tm]()). 
+		if ((iy == blockDim.x) && levTL < lev)//(ix==16) i.e. in the right halo
+		{
+			int jj = BLTL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + blockDim.x / 2;
+			int itop = memloc(halowidth, blkmemwidth, jj, 0, TL);;
+			hi = XEv.h[itop];
+			zi = zb[itop];
+		}
+		if ((iy == 0) && levBL < lev)//(ix==16) i.e. in the right halo
+		{
+			int jj = TLBL == ib ? floor(ix * (T)0.5) : floor(ix * (T)0.5) + blockDim.x / 2;
+			int ibc = memloc(halowidth, blkmemwidth, jj, blockDim.x - 1, BL);
+			hn = XEv.h[ibc];
+			zn = zb[ibc];
+		}
+
+		sl = ga * (hi + hCNr) * (zi - zCN);
+		sr = ga * (hCNl + hn) * (zn - zCN);
+
+		////Flux update
+
+		XFlux.Fhv[i] = fmv * fh;
+		XFlux.Fqvy[i] = fmv * (fu - sl);
+		XFlux.Sv[i] = fmv * (fu - sr);
+		XFlux.Fquy[i] = fmv * fv;
+	}
+	else
+	{
+		dtmax[i] = T(1.0) / epsi;
+		XFlux.Fhv[i] = T(0.0);
+		XFlux.Fqvy[i] = T(0.0);
+		XFlux.Sv[i] = T(0.0);
+		XFlux.Fquy[i] = T(0.0);
+	}
+
+}
+template __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<float> XBlock, EvolvingP<float> XEv, GradientsP<float> XGrad, FluxP<float> XFlux, float* dtmax, float* zb);
+template __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<double> XBlock, EvolvingP<double> XEv, GradientsP<double> XGrad, FluxP<double> XFlux, double* dtmax, double* zb);
+
 
 /** 
  * @brief "Adaptive" second-order hydrostatic reconstruction. CPU version for the Y-axis

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -277,14 +277,14 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 
 		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
 		// Condition on z and zf
-		//if ( (zn < zi) && (zl > zr) ){
-		//	zA = zr;
-		//} else if ( (zn > zi) && (zl < zr) ){
-		//	zA = zl;
-		//} else {
-		//	//define the Audusse terms
-		//	zA = max(zr, zl);
-		//}
+		if ( (zn < zi) && (zl > zr) ){
+			zA = zr;
+		} else if ( (zn > zi) && (zl < zr) ){
+			zA = zl;
+		} else {
+			//define the Audusse terms
+			zA = max(zr, zl);
+		}
 		
 		// Condition on z, eta and zf
 		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
@@ -296,7 +296,7 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 		// 	zA = max(zr, zl);
 		// }
 
-		zA = max(zr, zl);
+		// zA = max(zr, zl);
 
 		// Now the CN terms
 		zCN = min(zA, min(etal, etar));
@@ -866,14 +866,14 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 
 		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
 		// Condition on z and zf
-		//if ( (zn < zi) && (zl > zr) ){
-		//	zA = zr;
-		//} else if ( (zn > zi) && (zl < zr) ){
-		//	zA = zl;
-		//} else {
-		//	//define the Audusse terms
-		//	zA = max(zr, zl);
-		//}
+		if ( (zn < zi) && (zl > zr) ){
+			zA = zr;
+		} else if ( (zn > zi) && (zl < zr) ){
+			zA = zl;
+		} else {
+			//define the Audusse terms
+			zA = max(zr, zl);
+		}
 
 		// Condition on z, eta and zf
 		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
@@ -885,7 +885,7 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 		// 	zA = max(zr, zl);
 		// }
 
-		zA = max(zr, zl);
+		// zA = max(zr, zl);
 
 		// Now the CN terms
 		zCN = min(zA, min(etal, etar));

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -287,10 +287,12 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 		// }
 		
 		// Condition on z, eta and zf
-		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		//if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		if ( (zn < zi) && (etan < etai) && (hn < hi) && (zl > zr) ){
 			zA = zr;
-		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
-			zA = zl;
+		//} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		} else if ( (zn > zi) && (etan > etai) && (hn > hi) && (zl < zr) ){
+            zA = zl;
 		} else {
 			//define the Audusse terms
 			zA = max(zr, zl);
@@ -876,9 +878,11 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 		// }
 
 		// Condition on z, eta and zf
-		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		//if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		if ( (zn < zi) && (etan < etai) && (hn < hi) && (zl > zr) ){
 			zA = zr;
-		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		//} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		} else if ( (zn > zi) && (etan > etai) && (hn > hi) && (zl < zr) ){
 			zA = zl;
 		} else {
 			//define the Audusse terms

--- a/src/Reimann.cu
+++ b/src/Reimann.cu
@@ -277,24 +277,24 @@ template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T>
 
 		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
 		// Condition on z and zf
-		if ( (zn < zi) && (zl > zr) ){
-			zA = zr;
-		} else if ( (zn > zi) && (zl < zr) ){
-			zA = zl;
-		} else {
-			//define the Audusse terms
-			zA = max(zr, zl);
-		}
-		
-		// Condition on z, eta and zf
-		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// if ( (zn < zi) && (zl > zr) ){
 		// 	zA = zr;
-		// } else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		// } else if ( (zn > zi) && (zl < zr) ){
 		// 	zA = zl;
 		// } else {
 		// 	//define the Audusse terms
 		// 	zA = max(zr, zl);
 		// }
+		
+		// Condition on z, eta and zf
+		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+			zA = zr;
+		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+			zA = zl;
+		} else {
+			//define the Audusse terms
+			zA = max(zr, zl);
+		}
 
 		// zA = max(zr, zl);
 
@@ -866,24 +866,24 @@ template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T>
 
 		// Treatment of Wet/dry faces to eliminate non-monotnous face conditions
 		// Condition on z and zf
-		if ( (zn < zi) && (zl > zr) ){
-			zA = zr;
-		} else if ( (zn > zi) && (zl < zr) ){
-			zA = zl;
-		} else {
-			//define the Audusse terms
-			zA = max(zr, zl);
-		}
-
-		// Condition on z, eta and zf
-		// if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+		// if ( (zn < zi) && (zl > zr) ){
 		// 	zA = zr;
-		// } else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+		// } else if ( (zn > zi) && (zl < zr) ){
 		// 	zA = zl;
 		// } else {
 		// 	//define the Audusse terms
 		// 	zA = max(zr, zl);
 		// }
+
+		// Condition on z, eta and zf
+		if ( (zn < zi) && (etan < etai) && (zl > zr) ){
+			zA = zr;
+		} else if ( (zn > zi) && (etan > etai) && (zl < zr) ){
+			zA = zl;
+		} else {
+			//define the Audusse terms
+			zA = max(zr, zl);
+		}
 
 		// zA = max(zr, zl);
 

--- a/src/Reimann.h
+++ b/src/Reimann.h
@@ -9,8 +9,10 @@
 #include "Util_CPU.h"
 
 template <class T> __global__ void UpdateButtingerXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
+template <class T> __global__ void UpdateButtingerWDXGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 template <class T> __host__ void UpdateButtingerXCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 template <class T> __global__ void UpdateButtingerYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
+template <class T> __global__ void UpdateButtingerWDYGPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 template <class T> __host__ void UpdateButtingerYCPU(Param XParam, BlockP<T> XBlock, EvolvingP<T> XEv, GradientsP<T> XGrad, FluxP<T> XFlux, T* dtmax, T* zb);
 template <class T> __host__ __device__ T hllc(T g, T delta, T epsi, T CFL, T cm, T fm, T hm, T hp, T um, T up, T& fh, T& fq);
 #endif


### PR DESCRIPTION
Addition of engine = 4 using UpdateButtingerWDXGPU/YGPU
Updated Buttinger et al. (2019) with reconstructed face elevation check to ensure monotonicity of the face elevation between the lower and higher elevation cells. This is done to avoid non-physical transmissibility loss where the topography shows inflection points which results in:
 1. Water accumulation in cells at wet/dry faces, cause of the isolated rainfall patches in our run.
 2. Slightly lower discharges in channels. This effect essentially acts as a numerical friction slowing down the flow.

/!\ Persisting issue.
- When using the new functions in the test branch engine==1 (FlowGPU.cu), the solver runs correctly.
- When using the new functions in the test branch engine==4 (FlowGPU.cu), time step and water depth in the sea oscillates.
