### PR TITLE
Fix typos in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ We welcome code contributions that improve model physics, accelerate performance
 
 * **Core Engine:** High-performance routines utilize parallel programming frameworks. Ensure any modifications to the code **try** to preserve parallel efficiency of the kernels
 * **Data Formats:** BG_Flood relies heavily on structured grid structures and geospatial formats. Ensure that any updates affecting coordinate tracking or spatial ordering correctly handle standard vertical datums and projections without loss of spatial fidelity.
-* **Minimal Dependencies:** BG_Flood is meant to be as portable as possible and should only rely on minimal dependancies. Only significant features should call for adding dependancies  
+* **Minimal Dependencies:** BG_Flood is meant to be as portable as possible and should only rely on minimal dependencies. Only significant features should call for adding dependencies  
 
 #### Code Style Guide
 
@@ -54,7 +54,7 @@ To submit your changes, please follow these steps:
 3. **Implement Tests:** If adding a new feature or fixing a hydraulic routing bug, include corresponding **internal** validation tests. Verify your changes against standard benchmark flood scenarios if modifying any of the hydraulic engines.
 4. **Document Changes and show your own test results:** Update any relevant markdown documentation, inline comments, or configuration schema definitions if your changes introduce new parameters (e.g., modified rainfall ARI inputs or custom roughness coefficients).
 5. **Submit the PR:** Make sure you stage your changes appropriately. Well tested features That succeeds all of its test can open a Pull Request against `development` branch but poorly optimise experiment that need a bit of work should pull request on another branch off developments
-6. **No PR to main:** PR to main are reserved for lead dev team and will only be merged after thourough checks from the development branch. Exceptions are for text edit of documentation. 
+6. **No PR to main:** PR to main are reserved for lead dev team and will only be merged after thorough checks from the development branch. Exceptions are for text edit of documentation. 
 
 ### Pull Request Checklist
 

--- a/ParametersList-py.md
+++ b/ParametersList-py.md
@@ -9,7 +9,7 @@ BG_flood user interface consists in a text file, associating key words to user c
 |test|test| -1|-1: no test, 99: run all independent tests, X: run test X|
 |g|g| 9.81|Gravity in m.s-2|
 |rho|rho| 1025.0|Fluid density in kg.m-3|
-|eps|eps| 0.0001|Drying height in m (if h<eps, the surface is concidered dry)|
+|eps|eps| 0.0001|Drying height in m (if h<eps, the surface is considered dry)|
 |dt|dt| 0.0|Model time step in s.|
 |CFL|CFL| 0.5|Current Freidrich Limiter|
 |theta|theta| 1.3|Minmod limiter parameter, theta in [1,2]. <br>Can be used to tune the momentum dissipation (theta=1 gives minmod the most dissipative limiter and theta = 2 gives	superbee, the least dissipative).|
@@ -39,7 +39,7 @@ BG_flood user interface consists in a text file, associating key words to user c
 |xmax|xmax| nan("")|Grid xmax (if not alter by the user, will be defined based on the topography/bathymetry input map)|
 |grdalpha|grdalpha| nan("")|Grid rotation Y axis from the North input in degrees but later converted to rad|
 |posdown|posdown| 0|Flag for bathy input. Model requirement is positive up  so if posdown ==1 then zb=zb*-1.0f|
-|spherical| spherical , geo | 0|Flag for sperical coordinate (still in development)|
+|spherical| spherical , geo | 0|Flag for spherical coordinate (still in development)|
 |Radius|Radius| 6371220.|Earth radius [m]|
 |mask|mask| 9999.0|Mask any zb above this value. If the entire Block is masked then it is not allocated in the memory|
 ### Adaptation
@@ -109,9 +109,9 @@ BG_flood user interface consists in a text file, associating key words to user c
 |cf| cf , roughness , cfmap |(see constant in parameters)|cf=0.001;<br>cf=bottom_friction.nc?bfc;|Bottom friction coefficient map (associated to the chosen bottom friction model)<br>A list of roughness map can be provide. At any grid point, the last one defined will be used.|
 |il| il , Rain_il , initialloss |(see constant in parameters)|il=rain_loss.nc?initial_loss;|Initial Rain loss coefficient map (in mm)|
 |cl| cl , Rain_cl , continuousloss |(see constant in parameters)|cl=rain_loss.nc?continuous_loss;|Continuous Rain loss coefficient map (in mm/h)|
-|Bathy| Bathy , bathyfile , bathymetry , depfile , depthfile , topofile , topo , DEM |None but input NECESSARY|bathy=Westport_DEM_2020.nc?z<br>topo=Westport_DEM_2020.asc| Bathymetry/Topography input, ONLY NECESSARY INPUT<br>Different format are accepted: .asc, .nc, .md. , the grid must be regular with growing coordinate.<br>This grid will define the extend of the model domain and model resolution (if not inform by the user).<br>The coordinate can be cartesian or spherical (still in development).<br>A list of file can also be use to provide a thiner resolution localy by using the key word each time on a different line.<br>The first file will be use to define the domain area and base resolution but the following file<br>will be used during the refinement process.|
+|Bathy| Bathy , bathyfile , bathymetry , depfile , depthfile , topofile , topo , DEM |None but input NECESSARY|bathy=Westport_DEM_2020.nc?z<br>topo=Westport_DEM_2020.asc| Bathymetry/Topography input, ONLY NECESSARY INPUT<br>Different format are accepted: .asc, .nc, .md. , the grid must be regular with growing coordinate.<br>This grid will define the extend of the model domain and model resolution (if not inform by the user).<br>The coordinate can be cartesian or spherical (still in development).<br>A list of file can also be use to provide a thiner resolution locally by using the key word each time on a different line.<br>The first file will be use to define the domain area and base resolution but the following file<br>will be used during the refinement process.|
 |AOI| AOI , aoipoly |N/A|AOI=myarea.gmt;|Area of interest polygon<br>the input file is a text file with 2 columns containing the coordinate of a closed polygon (last line==first line)|
-|left| left , leftbndfile , leftbnd |1|left = 0;<br>left = leftBnd.txt,2;| 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)<br>For type 2 and 3 boundary, a file need to be added to determine the vaules at the boundary. This file will consist in a first column containing time (with possibly variable time steps) and forcing values in the following columns (1 column of values corresponding to a constant value along the boundary, 2 columns correspond to values at boundary edges with linear evolution in between, n columns correspond to n regularly spaced values applied along the boundary)|
+|left| left , leftbndfile , leftbnd |1|left = 0;<br>left = leftBnd.txt,2;| 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)<br>For type 2 and 3 boundary, a file need to be added to determine the values at the boundary. This file will consist in a first column containing time (with possibly variable time steps) and forcing values in the following columns (1 column of values corresponding to a constant value along the boundary, 2 columns correspond to values at boundary edges with linear evolution in between, n columns correspond to n regularly spaced values applied along the boundary)|
 |right| right , rightbndfile , rightbnd |1|right = 0;<br>right = rightBnd.txt,2;|Same as left boundary|
 |top| top , topbndfile , topbnd |1|top = 0;<br>top = topBnd.txt,2;|Same as left boundary|
 |bot| bot , botbndfile , botbnd , bottom |1|bot = 0;<br>bot = botBnd.txt,2;|Same as left boundary|

--- a/doc/ParametersList-py.md
+++ b/doc/ParametersList-py.md
@@ -9,7 +9,7 @@ BG_flood user interface consists in a text file, associating key words to user c
 |test|test| -1|-1: no test, 99: run all independent tests, X: run test X|
 |g|g| 9.81|Gravity in m.s-2|
 |rho|rho| 1025.0|Fluid density in kg.m-3|
-|eps|eps| 0.0001|Drying height in m (if h<eps, the surface is concidered dry)|
+|eps|eps| 0.0001|Drying height in m (if h<eps, the surface is considered dry)|
 |dt|dt| 0.0|Model time step in s.|
 |CFL|CFL| 0.5|Current Freidrich Limiter|
 |theta|theta| 1.3|Minmod limiter parameter, theta in [1,2]. <br>Can be used to tune the momentum dissipation (theta=1 gives minmod the most dissipative limiter and theta = 2 gives	superbee, the least dissipative).|
@@ -35,7 +35,7 @@ BG_flood user interface consists in a text file, associating key words to user c
 |xmax|xmax| nan("")|Grid xmax (if not alter by the user, will be defined based on the topography/bathymetry input map)|
 |grdalpha|grdalpha| nan("")|Grid rotation Y axis from the North input in degrees but later converted to rad|
 |posdown|posdown| 0|Flag for bathy input. Model requirement is positive up  so if posdown ==1 then zb=zb*-1.0f|
-|spherical|spherical| 0|Flag for sperical coordinate (still in development)|
+|spherical|spherical| 0|Flag for spherical coordinate (still in development)|
 |Radius|Radius| 6371220.|Earth radius [m]|
 |mask|mask| 9999.0|Mask any zb above this value. If the entire Block is masked then it is not allocated in the memory|
 ### Adaptation
@@ -90,8 +90,8 @@ BG_flood user interface consists in a text file, associating key words to user c
 |_Reference_|_Keys_|_default_|_Example_|_Explanation_|
 |---|---|---|---|---|
 |cf| cf , roughness , cfmap |(see constant in parameters)|cf=0.001;<br>cf=bottom_friction.nc?bfc;|Bottom friction coefficient map (associated to the chosen bottom friction model)|
-|Bathy| Bathy , bathyfile , bathymetry , depfile , depthfile , topofile , topo , DEM |None but input NECESSARY|bathy=Westport_DEM_2020.nc?z<br>topo=Westport_DEM_2020.asc| Bathymetry/Topography input, ONLY NECESSARY INPUT<br>Different format are accepted: .asc, .nc, .md. , the grid must be regular with growing coordinate.<br>This grid will define the extend of the model domain and model resolution (if not inform by the user).<br>The coordinate can be cartesian or spherical (still in development).<br>A list of file can also be use to provide a thiner resolution localy by using the key word each time on a different line.<br>The first file will be use to define the domain area and base resolution but the following file<br>will be used during the refinement process.|
-|left| left , leftbndfile , leftbnd |1|left = 0;<br>left = leftBnd.txt,2;| 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)<br>For type 2 and 3 boundary, a file need to be added to determine the vaules at the boundary. This file will consist in a first column containing time (with possibly variable time steps) and forcing values in the following columns (1 column of values corresponding to a constant value along the boundary, 2 columns correspond to values at boundary edges with linear evolution in between, n columns correspond to n regularly spaced values applied along the boundary)|
+|Bathy| Bathy , bathyfile , bathymetry , depfile , depthfile , topofile , topo , DEM |None but input NECESSARY|bathy=Westport_DEM_2020.nc?z<br>topo=Westport_DEM_2020.asc| Bathymetry/Topography input, ONLY NECESSARY INPUT<br>Different format are accepted: .asc, .nc, .md. , the grid must be regular with growing coordinate.<br>This grid will define the extend of the model domain and model resolution (if not inform by the user).<br>The coordinate can be cartesian or spherical (still in development).<br>A list of file can also be use to provide a thiner resolution locally by using the key word each time on a different line.<br>The first file will be use to define the domain area and base resolution but the following file<br>will be used during the refinement process.|
+|left| left , leftbndfile , leftbnd |1|left = 0;<br>left = leftBnd.txt,2;| 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)<br>For type 2 and 3 boundary, a file need to be added to determine the values at the boundary. This file will consist in a first column containing time (with possibly variable time steps) and forcing values in the following columns (1 column of values corresponding to a constant value along the boundary, 2 columns correspond to values at boundary edges with linear evolution in between, n columns correspond to n regularly spaced values applied along the boundary)|
 |right| right , rightbndfile , rightbnd |1|right = 0;<br>right = rightBnd.txt,2;|Same as left boundary|
 |top| top , topbndfile , topbnd |1|top = 0;<br>top = topBnd.txt,2;|Same as left boundary|
 |bot| bot , botbndfile , botbnd , bottom |1|bot = 0;<br>bot = botBnd.txt,2;|Same as left boundary|

--- a/docs/ParametersList-py.md
+++ b/docs/ParametersList-py.md
@@ -10,7 +10,7 @@ BG_flood user interface consists in a text file (`BG_param.txt` by default), ass
 |test|test| -1|-1: no test, 99: run all independent tests, X: run test X|
 |g|g| 9.81|Acceleration of gravity in m.s-2|
 |rho|rho| 1025.0|Fluid density in kg.m-3|
-|eps|eps| 0.0001|Drying height in m (if h<eps, the surface is concidered dry)|
+|eps|eps| 0.0001|Drying height in m (if h<eps, the surface is considered dry)|
 |dt|dt| 0.0|Model time step in s.|
 |CFL|CFL| 0.5|Current Freidrich Limiter criterium (between 0 and 1. Higher values may make the model unstable)|
 |theta|theta| 1.3|Minmod limiter parameter, theta in [1,2]. <br>Can be used to tune the momentum dissipation (theta=1 gives minmod the most dissipative limiter and theta = 2 gives	superbee, the least dissipative).|
@@ -33,7 +33,7 @@ BG_flood user interface consists in a text file (`BG_param.txt` by default), ass
 ### Grid parameters
 |_Reference_|_Keys_|_default_|_Explanation_|
 |---|---|---|---|
-|dx|dx| nan("")|Grid resolution, in m for a metric grid or in decimal degree for a sperical grid.|
+|dx|dx| nan("")|Grid resolution, in m for a metric grid or in decimal degree for a spherical grid.|
 |nx|nx| 0|Initial/input grid size (number of nodes) in x direction|
 |ny|ny| 0|Initial/input grid size (number of nodes) in y direction|
 |xo| xo , xmin | nan("")|Grid x origin (if not alter by the user, will be defined based on the topography/bathymetry input map)|
@@ -120,9 +120,9 @@ BG_flood user interface consists in a text file (`BG_param.txt` by default), ass
 |cf| cf , roughness , cfmap |(see constant in parameters)|cf=0.001;<br>cf=bottom_friction.nc?bfc;|Bottom friction coefficient map (associated to the chosen bottom friction model: n, z0, ...)<br>A list of roughness map can be provide. At any grid point, the last one defined will be used.|
 |il| il , Rain_il , initialloss |(see constant in parameters)|il=rain_loss.nc?initial_loss;|Initial Rain loss coefficient map (in mm)|
 |cl| cl , Rain_cl , continuousloss |(see constant in parameters)|cl=rain_loss.nc?continuous_loss;|Continuous Rain loss coefficient map (in mm/h)|
-|Bathy| Bathy , bathyfile , bathymetry , depfile , depthfile , topofile , topo , DEM |None but input NECESSARY|bathy=Westport_DEM_2020.nc?z<br>topo=Westport_DEM_2020.asc| Bathymetry/Topography input, ONLY NECESSARY INPUT<br>Different format are accepted: .asc, .nc, .md. , the grid must be regular with growing coordinate.<br>This grid will define the extend of the model domain and model resolution (if not inform by the user).<br>The coordinate can be cartesian or spherical (still in development).<br>A list of file can also be use to provide a thiner resolution localy by using the key word each time on a different line.<br>The first file will be use to define the domain area and base resolution but the following file<br>will be used during the refinement process.|
+|Bathy| Bathy , bathyfile , bathymetry , depfile , depthfile , topofile , topo , DEM |None but input NECESSARY|bathy=Westport_DEM_2020.nc?z<br>topo=Westport_DEM_2020.asc| Bathymetry/Topography input, ONLY NECESSARY INPUT<br>Different format are accepted: .asc, .nc, .md. , the grid must be regular with growing coordinate.<br>This grid will define the extend of the model domain and model resolution (if not inform by the user).<br>The coordinate can be cartesian or spherical (still in development).<br>A list of file can also be use to provide a thiner resolution locally by using the key word each time on a different line.<br>The first file will be use to define the domain area and base resolution but the following file<br>will be used during the refinement process.|
 |AOI| AOI , aoipoly |N/A|AOI=myarea.gmt;|Area of interest polygon<br>the input file is a text file with 2 columns containing the coordinate of a closed polygon (last line==first line)|
-|left| left , leftbndfile , leftbnd |1|left = 0;<br>left = leftBnd.txt,2;| 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)<br>For type 2 and 3 boundary, a file need to be added to determine the vaules at the boundary. This file will consist in a first column containing time (with possibly variable time steps) and forcing values in the following columns (1 column of values corresponding to a constant value along the boundary, 2 columns correspond to values at boundary edges with linear evolution in between, n columns correspond to n regularly spaced values applied along the boundary)|
+|left| left , leftbndfile , leftbnd |1|left = 0;<br>left = leftBnd.txt,2;| 0:Wall (no slip); 1:neumann (zeros gradient) [Default]; 2:sealevel dirichlet; 3: Absorbing 1D 4: Absorbing 2D (not yet implemented)<br>For type 2 and 3 boundary, a file need to be added to determine the values at the boundary. This file will consist in a first column containing time (with possibly variable time steps) and forcing values in the following columns (1 column of values corresponding to a constant value along the boundary, 2 columns correspond to values at boundary edges with linear evolution in between, n columns correspond to n regularly spaced values applied along the boundary)|
 |right| right , rightbndfile , rightbnd |1|right = 0;<br>right = rightBnd.txt,2;|Same as left boundary|
 |top| top , topbndfile , topbnd |1|top = 0;<br>top = topBnd.txt,2;|Same as left boundary|
 |bot| bot , botbndfile , botbnd , bottom |1|bot = 0;<br>bot = botBnd.txt,2;|Same as left boundary|

--- a/docs/modules/Validation_Cea.md
+++ b/docs/modules/Validation_Cea.md
@@ -5,7 +5,7 @@ shape basin with walls on the slopes (see link for layout). This lab test is mor
 
 The observed discharge show oscillations at the peak, most models do not show such oscillation but instead show a smooth steady curve. [Cea et al. (2008)](https://iwra.org/proceedings/congress/resource/abs478_article.pdf) in the paper show their model producing a smooth curve and [Molls et al. (2016)](https://cdn.ymaws.com/membersfloodplain.site-ym.com/resource/resmgr/2016Conference/FMA2016_Sacramento_RAS2DVeri.pdf) show a smooth curve for HEC-RAS (and suspiciouly smooth data).
 
-BG_Flood does replicate the oscillation they are produced s the water at the mottom of the bassin start to oscilate at the bottom of the basin. 
+BG_Flood does replicate the oscillation they are produced s the water at the mottom of the bassin start to oscillate at the bottom of the basin. 
 
 
 ## Comparison between all engines

--- a/docs/modules/Validation_Checks.md
+++ b/docs/modules/Validation_Checks.md
@@ -58,7 +58,7 @@ It is normal for the velocity to be non-zero. this is due to the round off error
 
 
 ## Mass conservation 
-Mass should be conserved in a model except when water is meant to leave the domain. Mass conservation is a basic test where whe check if mass of water already in the model and what is meant to be injected (river and/or rain) stay in the model (with wall bnds). This test is basic and trivial test with mild slope and already wet environment. It is, however a surprisingly hard test to suceed on steep dry slopes. 
+Mass should be conserved in a model except when water is meant to leave the domain. Mass conservation is a basic test where whe check if mass of water already in the model and what is meant to be injected (river and/or rain) stay in the model (with wall bnds). This test is basic and trivial test with mild slope and already wet environment. It is, however a surprisingly hard test to succeed on steep dry slopes. 
 
 The simple mass conservation test is great for checking engine flaws when using rain on grid. Here we push it to the extreme by throwing 100 m<sup>3</sup>/s for 100 s over 1 km<sup>2</sup> (equivalent 10 mm of rainfall falling in 100 s which is equivalent to a rate of 360 mm/h for 1.5-ish minutes ). Note that there are a few tricks to to force the Buttinger to conserve mass but we decided not to turn them off for these tests. 
 
@@ -82,12 +82,12 @@ The test above confirm that rainfall forcing is consistent with theory (even whe
 ## Boundary check
 We have checks to ensure that boundary work. 
 
-### Wall boundary are impermable
+### Wall boundary are impermeable
 IN this test we run a river down a steep slope and checks the mass inside the model is conserved. We do that along each side of the model.
 
 
 ## Adaptive
-Eahc of the test are run in a uniform resolution or with a variable resolution. for the mass conservation test the goal is the same but for propagation the results need to be different. More importantly in the variable resolution we chack that the solution are symetrical and that mesh structure do not impede wave propagation.
+Eahc of the test are run in a uniform resolution or with a variable resolution. for the mass conservation test the goal is the same but for propagation the results need to be different. More importantly in the variable resolution we chack that the solution are symmetrical and that mesh structure do not impede wave propagation.
 
 
 

--- a/docs/paper.md
+++ b/docs/paper.md
@@ -67,7 +67,7 @@ The model has been validated against standard academic benchmarks [@bosserelle20
 
 - **Efficient Block Uniform Quadtree (BUQ):** Implements a memory model inspired by @vacondio2017 to maximise GPU warp efficiency and significantly reduce memory latency within a CUDA-native framework. This variable-resolution grid implementation minimises the computational overhead typically associated with quadtree structures on GPU architectures (Figure 1). While this required intensive internal development it allows the code to run efficiently with a relatively naive implementation.
 - **Multiple Solvers:** Implements several well-tested, depth-averaged Shallow Water Equation (SWE) solvers and reconstruction schemes. The core numerical schemes have been ported and adapted from the `Basilisk` framework [@popinet2011quadtree].
-- **Explicit Mesh-Agnostic Preprocessing:** The computational mesh is generated natively by the code. All gridded geospatial inputs are automatically interpolated or block-averaged to the computational mesh during initialization, simplifying the preprocessing of disparate datasets. The mesh generation is This was acheived with minimal dependencies. 
+- **Explicit Mesh-Agnostic Preprocessing:** The computational mesh is generated natively by the code. All gridded geospatial inputs are automatically interpolated or block-averaged to the computational mesh during initialization, simplifying the preprocessing of disparate datasets. The mesh generation is This was achieved with minimal dependencies. 
 
 ## Data Interoperability and Automation
 


### PR DESCRIPTION
Fixes 19 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.

Left `obsolete/doc/` untouched since it looks deprecated. One fix is in `docs/paper.md`, happy to drop that one if you would rather not touch the paper during review.